### PR TITLE
Convert object to uint8Array to resolve Safari issue

### DIFF
--- a/src/lib/pki.js
+++ b/src/lib/pki.js
@@ -5,12 +5,17 @@ import util from "tweetnacl-util";
 import get from "lodash/fp/get";
 
 export const STORAGE_PREFIX = "ed255191~";
-export const toHex = x => Buffer.from(x).toString("hex");
+export const toHex = x => Buffer.from(toUnint8Array(x)).toString("hex");
+
 export const toByteArray = str => {
   const bytes = new Uint8Array(Math.ceil(str.length / 2));
   for (var i = 0; i < bytes.length; i++) bytes[i] = parseInt(str.substr(i * 2, 2), 16);
   return bytes;
 };
+
+export const toUnint8Array = (obj) =>
+  obj.constructor === Uint8Array ? obj :
+    Uint8Array.from(Object.keys(obj).map(key => obj[key]));
 
 export const loadKeys = (email, keys) => localforage.setItem(STORAGE_PREFIX + email, keys).then(() => keys);
 export const generateKeys = () => Promise.resolve(nacl.sign.keyPair());

--- a/src/lib/tests/pki.test.js
+++ b/src/lib/tests/pki.test.js
@@ -13,6 +13,18 @@ describe("Key pair generation and storage handlers (lib/pki.js)", () => {
     expect(pki.toByteArray("042236")).toEqual(new Uint8Array([4, 34, 54]));
   });
 
+  test("converts and object to a uint8Array", () => {
+    const obj = {
+      0: 234,
+      1: 126,
+      2: 328
+    };
+    const uint8 = Uint8Array.from([234, 126, 328]);
+    expect(pki.toUnint8Array(obj)).toEqual(uint8);
+    //test it doesn't change an already Uint8array object
+    expect(pki.toUnint8Array(uint8)).toEqual(uint8);
+  });
+
   test("generate a key pair and save it with localforage", async () => {
     expect.assertions(1);
     const EMAIL = "foo@bar.com";


### PR DESCRIPTION
What was happening is that Safari doesn't store the typed arrays (uint8Array) in it's indexed DB.
Firefox and Chrome work just fine.
closes #321 