### PR TITLE
Improve proposal content backup logic

### DIFF
--- a/src/connectors/editProposal.js
+++ b/src/connectors/editProposal.js
@@ -64,6 +64,10 @@ class SubmitWrapper extends Component {
     const Component = this.props.Component;
     return <Component { ...{ ...this.props,
       editingMode: true,
+      initialValues: {
+        ...this.props.initialValues,
+        editing: true
+      },
       onSave: this.onSave
     }}  />;
   }

--- a/src/connectors/newProposal.js
+++ b/src/connectors/newProposal.js
@@ -9,7 +9,7 @@ import { getNewProposalData } from "../lib/editors_content_backup";
 
 const newProposalConnector = connect(
   sel.selectorMap({
-    initialValues: or(sel.draftProposalById, getNewProposalData),
+    draftProposal: sel.draftProposalById,
     isLoading: or(sel.isLoadingSubmit, sel.newProposalIsRequesting),
     policy: sel.policy,
     userid: sel.userid,
@@ -35,9 +35,15 @@ const newProposalConnector = connect(
 );
 
 class NewProposalWrapper extends Component {
+  constructor(props){
+    super(props);
+    this.state = {
+      initialValues: props.draftProposal || getNewProposalData()
+    };
+  }
 
-  componentDidUpdate() {
-    const { token } = this.props;
+  componentDidUpdate(prevProps) {
+    const { token, draftProposal } = this.props;
     if (token) {
       if (this.props.draftProposalById) {
         this.props.onDeleteDraft(this.props.draftProposalById.draftId);
@@ -45,12 +51,20 @@ class NewProposalWrapper extends Component {
       this.props.onResetProposal();
       return this.props.history.push("/proposals/" + token);
     }
+
+    const draftProposalDataAvailable = !prevProps.draftProposal && draftProposal;
+    if(draftProposalDataAvailable) {
+      this.setState({
+        initialValues: draftProposal
+      });
+    }
   }
 
   render() {
     const Component = this.props.Component;
     return <Component { ...{ ...this.props,
-      onSave: this.onSave
+      onSave: this.onSave,
+      initialValues: this.state.initialValues
     }}
     />;
   }

--- a/src/lib/editors_content_backup.js
+++ b/src/lib/editors_content_backup.js
@@ -1,39 +1,45 @@
 /*
 This lib is designed to handle persisting data for the text editors using session storage
 */
+import qs from "query-string";
+
+export const NEW_PROPOSAL_PATH = "/proposals/new";
+
+export const getProposalPath = (location) => {
+  const { pathname, search } = location;
+  const { draftid } = qs.parse(search);
+  const path = draftid ? `${pathname}-${draftid}` : pathname;
+  return path;
+};
+
+export const PROPOSAL_FORM_NAME = "name";
+export const PROPOSAL_FORM_DESC = "description";
+
+export const getProposalBackupKey = (key, path) => `proposal-${key}::${path}`;
+
 const updateFormData = (state) => {
-  const newProposalData = (state.form["form/proposal"] && state.form["form/proposal"].values) || {};
-  const newCommentData = (state.form["form/reply"] && state.form["form/reply"].values) || {};
-  const path = window.location.pathname;
-  Object.keys(newProposalData).forEach(key =>
-    sessionStorage.setItem(`new-proposal-${key}`, newProposalData[key])
-  );
-  Object.keys(newCommentData).forEach(key =>
-    sessionStorage.setItem(`new-${key}::${path}`, newCommentData[key])
-  );
+  const proposalFormState = state.form["form/proposal"];
+  const newProposalData = (proposalFormState && proposalFormState.values) || {};
+  const name = newProposalData[PROPOSAL_FORM_NAME];
+  const description = newProposalData[PROPOSAL_FORM_DESC];
+  if(!name && !description) {
+    return;
+  }
+
+  const path = getProposalPath(window.location);
+  sessionStorage.setItem(getProposalBackupKey(PROPOSAL_FORM_NAME, path), newProposalData[PROPOSAL_FORM_NAME]);
+  sessionStorage.setItem(getProposalBackupKey(PROPOSAL_FORM_DESC, path), newProposalData[PROPOSAL_FORM_DESC]);
 };
 
 export const resetNewProposalData = () => {
-  sessionStorage.setItem("new-proposal-name", "");
-  sessionStorage.setItem("new-proposal-description", "");
+  sessionStorage.setItem(getProposalBackupKey(PROPOSAL_FORM_NAME, NEW_PROPOSAL_PATH), "");
+  sessionStorage.setItem(getProposalBackupKey(PROPOSAL_FORM_DESC, NEW_PROPOSAL_PATH), "");
 };
 
 export const getNewProposalData = () => {
   return {
-    name: sessionStorage.getItem("new-proposal-name") || "",
-    description: sessionStorage.getItem("new-proposal-description") || ""
-  };
-};
-
-export const resetNewCommentData = () => {
-  const { pathname } = window.location;
-  sessionStorage.setItem(`new-comment::${pathname}`, "");
-};
-
-export const getNewCommentData = () => {
-  const { pathname } = window.location;
-  return {
-    comment: sessionStorage.getItem(`new-comment::${pathname}`) || ""
+    name: sessionStorage.getItem(getProposalBackupKey(PROPOSAL_FORM_NAME, NEW_PROPOSAL_PATH)) || "",
+    description: sessionStorage.getItem(getProposalBackupKey(PROPOSAL_FORM_DESC, NEW_PROPOSAL_PATH)) || ""
   };
 };
 

--- a/src/lib/tests/support/helpers.js
+++ b/src/lib/tests/support/helpers.js
@@ -21,3 +21,13 @@ export const assertGETOnRouteIsCalled = async (path, func, args, mockResult = {}
   expect(fetchMock.called(path)).toBeTruthy();
   return result;
 };
+
+export const setMockUrl = (props) => {
+  Object.keys(props).forEach(key => {
+    Object.defineProperty(window.location, key, {
+      writable: true,
+      value: props[key]
+    });
+  });
+};
+

--- a/src/reducers/form.js
+++ b/src/reducers/form.js
@@ -1,5 +1,5 @@
 import { reducer } from "redux-form";
-import { resetNewProposalData, resetNewCommentData } from "../lib/editors_content_backup";
+import { resetNewProposalData } from "../lib/editors_content_backup";
 import * as act from "../actions/types";
 
 const formReducer = reducer.plugin({
@@ -27,7 +27,6 @@ const formReducer = reducer.plugin({
   "form/reply": (state, action) => {
     switch(action.type) {
     case act.RECEIVE_NEW_COMMENT:
-      resetNewCommentData();
       return undefined;
     default:
       return state;

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -8,6 +8,7 @@ class MockedLocalStorage {
   constructor() {
     this.keyValue = {};
   }
+  inspectValues = () => this.keyValue
   setItem = (key, value) => {
     this.keyValue = {
       ...this.keyValue,


### PR DESCRIPTION
closes #543 

This PR also cleans up a bit the logic for creating a  backup of the proposals form content into session storage.