### PR TITLE
Move proposal image remove icon next to title.

### DIFF
--- a/src/components/ProposalImages/index.js
+++ b/src/components/ProposalImages/index.js
@@ -18,14 +18,15 @@ class ProposalImages extends Component {
     return (
       <div>
         {(files || []).map(({ name, mime, digest, payload }, idx) => (
-          <div key={digest || idx}>
-            <h5>{name}</h5>
-            <div className="attached-image-ct clearfloat">
-              <img className="attached-image" alt={name} src={`data:${mime};base64,${payload}`} />
-              {readOnly ? null : (
-                <a className="attached-image-remove" onClick={() => this.onRemove(idx)} title="Remove image">✖</a>
-              )}
-            </div>
+          <div key={digest || idx} className="attached-image-ct">
+            <h5 className="attached-image-title">{name}</h5>
+            {!readOnly && (
+              <a
+                className="attached-image-remove"
+                onClick={() => this.onRemove(idx)}
+                title="Remove image">✖</a>
+            )}
+            <img className="attached-image" alt={name} src={`data:${mime};base64,${payload}`} />
           </div>
         ))}
       </div>

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -283,15 +283,22 @@ a:hover {
   margin-top: 16px;
 }
 
+.attached-image-ct {
+  margin-top: 16px;
+}
 .attached-image {
   display: block;
-  float: left;
   position: relative;
   width: 100%;
 }
+.attached-image-title {
+  display: inline-block;
+  height: 24px;
+  line-height: 24px;
+  margin: 0;
+}
 .attached-image-remove {
-  display: block;
-  float: left;
+  display: inline-block;
   cursor: pointer;
   background: #bf4153;
   width: 24px;


### PR DESCRIPTION
This was necessary to accommodate images that use the maximum width.

Example:

![image](https://user-images.githubusercontent.com/1452379/42130106-8426fdbc-7ca7-11e8-855f-71a38f18d301.png)