### PR TITLE
Replace markdown parser snuownd by showdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,8 @@
     "redux-form": "^7.1.1",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.2.0",
-    "showdown": "^1.8.3",
+    "showdown": "^1.8.4",
     "snew-classic-ui": "https://github.com/decred/snew-classic-ui",
-    "snuownd": "https://github.com/JordanMilne/snuownd",
     "timeago-react": "^1.2.2",
     "tweetnacl": "^1.0.0",
     "tweetnacl-util": "^0.15.0"

--- a/src/components/MarkdownEditor/MarkdownPreview.js
+++ b/src/components/MarkdownEditor/MarkdownPreview.js
@@ -1,11 +1,11 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import MarkdownHelp from './MarkdownHelp';
-import Markdown from '../snew/Markdown';
+import React from "react";
+import PropTypes from "prop-types";
+import MarkdownHelp from "./MarkdownHelp";
+import Markdown from "../snew/Markdown";
 
-const MarkdownPreview = ({body}) => (
+const MarkdownPreview = ({body, showdownOptions}) => (
   <div className="mde-preview">
-    <Markdown body={body} className="mde-preview-content"/>
+    <Markdown className="mde-preview-content" showdownOptions={showdownOptions} body={body} />
     <div className="mde-help">
       <MarkdownHelp />
     </div>

--- a/src/components/MarkdownEditor/index.js
+++ b/src/components/MarkdownEditor/index.js
@@ -1,6 +1,5 @@
-import MarkdownEditor from './MarkdownEditor.js';
-import 'normalize.css/normalize.css';
-import 'font-awesome/css/font-awesome.css';
-
+import MarkdownEditor from "./MarkdownEditor.js";
+import "normalize.css/normalize.css";
+import "font-awesome/css/font-awesome.css";
 
 export default MarkdownEditor;

--- a/src/components/snew/Markdown.js
+++ b/src/components/snew/Markdown.js
@@ -1,11 +1,14 @@
 import React from "react";
-import Snudownd from "snuownd";
-const parser = Snudownd.getParser();
+import * as Showdown from "showdown";
 
-const MarkdownRenderer = ({ body, className }) => (
-  <div className={className}>
-    <div className="md" dangerouslySetInnerHTML={{__html: parser.render(body || "")}} />
-  </div>
-);
+const MarkdownRenderer = ({ body, className, showdownOptions }) => {
+  const converter = new Showdown.Converter(showdownOptions || undefined);
+  const html = converter.makeHtml(body) || "<p>&nbsp</p>";
+  return (
+    <div className={className}>
+      <div className="md" dangerouslySetInnerHTML={{ __html: html }} />
+    </div>
+  );
+};
 
 export default MarkdownRenderer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7090,9 +7090,9 @@ shellwords@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
 
-showdown@^1.8.3:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/showdown/-/showdown-1.8.3.tgz#644dd3c8f9432c7744c49b45e9a198a01719435e"
+showdown@^1.8.4:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/showdown/-/showdown-1.8.4.tgz#f0e82567f15f3e40b92d886c071b55386cb0e2ce"
   dependencies:
     yargs "^10.0.3"
 
@@ -7143,10 +7143,6 @@ sntp@2.x.x:
   resolved "https://registry.yarnpkg.com/sntp/-/sntp-2.0.2.tgz#5064110f0af85f7cfdb7d6b67a40028ce52b4b2b"
   dependencies:
     hoek "4.x.x"
-
-"snuownd@https://github.com/JordanMilne/snuownd":
-  version "1.1.1"
-  resolved "https://github.com/JordanMilne/snuownd#06a1abc16ad06a1a6eff14afb7f9bcdb34e8ad01"
 
 sockjs-client@1.1.4:
   version "1.1.4"


### PR DESCRIPTION
I've replaced the markdown parser for both: Proposal details and Proposal Submit page. 
I think `showdown` parser (which is the same used in `react-mde`) works better than `snuownd`.
Besides it is more consistent with our current editor.
fixes #137 