### PR TITLE
Reducers to pure functions

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -2,7 +2,6 @@ import Promise from "promise";
 import * as sel from "../selectors";
 import * as api from "../lib/api";
 import * as pki from "../lib/pki";
-import get from "lodash/fp/get";
 import { confirmWithModal, openModal, closeModal } from "./modal";
 import * as modalTypes from "../components/Modal/modalTypes";
 import * as external_api_actions from "./external_api";
@@ -416,21 +415,9 @@ export const onSubmitStatusProposal = (loggedInAsEmail, token, status, censorMes
     if (status === 4) {
       dispatch(act.SET_PROPOSAL_APPROVED(true));
     }
-    const state = getState();
-    const viewedProposal = get([ "proposal", "response", "proposal" ], state.api);
     return api
       .proposalSetStatus(loggedInAsEmail, csrf, token, status, censorMessage)
-      .then(response => {
-        const { proposal: updatedProposal } = response;
-        const updateProposalStatus = proposal => {
-          if (get([ "censorshiprecord", "token" ], updatedProposal) === get([ "censorshiprecord", "token" ], proposal)) {
-            return updatedProposal;
-          } else {
-            return proposal;
-          }
-        };
-        dispatch(act.RECEIVE_SETSTATUS_PROPOSAL({ viewedProposal, updatedProposal, updateProposalStatus }));
-      })
+      .then(response => dispatch(act.RECEIVE_SETSTATUS_PROPOSAL(response)))
       .catch(error => {
         dispatch(act.RECEIVE_SETSTATUS_PROPOSAL(null, error));
       });

--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -7,6 +7,7 @@ import * as modalTypes from "../components/Modal/modalTypes";
 import * as external_api_actions from "./external_api";
 import { clearStateLocalStorage } from "../lib/local_storage";
 import { callAfterMinimumWait } from "./lib";
+import { resetNewProposalData } from "../lib/editors_content_backup";
 import act from "./methods";
 import {
   globalUsernamesById,
@@ -281,7 +282,7 @@ export const onSubmitProposal = (
     return Promise.resolve(api.makeProposal(name, description, files))
       .then(proposal => api.signProposal(loggedInAsEmail, proposal))
       .then(proposal => api.newProposal(csrf, proposal))
-      .then(proposal =>
+      .then(proposal => {
         dispatch(
           act.RECEIVE_NEW_PROPOSAL({
             ...proposal,
@@ -291,13 +292,15 @@ export const onSubmitProposal = (
             name,
             description
           })
-        )
-      )
+        );
+        resetNewProposalData();
+      })
       .then(() => {
         dispatch(act.SUBTRACT_PROPOSAL_CREDITS(1));
       })
       .catch(error => {
         dispatch(act.RECEIVE_NEW_PROPOSAL(null, error));
+        resetNewProposalData();
         throw error;
       });
   });
@@ -314,13 +317,13 @@ export const onSubmitEditedProposal = (
     return Promise.resolve(api.makeProposal(name, description, files))
       .then(proposal => api.signProposal(loggedInAsEmail, proposal))
       .then(proposal => api.editProposal(csrf, { ...proposal, token }))
-      .then(proposal =>
-        dispatch(
-          act.RECEIVE_EDIT_PROPOSAL(proposal)
-        )
-      )
+      .then(proposal => {
+        dispatch(act.RECEIVE_EDIT_PROPOSAL(proposal));
+        resetNewProposalData();
+      })
       .catch(error => {
         dispatch(act.RECEIVE_EDIT_PROPOSAL(null, error));
+        resetNewProposalData();
         throw error;
       });
   });

--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -8,7 +8,6 @@ import * as external_api_actions from "./external_api";
 import { clearStateLocalStorage } from "../lib/local_storage";
 import { callAfterMinimumWait } from "./lib";
 import act from "./methods";
-import cloneDeep from "lodash/cloneDeep";
 import {
   globalUsernamesById,
   selectDefaultPublicFilterValue,
@@ -332,21 +331,8 @@ export const onLikeComment = (loggedInAsEmail, token, commentid, action) =>
       dispatch(openModal("LOGIN", {}, null));
       return;
     }
-    const state = getState();
-    const newAction = parseInt(action, 10);
-    const commentsvotes = state.api.commentsvotes.response &&
-      state.api.commentsvotes.response.commentsvotes;
-    const backupCV = cloneDeep(commentsvotes);
-    const comments = state.api.proposalComments.response &&
-      state.api.proposalComments.response.comments;
-
-    const { cvs: newCommentsVotes, oldAction }
-      = api.reduceCommentLikes(commentsvotes, commentid, token, newAction);
-
     dispatch(act.REQUEST_LIKE_COMMENT({ commentid, token }));
