### PR TITLE
Wait 1 second to show loading icon on page transitions

### DIFF
--- a/src/components/snew/PageLoadingIcon.js
+++ b/src/components/snew/PageLoadingIcon.js
@@ -1,11 +1,36 @@
 import React from "react";
 import LoadingIcon from "./LoadingIcon";
 
-const PageLoadingIcon = ({ hidden }) => (
-  <LoadingIcon
-    hidden={hidden}
-    width={200}
-    style={{ margin: "300px auto 0 auto" }} />
-);
-
+class PageLoadingIcon extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      show: this.props.hidden || false
+    };
+  }
+  componentDidMount() {
+    if (!this.props.hidden) {
+      this.loadingIconDelay = setTimeout(() => {
+        this.setState({ show: true });
+        this.loadingIconDelay = 0;
+      }, 1000);
+    }
+  }
+  componentWillUnmount() {
+    if (this.loadingIconDelay) {
+      clearTimeout(this.loadingIconDelay);
+      this.loadingIconDelay = 0;
+    }
+  }
+  render () {
+    const { show } = this.state;
+    console.log(show);
+    return (
+      <LoadingIcon
+        hidden={!show}
+        width={200}
+        style={{ margin: "300px auto 0 auto" }} />
+    );
+  }
+}
 export default PageLoadingIcon;

--- a/src/components/snew/PageLoadingIcon.js
+++ b/src/components/snew/PageLoadingIcon.js
@@ -24,7 +24,6 @@ class PageLoadingIcon extends React.Component {
   }
   render () {
     const { show } = this.state;
-    console.log(show);
     return (
       <LoadingIcon
         hidden={!show}


### PR DESCRIPTION
As pointed out in https://github.com/decred/politeiagui/issues/159, the loading icon is causing some flickering when the page doesn't take long to load. As a solution, I added a 1 sec delay to show the loading icon on page transitions. The other approaches would require drastic UI changes and would be more appropriate after a redesign from the design team.

Fixes https://github.com/decred/politeiagui/issues/159