### PR TITLE
Better Proposal Files Policy Validation 

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "react": "^16.0.0",
     "react-body": "^0.2.0",
     "react-dom": "^16.0.0",
-    "react-file-reader": "^1.1.2",
+    "react-file-reader": "^1.1.3",
     "react-markmirror": "^0.4.16",
     "react-redux": "^5.0.6",
     "react-router-dom": "^4.2.2",

--- a/src/components/Form/Fields/FilesField.js
+++ b/src/components/Form/Fields/FilesField.js
@@ -4,23 +4,13 @@ import ReactFileReader from "react-file-reader";
 import { change } from 'redux-form';
 import ProposalImages from "../../ProposalImages";
 import PolicyErrors from './PolicyErrors';
-import { errorTypes, validateFiles, getFormattedFiles } from '../../ProposalImages/helpers';
+import { validateFiles, getFormattedFiles } from '../../ProposalImages/helpers';
 
 class FilesField extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       policyErrors: []
-    }
-  }
-
-  validateFileList = (fileList) => {
-    const { policy } = this.props;
-    const validateMaxImages = (fileList) => {
-      if (fileList.length > policy.maximages) {
-        return true
-      }
-      return false;
     }
   }
 
@@ -50,7 +40,7 @@ class FilesField extends React.Component {
         ><button>{placeholder}</button></ReactFileReader>
         {touched && error && !disabled && <span className="error">{error}</span>}
         { policyErrors.length > 0 && <PolicyErrors errors={policyErrors} />}
-        <ProposalImages files={input.value || []} onChange={input.onChange} policy={policy} />
+        <ProposalImages files={input.value || []} onChange={input.onChange} />
       </div>
     )
   }