-    dispatch(act.RECEIVE_SYNC_LIKE_COMMENT({
-      backupCV, comments, newCommentsVotes, oldAction, newAction, commentid
-    }));
+    dispatch(act.RECEIVE_SYNC_LIKE_COMMENT({ token, commentid, action }));
     return Promise.resolve(api.makeLikeComment(token, action, commentid))
       .then(comment => api.signLikeComment(loggedInAsEmail, comment))
       .then(comment => api.likeComment(csrf, comment))

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -5,6 +5,7 @@ import isEqual from "lodash/isEqual";
 import { onSubmitProposal, onChangeUsername, onChangePassword, onFetchProposalComments, onSubmitEditedProposal } from "./api";
 import { onFetchProposal as onFetchProposalApi, onSubmitComment as onSubmitCommentApi } from "./api";
 import { onFetchUsernamesById as onFetchUsernamesByIdApi } from "./api";
+import { resetNewProposalData } from "../lib/editors_content_backup";
 import * as sel from "../selectors";
 import act from "./methods";
 import { TOP_LEVEL_COMMENT_PARENTID } from "../lib/api";
@@ -38,8 +39,10 @@ export const onEditProposal = ({ name, description, files }, _, props) =>
   (dispatch) =>
     dispatch(onSubmitEditedProposal(props.loggedInAsEmail, name.trim(), description, files, props.token));
 
