### PR TITLE
Add specific messages for empty proposal lists.

### DIFF
--- a/src/components/ProposalFilter.js
+++ b/src/components/ProposalFilter.js
@@ -7,15 +7,46 @@ import {
 const ProposalFilter = ({handleChangeFilterValue, header, filterValue}) => (
   header === "Unvetted Proposals" ?
     <div style={{margin: "16px 352px 0 24px"}}>
-      <span style={{margin: "5px"}}>Show:</span>
-      <select
-        value={filterValue}
-        onChange={(e) => handleChangeFilterValue(e.target.value)}
-      >
-        <option value={PROPOSAL_STATUS_UNREVIEWED}>Only Unreviewed</option>
-        <option value={PROPOSAL_STATUS_CENSORED}>Only Censored</option>
-        <option value={0}>All</option>
-      </select>
+      <span style={{marginRight: "16px"}}>Show:</span>
+
+      <input
+        type="radio"
+        id="admin-proposals-filter-unreviewed"
+        name="admin-proposals-filter"
+        value={PROPOSAL_STATUS_UNREVIEWED}
+        checked={filterValue === PROPOSAL_STATUS_UNREVIEWED}
+        onChange={e => handleChangeFilterValue(e.target.value)} />
+      <label
+        for="admin-proposals-filter-unreviewed"
+        style={{margin: "0 16px 0 4px"}}>
+        Only unreviewed
+      </label>
+
+      <input
+        type="radio"
+        id="admin-proposals-filter-censored"
+        name="admin-proposals-filter"
+        value={PROPOSAL_STATUS_CENSORED}
+        checked={filterValue === PROPOSAL_STATUS_CENSORED}
+        onChange={e => handleChangeFilterValue(e.target.value)} />
+      <label
+        for="admin-proposals-filter-censored"
+        style={{margin: "0 16px 0 4px"}}>
+        Only censored
+      </label>
+
+      <input
+        type="radio"
+        id="admin-proposals-filter-all"
+        name="admin-proposals-filter"
+        value={0}
+        checked={filterValue === 0}
+        onChange={e => handleChangeFilterValue(e.target.value)} />
+      <label
+        for="admin-proposals-filter-all"
+        style={{margin: "0 16px 0 4px"}}>
+        All
+      </label>
     </div>
     : null
 );

--- a/src/components/snew/Content.js
+++ b/src/components/snew/Content.js
@@ -11,6 +11,7 @@ export const CustomContent = ({
   bodyClassName="listing-page",
   listings,
   proposals,
+  emptyProposalsMessage = "There are no proposals yet",
   isLoading,
   error,
   header,
@@ -26,37 +27,41 @@ export const CustomContent = ({
       body={error} />
   ) : isLoading ? (
     <PageLoadingIcon key="content" />
-  ) : (listings && listings.length > 0) || proposals.length > 0 ? (
-    [
+  ) : (
+    <div>
       <h1 style={{margin: "16px 352px 0 24px"}}>
         {header}
-      </h1>,
+      </h1>
       <ProposalFilter
         header={header}
         handleChangeFilterValue={onChangeFilter}
         filterValue={filterValue}
-      />,
-      <Content {...{
-        ...props,
-        key: "content",
-        activeVotesEndHeight: props.activeVotesEndHeight,
-        lastBlockHeight: props.lastBlockHeight,
-        listings: listings || [
-          {
-            allChildren:
-            proposals.filter(
-              proposal =>
-                !filterValue || proposal.status === filterValue
-            )
-              .map((proposal, idx) => formatProposalData(proposal, idx, activeVotes))
-          }
-        ]
-      }} />
-    ]
-  ) : (
-    <h1 style={{ textAlign: "center", paddingTop: "300px" }}>
-      There are no proposals yet
-    </h1>
+      />
+      {
+        (listings && listings.length > 0) || proposals.length > 0 ? (
+          <Content {...{
+            ...props,
+            key: "content",
+            activeVotesEndHeight: props.activeVotesEndHeight,
+            lastBlockHeight: props.lastBlockHeight,
+            listings: listings || [
+              {
+                allChildren:
+                proposals.filter(
+                  proposal =>
+                    !filterValue || proposal.status === filterValue
+                )
+                  .map((proposal, idx) => formatProposalData(proposal, idx, activeVotes))
+              }
+            ]
+          }} />
+        ) : (
+          <h1 style={{ textAlign: "center", paddingTop: "125px", color: "#777" }}>
+            {emptyProposalsMessage}
+          </h1>
+        )
+      }
+    </div>
   );
 
   return [

--- a/src/connectors/admin.js
+++ b/src/connectors/admin.js
@@ -2,6 +2,10 @@ import { connect } from "react-redux";
 import * as sel from "../selectors";
 import * as act from "../actions";
 import { or } from "../lib/fp";
+import {
+  PROPOSAL_STATUS_UNREVIEWED,
+  PROPOSAL_STATUS_CENSORED
+} from "../constants";
 
 export default connect(
   sel.selectorMap({
@@ -9,7 +13,17 @@ export default connect(
     error: sel.unvettedProposalsError,
     isLoading: or(sel.unvettedProposalsIsRequesting, sel.setStatusProposalIsRequesting),
     filterValue: sel.getAdminFilterValue,
-    header: () => "Unvetted Proposals"
+    header: () => "Unvetted Proposals",
+    emptyProposalsMessage: (state) => {
+      switch(sel.getAdminFilterValue(state)) {
+      case PROPOSAL_STATUS_UNREVIEWED:
+        return "There are no proposals to review";
+      case PROPOSAL_STATUS_CENSORED:
+        return "There are no censored proposals, yay!";
+      default:
+        return "There are no unvetted proposals";
+      }
+    }
   }),
   {
     onFetchData: act.onFetchUnvetted,

--- a/src/connectors/proposals.js
+++ b/src/connectors/proposals.js
@@ -12,7 +12,8 @@ export default connect(
     isLoading: or(sel.vettedProposalsIsRequesting, sel.isApiRequestingActiveVotes),
     error: or(sel.vettedProposalsError, sel.activeVotesError),
     activeVotes: sel.activeVotes,
-    header: () => "Active Proposals"
+    header: () => "Active Proposals",
+    emptyProposalsMessage: () => "There are no active proposals"
   }),
   dispatch => bindActionCreators({
     onFetchData: act.onFetchVetted,

--- a/src/connectors/userProposals.js
+++ b/src/connectors/userProposals.js
@@ -13,7 +13,8 @@ const userProposalsConnector = connect(
     error: sel.userProposalsError,
     isLoading: sel.userProposalsIsRequesting,
     activeVotes: sel.activeVotes,
-    header: () => "Your Proposals"
+    header: () => "Your Proposals",
+    emptyProposalsMessage: () => "You have not created any proposals yet"
   }),
   dispatch =>
     bindActionCreators(
@@ -34,7 +35,7 @@ class Wrapper extends Component {
 
   render() {
     const Component = this.props.Component;
-    const {loggedInAsEmail, isAdmin, proposals, error, isLoading, header} = this.props;
+    const {loggedInAsEmail, isAdmin, proposals, error, isLoading, header, emptyProposalsMessage} = this.props;
     return <Component
       loggedInAsEmail={loggedInAsEmail}
       isAdmin={isAdmin}
@@ -42,6 +43,7 @@ class Wrapper extends Component {
       error={error}
       isLoading={isLoading}
       header={header}
+      emptyProposalsMessage={emptyProposalsMessage}
     />;
   }
 }


### PR DESCRIPTION
Also change the `<select>` filter field on the admin proposals list page to a radio group, for easier switching.

Fixes #199.