### PR TITLE
Keeps proposal form state if the submit failed with an error

### DIFF
--- a/src/reducers/form.js
+++ b/src/reducers/form.js
@@ -7,6 +7,9 @@ const formReducer = reducer.plugin({
   "form/proposal": (state, action) => {
     switch(action.type) {
     case act.RECEIVE_NEW_PROPOSAL:
+      if (action.error) {
+        return state;
+      }
       resetNewProposalData();
       return undefined;
     default:


### PR DESCRIPTION
If submit proposal action fails with error, the reducer returns the current state of the form.

closes https://github.com/decred/politeiagui/issues/477