### PR TITLE
minor fix -> trimming email when undefined

### DIFF
--- a/src/connectors/login.js
+++ b/src/connectors/login.js
@@ -42,7 +42,7 @@ class Wrapper extends Component {
   onLogin(args) {
     args = {
       ...args,
-      email: args.email.trim()
+      email: args.email === undefined ? null : args.email.trim()
     };
     validate(args);
     return this.props.onLogin(args).then(() => {


### PR DESCRIPTION
The login connector tried to trim the email whenever the user pressed Login, even when email was undefined, throwing js error page.

Now it is throwing the error message with Message component.