### PR TITLE
Hash user’s password before sending it to the server

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "font-awesome": "^4.7.0",
     "js-file-download": "^0.4.1",
     "js-sha256": "^0.7.1",
+    "js-sha3": "^0.8.0",
     "localforage": "^1.5.4",
     "lodash": "^4.17.4",
     "node-less-chokidar": "^0.1.2",

--- a/src/lib/tests/api.test.js
+++ b/src/lib/tests/api.test.js
@@ -481,4 +481,10 @@ describe("api integration modules (lib/api.js)", () => {
     );
   });
 
+  test("it correctly returns the hex encoded SHA3-256 of a string", () => {
+    expect(
+      api.digest("password")
+    ).toEqual("c0067d4af4e87f00dbac63b6156828237059172d1bbeac67427345d6a9fda484");
+  });
+
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5272,6 +5272,10 @@ js-sha256@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.7.1.tgz#929c4244ecf19d535404c338b19ab693f5cf4b1b"
 
+js-sha3@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"


### PR DESCRIPTION
closes #443 

**Note:** In case someone is wondering why I haven't used the crypto-js lib (which was included already in the project) is because their SHA3-256 algorithm is slightly different from the standard one. From their [docs](https://code.google.com/archive/p/crypto-js/):
> SHA-3
[...]
>NOTE: I made a mistake when I named this implementation SHA-3. It should be named Keccak[c=2d]. Each of the SHA-3 functions is based on an instance of the Keccak algorithm, which NIST selected as the winner of the SHA-3 competition, but those SHA-3 functions won't produce hashes identical to Keccak. 