### PR TITLE
Markdown 'on the fly' help

### DIFF
--- a/src/components/MarkdownEditor/MarkdownEditor.js
+++ b/src/components/MarkdownEditor/MarkdownEditor.js
@@ -1,19 +1,17 @@
-import React from 'react';
+import React from "react";
 import PropTypes from "prop-types";
-import { ReactMdeToolbar, ReactMdeTextArea, ReactMdeCommands } from 'react-mde';
+import { ReactMdeToolbar, ReactMdeTextArea, ReactMdeCommands } from "react-mde";
 import {
     getSelection,
 } from "react-mde/lib/js/helpers/ReactMdeSelectionHelper";
-import 'react-mde/lib/styles/css/react-mde.css';
-import 'react-mde/lib/styles/css/react-mde-toolbar.css';
-import 'react-mde/lib/styles/css/react-mde-textarea.css';
-import 'react-mde/lib/styles/css/react-mde-preview.css';
-import MarkdownPreview from './MarkdownPreview';
+import "react-mde/lib/styles/css/react-mde.css";
+import "react-mde/lib/styles/css/react-mde-toolbar.css";
+import "react-mde/lib/styles/css/react-mde-textarea.css";
+import "react-mde/lib/styles/css/react-mde-preview.css";
+import MarkdownPreview from "./MarkdownPreview";
+import MarkdownLiveHelper from "./MarkdownLiveHelper";
 
 class MarkdownEditor extends React.Component {
-  textArea: HTMLTextAreaElement;
-  preview: HTMLDivElement;
-
   getCustomCommands = () => {
     const {
       makeHeaderCommand,
@@ -57,6 +55,7 @@ class MarkdownEditor extends React.Component {
             value={{ text: value }}
             textAreaRef={(c) => this.textArea = c}
         />
+        <MarkdownLiveHelper classToSelect="mde-preview-content" />
         <MarkdownPreview body={value} />
       </div>
     );

--- a/src/components/MarkdownEditor/MarkdownLiveHelper.js
+++ b/src/components/MarkdownEditor/MarkdownLiveHelper.js
@@ -1,0 +1,61 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { applyMistakeFinders, getPreviewContent } from "./helpers";
+import Message from "../Message";    
+
+class MarkdownLiveHelper extends React.Component {
+    interval = null
+
+    constructor(props) {
+        super(props);
+        this.state = {
+            show: false,
+            findersResults: []
+        }
+    }
+    
+    componentDidMount() {
+        this.interval = setInterval(() => {
+            this.lookForMistakes()
+        }, 1000)
+    }
+
+    componentWillUnmount() {
+        clearInterval(this.interval);
+    }
+
+    lookForMistakes = () => {
+        const { classToSelect } = this.props;
+        const value = getPreviewContent(classToSelect);
+        const {findersResults, anyMistake} = applyMistakeFinders(value);
+        this.setState({
+            show: anyMistake,
+            findersResults
+        })
+    }
+
+    renderMessages = (findersResults) => {
+        return (
+            <ul style={{paddingLeft: '20px'}}>
+                {
+                findersResults.map((result, i) => 
+                    <li key={`rm-${i}`}>{result.message}</li>
+                )
+                } 
+            </ul>
+        );
+    }
+
+    render() {
+        const { show, findersResults } = this.state;
+        return show ? (
+            <Message body={this.renderMessages(findersResults)} type='info' />                
+        ) : null;
+    }
+}
+
+MarkdownLiveHelper.propTypes = {
+    classToSelect: PropTypes.string.isRequired    
+};
+
+export default MarkdownLiveHelper;

--- a/src/components/MarkdownEditor/MarkdownPreview.js
+++ b/src/components/MarkdownEditor/MarkdownPreview.js
@@ -1,9 +1,9 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import MarkdownHelp from './MarkdownHelp';
-import Markdown from '../snew/Markdown';
+import React from "react";
+import PropTypes from "prop-types";
+import MarkdownHelp from "./MarkdownHelp";
+import Markdown from "../snew/Markdown";
 
-const MarkdownPreview = ({body}) => (
+const MarkdownPreview = ({ body }) => (
   <div className="mde-preview">
     <Markdown body={body} className="mde-preview-content"/>
     <div className="mde-help">

--- a/src/components/MarkdownEditor/helpers.js
+++ b/src/components/MarkdownEditor/helpers.js
@@ -1,0 +1,68 @@
+const CHAR_CODES = {
+    newline: 10
+};
+
+const finderResult = (mistake, message = '') => ({mistake, message});
+
+function iterateOverStringCharsCode(str, callback) {
+    for (let i = 0, len = str.length; i < len; i++) {
+        callback(str.charCodeAt(i), i);
+    }
+};
+
+function tryingParagraphWithOneNewline(value) {
+    const { newline } = CHAR_CODES;
+    let thereAreASingleNewline = false;
+    iterateOverStringCharsCode(value, (charCode, index) => {
+        const nextCharCode = value.charCodeAt(index + 1);
+        const prevCharCode = value.charCodeAt(index - 1);
+        if (charCode === newline && nextCharCode && nextCharCode !== newline && prevCharCode !== newline ) {
+            thereAreASingleNewline = true;    
+        }
+    })
+    return finderResult(thereAreASingleNewline, 'You should press Enter twice to create separate paragraphs of text');
+};
+
+const mistakeFinders = [
+    tryingParagraphWithOneNewline
+];
+
+export function applyMistakeFinders(value) {
+    const findersResults = mistakeFinders.map(f => f(value));
+    const anyMistake = findersResults.filter(r => r.mistake).length > 0;
+    return ({
+        findersResults, 
+        anyMistake
+    })
+};
+
+export function getPreviewContent(className) {
+    const previewContent = document.querySelector(`.${className}`).firstChild;
+    const nodeList = previewContent.childNodes;
+    const paragraphNodes = generateParagraphNodesArray(nodeList);
+    const concatedString = generateConcatedStringFromTextNodes(paragraphNodes);
+    return concatedString;
+}
+
+function generateParagraphNodesArray(nodeList) {
+    const paragraphNodes = [];
+    for (let node of nodeList) {
+        if (node.nodeName === 'P') {
+            paragraphNodes.push(node);
+        }
+    }
+    return paragraphNodes;
+}
+
+function generateConcatedStringFromTextNodes(paragraphNodes) {
+    const validTextChunks = paragraphNodes.reduce((acc, node) => {
+        const childrens = node.childNodes;
+        for (let child of childrens) {
+            if (child.nodeName === "#text") {
+                acc += child.nodeValue;
+            }
+        }
+        return acc;
+    }, "");
+    return validTextChunks;
+}

--- a/src/components/Message.js
+++ b/src/components/Message.js
@@ -4,16 +4,24 @@ const Message = ({
   type,
   header,
   body
-}) => (
-  <div className={"message-ct message-" + type}>
-    <div className="message-icon">{type === "success" ? "✔" : "✖"}</div>
-    <div className="message-text">
-      <div className="message-header">{header}</div>
-      <div className="message-body">
-        {(body instanceof Error) ? body.message : body}
-      </div>
+}) => {
+  const mapTypeToIcon = {
+    success: "✔",
+    error: "✖",
+    info: "ℹ︎"
+  }
+  const icon = mapTypeToIcon[type] ? mapTypeToIcon[type] : mapTypeToIcon.error;
+  return (
+    <div className={"message-ct message-" + type}>
+      <div className="message-icon">{icon}</div>
+        <div className="message-text">
+          <div className="message-header">{header}</div>
+            <div className="message-body">
+              {(body instanceof Error) ? body.message : body}
+            </div>
+        </div>
     </div>
-  </div>
-);
+  )
+};
 
 export default Message;

--- a/src/components/snew/Markdown/Markdown.js
+++ b/src/components/snew/Markdown/Markdown.js
@@ -1,5 +1,5 @@
 import React from "react";
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown from "react-markdown";
 
 const customRenderers = {
   image: ({src, alt}) => {
@@ -8,14 +8,14 @@ const customRenderers = {
   link: ({href, children}) => {
     return <a rel="nofollow" href={href}>{children[0]}</a>;
   }
-}
+};
 
 const MarkdownRenderer = ({ body, className }) => (
   <div className={className}>
     <ReactMarkdown 
       className="md" 
       renderers={customRenderers}
-      source={body}  
+      source={body}
     />
   </div>
 );

--- a/src/components/snew/Markdown/index.js
+++ b/src/components/snew/Markdown/index.js
@@ -1,0 +1,3 @@
+import Markdown from "./Markdown";
+
+export default Markdown;

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -216,6 +216,15 @@ a:hover {
 .message-error .message-header {
   color: #bf4153;
 }
+.message-info {
+  border: 1px solid #2971FF;
+}
+.message-info .message-icon {
+  background: #2971FF;
+}
+.message-info .message-header {
+  color: #2971FF;
+}
 
 .proposal-meta-data {
   margin-bottom: 8px;


### PR DESCRIPTION
I've introduced the component `MarkdownLiveHelper` it basically allows you to specify "mistakefinders" which take as input the current editor value and return if there is a potencial mistake and a helper message to be displayed for the user. We can use many of them but for now we have only detection for single newlines between chars.
In the overall it looks like this:
![screen shot 2017-12-14 at 12 23 40 pm](https://user-images.githubusercontent.com/14864439/33997302-1174ac4c-e0cb-11e7-8c80-988371e25aab.png)
fixes #150 