### PR TITLE
Refactor Component Lifecycle Code

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -25,8 +25,9 @@ store.subscribe(throttle(() => {
 const createStorageListener = store => event => store.dispatch(onLocalStorageChange(event));
 
 class Loader extends Component {
-  componentWillMount() {
-    this.props.onInit();
+  constructor(props) {
+    super();
+    props.onInit();
   }
 
   verifyUserPubkey = (email, keyToBeMatched) =>

--- a/src/App.js
+++ b/src/App.js
@@ -38,32 +38,32 @@ class Loader extends Component {
         )
       );
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.loggedInAsEmail) {
-      this.verifyUserPubkey(nextProps.loggedInAsEmail, nextProps.userPubkey);
+  componentDidUpdate(prevProps) {
+    if (!prevProps.loggedInAsEmail && this.props.loggedInAsEmail) {
+      this.props.onLoadDraftProposals(this.props.loggedInAsEmail);
     }
 
-    if (!this.props.loggedInAsEmail && nextProps.loggedInAsEmail) {
-      this.props.onLoadDraftProposals(nextProps.loggedInAsEmail);
-    }
-
-    if(!this.props.onboardViewed && nextProps.lastLoginTime === 0){
+    if(!prevProps.onboardViewed && this.props.lastLoginTime === 0){
       this.props.setOnboardAsViewed();
       this.props.openModal(ONBOARD);
     }
 
 
-    if (!this.props.apiError && nextProps.apiError) {
+    if (!prevProps.apiError && this.props.apiError) {
       // Unrecoverable error
-      if (nextProps.apiError.internalError) {
-        this.props.history.push(`/500?error=${nextProps.apiError.message}`);
+      if (this.props.apiError.internalError) {
+        this.props.history.push(`/500?error=${this.props.apiError.message}`);
       } else {
-        console.error("ERROR:", nextProps.apiError.message);
+        console.error("ERROR:", this.props.apiError.message);
       }
     }
   }
 
   componentDidMount() {
+    if (this.props.loggedInAsEmail) {
+      this.verifyUserPubkey(this.props.loggedInAsEmail, this.props.userPubkey);
+    }
+
     this.storageListener = createStorageListener(store);
     window.addEventListener("storage", this.storageListener);
     if (this.props.loggedInAsEmail) {

--- a/src/components/AccountPage.js
+++ b/src/components/AccountPage.js
@@ -44,9 +44,8 @@ class KeyPage extends React.Component {
     if (shouldAutoVerifyKey && updateUserKey) {
       const { verificationtoken } = updateUserKey;
       if ((prevUpdateUserKey && (verificationtoken !== prevUpdateUserKey.verificationtoken))
-        || !prevUpdateUserKey && verificationtoken) {
+        || (!prevUpdateUserKey && verificationtoken)) {
         this.setState({ openedVerification: true });
-        console.log("FIRE");
         this.props.history.push(`/user/key/verify/?verificationtoken=${verificationtoken}`);
         return;
       }

--- a/src/components/AccountPage.js
+++ b/src/components/AccountPage.js
@@ -40,6 +40,19 @@ class KeyPage extends React.Component {
     }
   }
 
+  updatePubkey = (shouldAutoVerifyKey, prevUpdateUserKey, updateUserKey) => {
+    if (shouldAutoVerifyKey && updateUserKey) {
+      const { verificationtoken } = updateUserKey;
+      if ((prevUpdateUserKey && (verificationtoken !== prevUpdateUserKey.verificationtoken))
+        || !prevUpdateUserKey && verificationtoken) {
+        this.setState({ openedVerification: true });
+        console.log("FIRE");
+        this.props.history.push(`/user/key/verify/?verificationtoken=${verificationtoken}`);
+        return;
+      }
+    }
+  }
+
   refreshPubKey = () => {
     myPubKeyHex(this.props.loggedInAsEmail).then(pubkey => {
       if(!this.unmounting) {
@@ -52,28 +65,19 @@ class KeyPage extends React.Component {
     this.resolvePubkey();
   }
 
-  componentDidUpdate() {
-    this.resolvePubkey();
-  }
-
   componentWillUnmount() {
     this.unmounting = true;
     this.props.onIdentityImported(null);
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(prevProps) {
+    this.resolvePubkey();
     if (this.state.openedVerification)
       return;
-    const { shouldAutoVerifyKey, updateUserKey } = nextProps;
-    if (shouldAutoVerifyKey && updateUserKey) {
-      this.setState({ openedVerification: true });
-      const { verificationtoken } = updateUserKey;
-      this.props.history.push(`/user/key/verify/?verificationtoken=${verificationtoken}`);
-      return;
-    }
+    this.updatePubkey(this.props.shouldAutoVerifyKey, prevProps.updateUserKey, this.props.updateUserKey);
 
     // update displayed public key when the identity is successfully imported
-    if (!this.props.identityImportSuccess && nextProps.identityImportSuccess) {
+    if (!prevProps.identityImportSuccess && this.props.identityImportSuccess) {
       this.refreshPubKey();
     }
   }

--- a/src/components/ForgottenPassword/index.js
+++ b/src/components/ForgottenPassword/index.js
@@ -7,9 +7,9 @@ import forgottenPasswordConnector from "../../connectors/forgottenPassword";
 import validate from "./ForgottenPasswordValidator";
 
 class ForgottenPassword extends Component {
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.forgottenPasswordResponse) {
-      nextProps.history.push("/user/forgotten/password/next");
+  componentDidUpdate() {
+    if (this.props.forgottenPasswordResponse) {
+      this.props.history.push("/user/forgotten/password/next");
     }
   }
 

--- a/src/components/ForgottenPasswordPage.js
+++ b/src/components/ForgottenPasswordPage.js
@@ -5,14 +5,10 @@ import qs from "query-string";
 class ForgottenPasswordPage extends Component {
   constructor(props) {
     super(props);
+    const { email } = qs.parse(props.location.search);
     this.state = {
-      email: ""
+      email: email
     };
-  }
-
-  componentWillMount() {
-    const { email } = qs.parse(this.props.location.search);
-    this.setState({ email });
   }
 
   render() {

--- a/src/components/LogoutPage.js
+++ b/src/components/LogoutPage.js
@@ -7,9 +7,9 @@ class LogoutPage extends Component {
     this.props.onLogout();
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (!this.props.error && nextProps.error) {
-      this.props.history.push(`/500?error=${nextProps.error.message}`);
+  componentDidUpdate(prevProps) {
+    if (!prevProps.error && this.props.error) {
+      this.props.history.push(`/500?error=${this.props.error.message}`);
     }
   }
 

--- a/src/components/Modal/ModalStack.js
+++ b/src/components/Modal/ModalStack.js
@@ -11,7 +11,8 @@ class ModalStack extends React.Component {
       modals: []
     };
   }
-  componentWillReceiveProps({ openedModals }) {
+  componentDidUpdate() {
+    const { openedModals } = this.props;
     const { modals } = this.state;
     let modalChanged = false;
     if(modals.length > openedModals.length) {

--- a/src/components/PasswordReset/index.js
+++ b/src/components/PasswordReset/index.js
@@ -24,9 +24,9 @@ class PasswordReset extends Component {
     this.props.resetPasswordReset();
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.passwordResetResponse) {
-      nextProps.history.push("/user/password/reset/next");
+  componentDidUpdate() {
+    if (this.props.passwordResetResponse) {
+      this.props.history.push("/user/password/reset/next");
     }
   }
 

--- a/src/components/PasswordReset/index.js
+++ b/src/components/PasswordReset/index.js
@@ -10,14 +10,13 @@ import validate from "./PasswordResetValidator";
 import { SubmissionError } from "redux-form";
 
 class PasswordReset extends Component {
-  componentWillMount() {
+  constructor(props) {
+    super();
     const query = this.getQueryParams();
-
     if (isRequiredValidator(query.email) && isRequiredValidator(query.verificationtoken)) {
       return;
     }
-
-    this.props.history.push("/");
+    props.history.push("/");
   }
 
   componentWillUnmount() {

--- a/src/components/ProposalDetail/ProposalDetail.js
+++ b/src/components/ProposalDetail/ProposalDetail.js
@@ -13,13 +13,13 @@ class ProposalDetail extends React.Component {
       sortedComments: []
     };
   }
-  componentWillReceiveProps(nextProps) {
-    if((!this.props.proposal || Object.keys(this.props.proposal).length === 0 ) &&
-      nextProps.proposal && Object.keys(nextProps.proposal).length > 0 &&
-      nextProps.proposal.status === 4 ){
-      this.props.onFetchProposalVoteStatus(this.props.token);
+  componentDidUpdate(prevProps) {
+    if((!prevProps.proposal || Object.keys(prevProps.proposal).length === 0 ) &&
+      this.props.proposal && Object.keys(this.props.proposal).length > 0 &&
+      this.props.proposal.status === 4 ){
+      prevProps.onFetchProposalVoteStatus(prevProps.token);
     }
-    this.handleUpdateOfComments(this.props, nextProps);
+    this.handleUpdateOfComments(prevProps, this.props);
   }
   componentDidMount() {
     this.props.onFetchLikedComments(this.props.token);

--- a/src/components/ResendVerificationEmail/index.js
+++ b/src/components/ResendVerificationEmail/index.js
@@ -7,9 +7,9 @@ import resendVerificationEmailConnector from "../../connectors/resendVerificatio
 import validate from "./ResendVerificationEmailValidator";
 
 class ResendVerificationEmail extends Component {
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.resendVerificationEmailResponse) {
-      nextProps.history.push("/user/resend/next");
+  componentDidUpdate() {
+    if (this.props.resendVerificationEmailResponse) {
+      this.props.history.push("/user/resend/next");
     }
   }
 

--- a/src/components/Router/AuthenticatedRoute.js
+++ b/src/components/Router/AuthenticatedRoute.js
@@ -16,9 +16,9 @@ class AuthenticatedRoute extends Component {
     this.checkAuthentication(this.props);
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (!nextProps.loggedInAsEmail || nextProps.location !== this.props.location) {
-      this.checkAuthentication(nextProps);
+  componentDidUpate(prevProps) {
+    if (!this.props.loggedInAsEmail || this.props.location !== prevProps.location) {
+      this.checkAuthentication(this.props);
     }
   }
 

--- a/src/components/Router/AuthenticatedRoute.js
+++ b/src/components/Router/AuthenticatedRoute.js
@@ -4,16 +4,16 @@ import requireLoginConnector from "../../connectors/requireLogin";
 import { loadStateLocalStorage } from "../../lib/local_storage";
 
 class AuthenticatedRoute extends Component {
+  constructor(props) {
+    super();
+    this.checkAuthentication(props);
+  }
   componentDidMount() {
     if (this.props.loggedInAsEmail) {
       return;
     }
 
     this.props.redirectedFrom(this.props.location.pathname);
-  }
-
-  componentWillMount() {
-    this.checkAuthentication(this.props);
   }
 
   componentDidUpate(prevProps) {

--- a/src/components/UserDetail/index.js
+++ b/src/components/UserDetail/index.js
@@ -21,15 +21,15 @@ class UserDetail extends Component {
     return user && (user.isadmin || user.id === loggedInAsUserId);
   }
 
-  componentWillReceiveProps({ editUserResponse, ...props }) {
+  componentDidUpdate() {
+    const { editUserResponse } = this.props;
     if(editUserResponse) {
       window.location.reload();
     }
 
-    if(this.isAdminOrTheUser(props)) {
+    if(this.isAdminOrTheUser(this.props)) {
       this.setState({ tabId: USER_DETAIL_TAB_GENERAL });
     }
-
   }
 
   onTabChange(tabId) {

--- a/src/components/Verify/index.js
+++ b/src/components/Verify/index.js
@@ -6,17 +6,18 @@ import VerifyPage from "./Page";
 import verifyConnector from "../../connectors/verify";
 
 class Verify extends Component {
-  componentWillMount() {
-    const { verificationtoken, email } = qs.parse(this.props.location.search);
-    if (isEmpty(this.props.location.search)
+  constructor(props) {
+    super();
+    const { verificationtoken, email } = qs.parse(props.location.search);
+    if (isEmpty(props.location.search)
       || !email || !verificationtoken
       || typeof(email) !== "string" || typeof(verificationtoken) !== "string"
     ) {
-      this.props.history.push("/user/login");
+      props.history.push("/user/login");
       return;
     }
 
-    this.props.onVerify(this.props.location.search)
+    props.onVerify(props.location.search)
       .catch(err => {
         console.error(err.stack || err);
       });

--- a/src/components/VerifyKey/index.js
+++ b/src/components/VerifyKey/index.js
@@ -9,14 +9,15 @@ import qs from "query-string";
 import Message from "../Message";
 
 class VerifyKey extends Component {
-  componentWillMount() {
-    const { verificationtoken } = qs.parse(this.props.location.search);
-    if (isEmpty(this.props.location.search) || !verificationtoken || typeof(verificationtoken) !== "string") {
-      this.props.history.push("/user/login");
+  constructor(props) {
+    super();
+    const { verificationtoken } = qs.parse(props.location.search);
+    if (isEmpty(props.location.search) || !verificationtoken || typeof(verificationtoken) !== "string") {
+      props.history.push("/user/login");
     }
-    const { email } = this.props;
+    const { email } = props;
     if(email && verificationtoken) {
-      this.props.onVerifyUserKey(email, verificationtoken);
+      props.onVerifyUserKey(email, verificationtoken);
     }
   }
 

--- a/src/components/VerifyKey/index.js
+++ b/src/components/VerifyKey/index.js
@@ -20,17 +20,17 @@ class VerifyKey extends Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
-    if(!this.props.email && nextProps.email) {
+  componentDidUpdate(prevProps) {
+    if(!prevProps.email && this.props.email) {
       const { verificationtoken } = qs.parse(this.props.location.search);
-      const { email } = nextProps;
+      const { email } = this.props;
       this.props.onVerifyUserKey(email, verificationtoken);
     }
-    const { verifyUserKey, apiMeResponse, loggedInAsEmail } = nextProps;
+    const { verifyUserKey, apiMeResponse, loggedInAsEmail } = this.props;
     if(verifyUserKey && verifyUserKey.success && apiMeResponse && loggedInAsEmail) {
       pki.myPubKeyHex(loggedInAsEmail).then((pubkey) => {
         if(pubkey !== apiMeResponse.publickey) {
-          this.props.updateMe({ ...nextProps.apiMeResponse, publickey: pubkey });
+          this.props.updateMe({ ...this.props.apiMeResponse, publickey: pubkey });
         }
       });
     }

--- a/src/components/snew/Content.js
+++ b/src/components/snew/Content.js
@@ -86,11 +86,11 @@ class Loader extends Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate() {
     const { isFetched } = this.state;
     if (isFetched)
       return;
-    const { csrf } = nextProps;
+    const { csrf } = this.props;
     if (csrf) {
       this.setState({ isFetched: true });
       this.props.onFetchProposalsVoteStatus && this.props.onFetchProposalsVoteStatus();

--- a/src/components/snew/Subreddit.js
+++ b/src/components/snew/Subreddit.js
@@ -9,8 +9,8 @@ const noSidebar = (p1) => (p2) => <Subreddit {...{ ...p2, ...p1 }} useSidebar={f
 const withSidebar = (p1) => (p2) => <Subreddit {...{ ...p2, ...p1 }} useSidebar={true} />;
 
 class CustomSubreddit extends Component {
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.location.pathname !== this.props.location.pathname) {
+  componentDidUpdate(prevProps) {
+    if (prevProps.location.pathname !== this.props.location.pathname) {
       this.props.onRouteChange();
       window.scrollTo(0, 0);
     }

--- a/src/connectors/editProposal.js
+++ b/src/connectors/editProposal.js
@@ -46,7 +46,8 @@ class SubmitWrapper extends Component {
     this.props.onFetchProposal && this.props.onFetchProposal(token);
   }
 
-  componentWillReceiveProps({ editedProposalToken, proposal }){
+  componentDidUpdate(){
+    const { editedProposalToken, proposal } = this.props;
     if (editedProposalToken) {
       this.props.onResetProposal();
       return this.props.history.push("/proposals/" + editedProposalToken);

--- a/src/connectors/login.js
+++ b/src/connectors/login.js
@@ -35,7 +35,8 @@ class Wrapper extends Component {
 
   onHidePrivacyPolicy  = () => this.setState({ showPrivacyPolicy: false });
 
-  componentWillReceiveProps({ loggedInAsEmail, redirectedFrom, resetRedirectedFrom, history }) {
+  componentDidUpdate() {
+    const { loggedInAsEmail, redirectedFrom, resetRedirectedFrom, history } = this.props;
     if (loggedInAsEmail && redirectedFrom) {
       resetRedirectedFrom();
       history.push(redirectedFrom);

--- a/src/connectors/newProposal.js
+++ b/src/connectors/newProposal.js
@@ -36,7 +36,8 @@ const newProposalConnector = connect(
 
 class NewProposalWrapper extends Component {
 
-  componentWillReceiveProps({ token }) {
+  componentDidUpdate() {
+    const { token } = this.props;
     if (token) {
       if (this.props.draftProposalById) {
         this.props.onDeleteDraft(this.props.draftProposalById.draftId);

--- a/src/connectors/signup.js
+++ b/src/connectors/signup.js
@@ -46,22 +46,22 @@ class Wrapper extends Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.loggedInAsEmail) {
+  componentDidUpdate() {
+    if (this.props.loggedInAsEmail) {
       if (this.props.isAdmin) {
         this.props.history.push("/admin/");
       } else {
         this.props.history.push("/user/proposals");
       }
-    } else if (nextProps.newUserResponse) {
-      nextProps.history.push("/user/signup/next");
+    } else if (this.props.newUserResponse) {
+      this.props.history.push("/user/signup/next");
     }
 
     const { hasFetchedPolicy } = this.state;
     if (hasFetchedPolicy)
       return;
 
-    if (nextProps.csrf) {
+    if (this.props.csrf) {
       this.setState({ hasFetchedPolicy: true });
       this.props.policy || this.props.onFetchData();
     }

--- a/src/connectors/submitProposal.js
+++ b/src/connectors/submitProposal.js
@@ -31,6 +31,17 @@ class SubmitWrapper extends Component {
     this.props.policy || this.props.onFetchData();
   }
 
+  // componentDidUpdate() {
+  //   const { token } = this.props;
+  //   if (token) {
+  //     if (this.props.draftProposalById) {
+  //       this.props.onDeleteDraft(this.props.draftProposalById.draftId);
+  //     }
+  //     this.props.onResetProposal();
+  //     return this.props.history.push("/proposals/" + token);
+  //   }
+  // }
+
   render() {
     const Component = this.props.Component;
     return <Component { ...{ ...this.props,

--- a/src/connectors/submitProposal.js
+++ b/src/connectors/submitProposal.js
@@ -31,17 +31,6 @@ class SubmitWrapper extends Component {
     this.props.policy || this.props.onFetchData();
   }
 
-  // componentDidUpdate() {
-  //   const { token } = this.props;
-  //   if (token) {
-  //     if (this.props.draftProposalById) {
-  //       this.props.onDeleteDraft(this.props.draftProposalById.draftId);
-  //     }
-  //     this.props.onResetProposal();
-  //     return this.props.history.push("/proposals/" + token);
-  //   }
-  // }
-
   render() {
     const Component = this.props.Component;
     return <Component { ...{ ...this.props,


### PR DESCRIPTION
`componentWillReceiveProps` and `componentWillMount` lifecycles are considered legacy and the  [React docs](https://reactjs.org/docs/react-component.html) advises to avoid using them. Soon they will be completely discontinued. I've refactored the lifecycle of our components that used them using `componentDidUpdate` and the `constructor` instead.