--- a/src/components/Form/Fields/FilesField.js
+++ b/src/components/Form/Fields/FilesField.js
@@ -17,7 +17,8 @@ class FilesField extends React.Component {
   handleFilesChange = (files) => {
     const { input, policy, meta: { dispatch } } = this.props;
     const formatedFiles = getFormattedFiles(files);
-    const validation = validateFiles(formatedFiles.concat(input.value), policy);
+    const inputAndNewFiles = input.value ? formatedFiles.concat(input.value) : formatedFiles;
+    const validation = validateFiles(inputAndNewFiles, policy);
 
     this.setState({
       policyErrors: validation.errors ? validation.errors : []

--- a/src/components/Form/Fields/FilesField.js
+++ b/src/components/Form/Fields/FilesField.js
@@ -1,24 +1,60 @@
 import React from "react";
 import PropTypes from "prop-types";
 import ReactFileReader from "react-file-reader";
+import { change } from 'redux-form';
 import ProposalImages from "../../ProposalImages";
+import PolicyErrors from './PolicyErrors';
+import { errorTypes, validateFiles, getFormattedFiles } from '../../ProposalImages/helpers';
 
-const FilesField = ({ placeholder="Upload", input, touched, error, disabled, policy }) => (
-  <div className="files-field">
-    <ReactFileReader
-      base64
-      multipleFiles
-      fileTypes={policy.validmimetypes}
-      handleFiles={({ base64, fileList }) =>
-        input.onChange(Array.from(fileList).map(({ name, size, type: mime }, idx) => ({
-          name, mime, size, payload: base64[idx].split("base64,").pop()
-        })))
+class FilesField extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      policyErrors: []
+    }
+  }
+
+  validateFileList = (fileList) => {
+    const { policy } = this.props;
+    const validateMaxImages = (fileList) => {
+      if (fileList.length > policy.maximages) {
+        return true
       }
-    ><button>{placeholder}</button></ReactFileReader>
-    {touched && error && !disabled && <span className="error">{error}</span>}
-    <ProposalImages files={input.value || []} onChange={input.onChange} policy={policy} />
-  </div>
-);
+      return false;
+    }
+  }
+
+  handleFilesChange = (files) => {
+    const { input, policy, meta: { dispatch } } = this.props;
+    const formatedFiles = getFormattedFiles(files);
+    const validation = validateFiles(formatedFiles.concat(input.value), policy);
+
+    this.setState({
+      policyErrors: validation.errors ? validation.errors : []
+    })
+
+    return dispatch(change('form/proposal','files', validation.files));
+  }
+
+  render() {
+    const { placeholder="Upload", input, touched, error, disabled, policy } = this.props;
+    const { policyErrors } = this.state;
+
+    return (
+      <div className="files-field">
+        <ReactFileReader
+          base64
+          multipleFiles
+          fileTypes={policy.validmimetypes}
+          handleFiles={this.handleFilesChange}
+        ><button>{placeholder}</button></ReactFileReader>
+        {touched && error && !disabled && <span className="error">{error}</span>}
+        { policyErrors.length > 0 && <PolicyErrors errors={policyErrors} />}
+        <ProposalImages files={input.value || []} onChange={input.onChange} policy={policy} />
+      </div>
+    )
+  }
+}
 
 FilesField.propTypes = {
   placeholder: PropTypes.string.isRequired,

--- a/src/components/Form/Fields/FilesField.js
+++ b/src/components/Form/Fields/FilesField.js
@@ -8,6 +8,7 @@ const FilesField = ({ placeholder="Upload", input, touched, error, disabled, pol
     <ReactFileReader
       base64
       multipleFiles
+      fileTypes={policy.validmimetypes}
       handleFiles={({ base64, fileList }) =>
         input.onChange(Array.from(fileList).map(({ name, size, type: mime }, idx) => ({
           name, mime, size, payload: base64[idx].split("base64,").pop()

--- a/src/components/Form/Fields/PolicyErrors.js
+++ b/src/components/Form/Fields/PolicyErrors.js
@@ -1,11 +1,12 @@
 import React from 'react';
+import Message from "../../Message";
 
 const PolicyErrors = ({errors}) => (
-  <ul>
+  <div>
     {
-      errors.map((error, idx) => <li key={idx} className="error">{error}</li>)
+      errors.map((error, idx) => <Message key={idx} body={error} type='error' />)
     }
-  </ul>
+  </div>
 );
 
 export default PolicyErrors;

--- a/src/components/Form/Fields/PolicyErrors.js
+++ b/src/components/Form/Fields/PolicyErrors.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const PolicyErrors = ({errors}) => (
+  <ul>
+    {
+      errors.map((error, idx) => <li key={idx} className="error">{error}</li>)
+    }
+  </ul>
+);
+
+export default PolicyErrors;

--- a/src/components/ProposalImages/helpers.js
+++ b/src/components/ProposalImages/helpers.js
@@ -1,3 +1,27 @@
+/* The validation will return an object with the following shape
+  { files: [file1, file2], validationErrors: ['message1', 'message2']}
+*/
+export const errorTypes = {
+  MAX_SIZE: 'max_size',
+  MAX_IMAGES: 'max_length'
+}
+
+export function validateFiles(files, policy) {
+  const validation = {
+    files,
+    errors: []
+  }
+  const validatedMaxImages = validateMaxImages(validation, policy);
+  const validatedMaxSize = validateMaxSize(validatedMaxImages, policy);
+  return validatedMaxSize;
+}
+
+export function getFormattedFiles({ base64, fileList }) {
+  return Array.from(fileList).map(({ name, size, type: mime }, idx) => ({
+    name, mime, size, payload: base64[idx].split("base64,").pop()
+  }))
+}
+
 export function isFileValid(file, policy) {
   if (file.size > policy.maximagesize) {
     return false;
@@ -8,4 +32,37 @@ export function isFileValid(file, policy) {
   }
 
   return true;
+}
+
+function getErrorMessage(policy, errorType, filename = '') {
+  const errors = {
+    [errorTypes.MAX_SIZE]: `The file ${filename} exceeds the maximum size`,
+    [errorTypes.MAX_IMAGES]: `You can upload a maximum of ${policy.maximages} images per proposal`
+  }
+  return errors[errorType];
+}
+
+function validateMaxImages({errors, files}, policy) {
+  if (files.length > policy.maximages) {
+    errors.push(getErrorMessage(policy, errorTypes.MAX_IMAGES));
+    return ({
+      files: files.splice(0, policy.maximages - 1),
+      errors
+    });
+  }
+  return ({errors, files});
+}
+
+function validateMaxSize({errors, files}, policy) {
+  const newFiles = files.filter(file => {
+    if (file.size > policy.maximagesize) {
+      errors.push(getErrorMessage(policy, errorTypes.MAX_SIZE, file.name));
+      return false;
+    }
+    return true;
+  })
+  return ({
+    files: newFiles,
+    errors
+  });
 }

--- a/src/components/ProposalImages/helpers.js
+++ b/src/components/ProposalImages/helpers.js
@@ -46,7 +46,7 @@ function validateMaxImages({errors, files}, policy) {
   if (files.length > policy.maximages) {
     errors.push(getErrorMessage(policy, errorTypes.MAX_IMAGES));
     return ({
-      files: files.splice(0, policy.maximages - 1),
+      files: files.slice(0, policy.maximages - 1),
       errors
     });
   }

--- a/src/components/ProposalImages/index.js
+++ b/src/components/ProposalImages/index.js
@@ -13,7 +13,7 @@ class ProposalImages extends Component {
   }
 
   render() {
-    const { files, readOnly, policy } = this.props;
+    const { files, readOnly } = this.props;
 
     return (
       <div>
@@ -35,7 +35,6 @@ class ProposalImages extends Component {
 
 ProposalImages.propTypes = {
   files: PropTypes.array.isRequired,
-  policy: PropTypes.object,
   readOnly: PropTypes.bool.isRequired,
 };
 

--- a/src/components/ProposalImages/index.js
+++ b/src/components/ProposalImages/index.js
@@ -1,6 +1,5 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { isFileValid } from "./helpers";
 
 class ProposalImages extends Component {
   constructor(props) {
@@ -20,7 +19,7 @@ class ProposalImages extends Component {
       <div>
         {(files || []).map(({ name, mime, digest, payload, size }, idx) => (
           <div key={digest || idx}>
-            <h5>{name}{readOnly ? null : isFileValid({ size, mime }, policy) ? null :  <span className="error">&nbsp;Errored</span> }</h5>
+            <h5>{name}</h5>
             <div className="attached-image-ct clearfloat">
               <img className="attached-image" alt={name} src={`data:${mime};base64,${payload}`} />
               {readOnly ? null : (

--- a/yarn.lock
+++ b/yarn.lock
@@ -6356,9 +6356,9 @@ react-error-overlay@^2.0.2:
     settle-promise "1.0.0"
     source-map "0.5.6"
 
-react-file-reader@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/react-file-reader/-/react-file-reader-1.1.2.tgz#78df60a28d2ac008d445b5f049905d647dcd4e9c"
+react-file-reader@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/react-file-reader/-/react-file-reader-1.1.3.tgz#caf1044ca6e2db1dc5284fd748a940ed682aa507"
   dependencies:
     prop-types "^15.5.0"
     uuid4 "^1.0.0"


### PR DESCRIPTION
I've added a validation for the files whenever a user try to add new files. The files which doesn't fit the policy validation won't be added to the input's files and error messages will be displayed to the user. 
Right now there are two main policy validations being processed: 

- Max number of file: make sure to respect the max number of images allowed by the policy and provide an global error message. 
- Max size of each file: make sure that every file added to the input's value will respect the max size allowed by the policy and provide an error message per file.
- Mime types is validated by the component 'react-file-reader' which won't allow you to select mime type that aren't specified in the prop `fileTypes`.

The FE result will be like this: 
![screen shot 2017-11-21 at 3 49 59 pm](https://user-images.githubusercontent.com/14864439/33088052-a814b48a-ced3-11e7-8331-e475e3f56aee.png)
