### PR TITLE
Change thread num for e2e tests to 1

### DIFF
--- a/test/e2e/nightwatch.json
+++ b/test/e2e/nightwatch.json
@@ -5,7 +5,7 @@
   "page_objects_path": "test/e2e/page_objects",
   "test_workers": {
     "enabled": true,
-    "workers": "auto"
+    "workers": 1
   },
   "selenium" : {
     "start_process" : true,


### PR DESCRIPTION
This change prevents tests from executing concurrently so that the server running them isn't overloaded, in an attempt to fix #147.