-export const onSaveDraftProposal = ({ name, description, files, draftId }) =>
-  act.SAVE_DRAFT_PROPOSAL({ name: name.trim(), description, files, timestamp: Date.now() / 1000, draftId });
+export const onSaveDraftProposal = ({ name, description, files, draftId }) => {
+  resetNewProposalData();
+  return act.SAVE_DRAFT_PROPOSAL({ name: name.trim(), description, files, timestamp: Date.now() / 1000, draftId });
+};
 
 export const onLoadDraftProposals = (email) => {
   const stateFromLS = loadStateLocalStorage(email);

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -228,3 +228,33 @@ export const usernamesById = (csrf, userids) => {
 export const proposalsVoteStatus = () => GET("/v1/proposals/votestatus").then(getResponse);
 export const proposalVoteStatus = (token) => GET(`/v1/proposals/${token}/votestatus`).then(getResponse);
 
+
+export const reduceCommentLikes = (commentsvotes, commentid, token, newAction) => {
+  let reducedVotes = null;
+  const cvfound = commentsvotes && commentsvotes.find(
+    cv => cv.commentid === commentid && cv.token === token
+  );
+
+  if (cvfound) {
+    reducedVotes = commentsvotes.reduce(
+      (acc, cv) => {
+        if (cv.commentid === commentid && cv.token === token) {
+          const currentAction = parseInt(cv.action, 10);
+          acc.oldAction = currentAction;
+          cv = {
+            ...cv,
+            action: newAction === currentAction ? 0 : newAction
+          };
+        }
+        return { ...acc, cvs: acc.cvs.concat([cv]) };
+      }, { cvs: [], oldAction: null });
+  } else {
+    const newCommentVote = { token, commentid, action: newAction };
+    reducedVotes = {
+      cvs: commentsvotes ? commentsvotes.concat([newCommentVote]) : [newCommentVote],
+      oldAction: 0
+    };
+  }
+
+  return reducedVotes;
+};

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -227,34 +227,3 @@ export const usernamesById = (csrf, userids) => {
 
 export const proposalsVoteStatus = () => GET("/v1/proposals/votestatus").then(getResponse);
 export const proposalVoteStatus = (token) => GET(`/v1/proposals/${token}/votestatus`).then(getResponse);
-
-
-export const reduceCommentLikes = (commentsvotes, commentid, token, newAction) => {
-  let reducedVotes = null;
-  const cvfound = commentsvotes && commentsvotes.find(
-    cv => cv.commentid === commentid && cv.token === token
-  );
-
-  if (cvfound) {
-    reducedVotes = commentsvotes.reduce(
-      (acc, cv) => {
-        if (cv.commentid === commentid && cv.token === token) {
-          const currentAction = parseInt(cv.action, 10);
-          acc.oldAction = currentAction;
-          cv = {
-            ...cv,
-            action: newAction === currentAction ? 0 : newAction
-          };
-        }
-        return { ...acc, cvs: acc.cvs.concat([cv]) };
-      }, { cvs: [], oldAction: null });
-  } else {
-    const newCommentVote = { token, commentid, action: newAction };
-    reducedVotes = {
-      cvs: commentsvotes ? commentsvotes.concat([newCommentVote]) : [newCommentVote],
-      oldAction: 0
-    };
-  }
-
-  return reducedVotes;
-};

--- a/src/reducers/api.js
+++ b/src/reducers/api.js
@@ -37,7 +37,17 @@ export const DEFAULT_STATE = {
 export const onReceiveSetStatus = (state, action) => {
   state = receive("setStatusProposal", state, action);
   if (action.error) return state;
-  const { viewedProposal, updatedProposal, updateProposalStatus } = action.payload;
+
+  const { proposal: updatedProposal } = action.payload;
+  const viewedProposal = get([ "proposal", "response", "proposal" ], state);
+  const updateProposalStatus = proposal => {
+    if (get([ "censorshiprecord", "token" ], updatedProposal) === get([ "censorshiprecord", "token" ], proposal)) {
+      return updatedProposal;
+    } else {
+      return proposal;
+    }
+  };
+
   return {
     ...state,
     proposal: viewedProposal

--- a/src/reducers/api.js
+++ b/src/reducers/api.js
@@ -1,10 +1,8 @@
 import * as act from "../actions/types";
 import get from "lodash/fp/get";
 import map from "lodash/fp/map";
-import cloneDeep from "lodash/cloneDeep";
 import { DEFAULT_REQUEST_STATE, request, receive, reset, resetMultiple } from "./util";
 import { PROPOSAL_VOTING_ACTIVE } from "../constants";
-import { clearStateLocalStorage } from "../lib/local_storage";
 
 export const DEFAULT_STATE = {
   me: DEFAULT_REQUEST_STATE,
@@ -39,17 +37,7 @@ export const DEFAULT_STATE = {
 export const onReceiveSetStatus = (state, action) => {
   state = receive("setStatusProposal", state, action);
   if (action.error) return state;
-
-  const { proposal: updatedProposal } = action.payload;
-  const viewedProposal = get([ "proposal", "response", "proposal" ], state);
-  const updateProposalStatus = proposal => {
-    if (get([ "censorshiprecord", "token" ], updatedProposal) === get([ "censorshiprecord", "token" ], proposal)) {
-      return updatedProposal;
-    } else {
-      return proposal;
-    }
-  };
-
+  const { viewedProposal, updatedProposal, updateProposalStatus } = action.payload;
   return {
     ...state,
     proposal: viewedProposal
@@ -125,43 +113,8 @@ export const onResetSyncLikeComment = (state) => {
 };
 
 export const onReceiveSyncLikeComment = (state, action) => {
-  const { token, action: cAction, commentid } = action.payload;
-  const newAction = parseInt(cAction, 10);
-
-  const commentsvotes = state.commentsvotes.response &&
-    state.commentsvotes.response.commentsvotes;
-  const backupCV = cloneDeep(commentsvotes);
-  const comments = state.proposalComments.response &&
-    state.proposalComments.response.comments;
-
-  let reducedVotes = null;
-  const cvfound = commentsvotes && commentsvotes.find(
-    cv => cv.commentid === commentid && cv.token === token
-  );
-
-  if (cvfound) {
-    reducedVotes = commentsvotes.reduce(
-      (acc, cv) => {
-        if (cv.commentid === commentid && cv.token === token) {
-          const currentAction = parseInt(cv.action, 10);
-          acc.oldAction = currentAction;
-          cv = {
-            ...cv,
-            action: newAction === currentAction ? 0 : newAction
-          };
-        }
-        return { ...acc, cvs: acc.cvs.concat([cv]) };
-      }, { cvs: [], oldAction: null });
-  } else {
-    const newCommentVote = { token, commentid, action: newAction };
-    reducedVotes = {
-      cvs: commentsvotes ? commentsvotes.concat([newCommentVote]) : [newCommentVote],
-      oldAction: 0
-    };
-  }
-
-  const { cvs: newCommentsVotes, oldAction } = reducedVotes;
-
+  const { backupCV, comments, newCommentsVotes,
+    oldAction, newAction, commentid } = action.payload;
   return {
     ...state,
     commentsvotes: {
@@ -314,7 +267,6 @@ const api = (state = DEFAULT_STATE, action) => (({
   [act.RECEIVE_LOGOUT]: () => {
     const tempState = DEFAULT_STATE;
     tempState.init = state.init;
-    clearStateLocalStorage(); // TODO: move to keep reducers as pure functions
     return tempState;
   }
 })[action.type] || (() => state))();

--- a/src/reducers/form.js
+++ b/src/reducers/form.js
@@ -1,5 +1,4 @@
 import { reducer } from "redux-form";
-import { resetNewProposalData } from "../lib/editors_content_backup";
 import * as act from "../actions/types";
 
 const formReducer = reducer.plugin({
@@ -9,16 +8,13 @@ const formReducer = reducer.plugin({
       if (action.error) {
         return state;
       }
-      resetNewProposalData();
       return undefined;
     case act.RECEIVE_EDIT_PROPOSAL:
       if (action.error) {
         return state;
       }
-      resetNewProposalData();
       return undefined;
     case act.SAVE_DRAFT_PROPOSAL:
-      resetNewProposalData();
       return undefined;
     default:
       return state;


### PR DESCRIPTION
Audit reducers to be pure functions only, and moved logic like assignments and declarations, iterations, to action/lib.

Only two reducers from api module needed a rewrite.

closes https://github.com/decred/politeiagui/issues/562