### PR TITLE
Comment bundle download

### DIFF
--- a/src/components/DownloadBundle.js
+++ b/src/components/DownloadBundle.js
@@ -1,14 +1,16 @@
 import React, { Component } from "react";
 import proposalDownloadConnector from "../connectors/proposalDownload";
 import fileDownload from "js-file-download";
+import { commentsToT1 } from "../lib/snew";
 
 class DownloadBundle extends Component {
   constructor(props) {
     super(props);
-    this.handleDownloadClick = this.handleDownloadClick.bind(this);
+    this.handleDownloadProposal = this.handleDownloadProposal.bind(this);
+    this.handleDownloadComment = this.handleDownloadComment.bind(this);
   }
 
-  handleDownloadClick() {
+  handleDownloadProposal() {
     const { proposal, serverPubkey } = this.props;
     const bundle = proposal;
     bundle.serverPubkey = serverPubkey;
@@ -16,12 +18,25 @@ class DownloadBundle extends Component {
     fileDownload(data, `${proposal.censorshiprecord.token}.json`);
   }
 
+  handleDownloadComment() {
+    const { proposalComments, proposal } = this.props;
+    const data = JSON.stringify(commentsToT1(proposalComments), null, 2);
+    fileDownload(data, `${proposal.censorshiprecord.token}-comments.json`);
+  }
+
+
   render() {
-    return (
-      <a style={{ cursor: "pointer" }} onClick={this.handleDownloadClick}>
+    const t = this.props.type;
+
+    return t === "proposal" ? (
+      <a style={{ cursor: "pointer" }} onClick={this.handleDownloadProposal}>
         {this.props.message || "Download Proposal Bundle"}
       </a>
-    );
+    ) : t === "comments" ? (
+      <a style={{ cursor: "pointer" }} onClick={this.handleDownloadComment}>
+        {this.props.message || "Download Comments Bundle"}
+      </a>
+    ) : null;
   }
 }
 

--- a/src/components/snew/ThingLink.js
+++ b/src/components/snew/ThingLink.js
@@ -62,13 +62,20 @@ const ThingLinkComp = ({
   isTestnet,
   getVoteStatus,
   confirmWithModal,
-  userId
+  userId,
+  comments
 }) => {
   const voteStatus = getVoteStatus(id) && getVoteStatus(id).status;
   const displayVersion = review_status === PROPOSAL_STATUS_PUBLIC;
   const isVotingActiveOrFinished = voteStatus === PROPOSAL_VOTING_ACTIVE || voteStatus === PROPOSAL_VOTING_FINISHED;
   const isEditable = authorid === userId && !isVotingActiveOrFinished && review_status !== PROPOSAL_STATUS_CENSORED;
   const hasBeenUpdated = review_status === PROPOSAL_STATUS_UNREVIEWED_CHANGES || parseInt(version, 10) > 1;
+  const hasAuthoredComment = () => {
+    for (const c of comments) {
+      if (c.userid === userId) return true;
+    }
+    return false;
+  };
   return (
     <div
       className={`thing thing-proposal id-${id} odd link ${
@@ -184,7 +191,7 @@ const ThingLinkComp = ({
                 >
                   Your proposal has been created, but it will not be public
                 until an admin approves it. You can{" "}
-                  <DownloadBundle message="download your proposal" /> and use
+                  <DownloadBundle message="download your proposal" type="proposal"/> and use
                 the{" "}
                   <a
                     href="https://github.com/decred/politeia/tree/master/politeiad/cmd/politeia_verify"
@@ -196,14 +203,25 @@ const ThingLinkComp = ({
                   to prove that your submission has been accepted for review by
                   Politeia. If your proposal is censored by an admin, you won't be
                   able to access it's contents.
+                  and use
+
                 </p>
               </span>
             </Message>
-          ) : (
-            <div style={{ marginTop: "15px", marginBottom: "15px" }}>
-              <DownloadBundle />
-            </div>
-          ))}
+          ) : hasAuthoredComment() ? (
+            <div>
+              <div style={{ marginTop: "15px", marginBottom: "15px" }}>
+                <DownloadBundle type="proposal" />
+              </div>
+              <div style={{ marginTop: "15px", marginBottom: "15px" }}>
+                <DownloadBundle type="comments" />
+              </div>
+            </div>)
+            : (
+              <div style={{ marginTop: "15px", marginBottom: "15px" }}>
+                <DownloadBundle type="proposal" /> <br></br>
+              </div>
+            ))}
         {censorMessage && <CensorMessage message={censorMessage} />}
         <Expando {...{ expanded, is_self, selftext, selftext_html }} />
         <ProposalImages readOnly files={otherFiles} />

--- a/src/connectors/proposalDownload.js
+++ b/src/connectors/proposalDownload.js
@@ -4,6 +4,7 @@ import * as sel from "../selectors";
 const proposalDownloadConnector = connect(
   sel.selectorMap({
     proposal: sel.proposal,
+    proposalComments: sel.proposalComments,
     serverPubkey: sel.serverPubkey
   })
 );

--- a/src/connectors/thingLink.js
+++ b/src/connectors/thingLink.js
@@ -2,7 +2,7 @@ import { connect } from "react-redux";
 import * as sel from "../selectors";
 import * as act from "../actions";
 
-const proposalDownloadConnector = connect(
+const thingLinkConnector = connect(
   sel.selectorMap({
     isProposalStatusApproved: sel.isProposalStatusApproved,
     tokenFromStartingVoteProp: sel.getPropTokenIfIsStartingVote,
@@ -10,6 +10,7 @@ const proposalDownloadConnector = connect(
     lastBlockHeight: sel.lastBlockHeight,
     isTestnet: sel.isTestNet,
     getVoteStatus: sel.getPropVoteStatus,
+    comments: sel.proposalComments,
     csrf: sel.csrf
   }),
   {
@@ -18,4 +19,4 @@ const proposalDownloadConnector = connect(
   }
 );
 
-export default proposalDownloadConnector;
+export default thingLinkConnector;


### PR DESCRIPTION
Adds another handler for downloading comment context when needed.

Right now, if the logged user has a comment authored on the proposal, the option to download the comment bundle is available, but we can tailor that easily if it's decided that only censored comments will be available, or some other cases.