### PR TITLE
Fix bug where logo doesn't spin around the center

### DIFF
--- a/src/style/index.css
+++ b/src/style/index.css
@@ -274,7 +274,7 @@ a:hover {
 }
 .logo {
   position: absolute;
-  height: 200px;
+  height: 150px;
   width: 200px;
   background-image: url("./spinner.svg");
   background-position: 0px 0px;


### PR DESCRIPTION
The loading icon doesn't seem to be spinning around the center of the logo because the image is too tall, so this PR reduces its height.