### PR TITLE
Improvements on paywall flow

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -79,9 +79,9 @@ const LoaderComponent = withRouter(loaderConnector(Loader));
 
 const HeaderAlertComponent = withRouter(
   loaderConnector(
-    ({ location, loggedInAsEmail, userCanExecuteActions, history }) => {
+    ({ location, loggedInAsEmail, keyMismatch, history }) => {
       if (!loggedInAsEmail) return null;
-      if (!userCanExecuteActions && location.pathname !== "/user/account") {
+      if (keyMismatch && location.pathname !== "/user/account") {
         return (
           <HeaderAlert className="action-needed-alert">
 						You cannot currently submit proposals or comments, please visit your{" "}

--- a/src/components/AccountPage.js
+++ b/src/components/AccountPage.js
@@ -5,7 +5,6 @@ import PasswordChange from "./PasswordChange";
 import UsernameChange from "./UsernameChange";
 import Message from "./Message";
 import { myPubKeyHex } from "../lib/pki";
-import Paywall from "./Paywall";
 import accountConnector from "../connectors/account";
 import { CONFIRM_ACTION } from "../components/Modal/modalTypes";
 import { PUB_KEY_STATUS_LOADED, PUB_KEY_STATUS_LOADING } from "../constants";
@@ -98,14 +97,12 @@ class KeyPage extends React.Component {
   }
 
   render() {
-    console.log(this.props);
     const {
       loggedInAsEmail,
       onUpdateUserKey,
       updateUserKey,
       updateUserKeyError,
       keyMismatch,
-      userAlreadyPaid,
       onIdentityImported,
       identityImportError,
       identityImportSuccess,
@@ -114,9 +111,6 @@ class KeyPage extends React.Component {
     const { pubkey, pubkeyStatus, showIdentityHelpText } = this.state;
     return (
       <div className="content" role="main" >
-        {!userAlreadyPaid ? (
-          <Paywall />
-        ) : null}
         {keyMismatch && !identityImportSuccess ? (
           <Message
             type="error"

--- a/src/components/AddressViewer.js
+++ b/src/components/AddressViewer.js
@@ -1,0 +1,32 @@
+import React from "react";
+import QRCode from "./QRCode";
+
+const copyToClipboard = str => {
+  const el = document.createElement("textarea");
+  el.value = str;
+  document.body.appendChild(el);
+  el.select();
+  document.execCommand("copy");
+  document.body.removeChild(el);
+};
+
+const AddressViewer = ({ paywallAddress }) => {
+  return (
+    <div style={{ display: "flex",  alignItems: "center", justifyContent: "center" }}>
+      <div className="address-viewer">
+        <div className="address-viewer_menu">
+          <span
+            className="address-viewer_menu_option fa fa-copy"
+            onClick={() => copyToClipboard(paywallAddress)}
+          ></span>
+        </div>
+        <span id={"paywall-address"} className="address-viewer_text">
+          {paywallAddress}
+        </span>
+      </div>
+      <QRCode addr={paywallAddress} />
+    </div>
+  );
+};
+
+export default AddressViewer;

--- a/src/components/Modal/ModalContent.js
+++ b/src/components/Modal/ModalContent.js
@@ -4,13 +4,15 @@ import ConfirmAction from "./contents/ConfirmAction";
 import ConfirmActionWithReason from "./contents/ConfirmActionWithReason";
 import Login from "./contents/Login";
 import OnBoard from "./contents/OnBoard";
+import PaywallModal from "./contents/PaywallModal";
 import { withRouter } from "react-router-dom";
 
 const mapModalTypeToContent = {
   [modalTypes.CONFIRM_ACTION]: ({ modalData }) => <ConfirmAction me={modalData} />,
   [modalTypes.CONFIRM_ACTION_WITH_REASON]: ({ modalData }) => <ConfirmActionWithReason me={modalData} />,
   [modalTypes.LOGIN]: ({ location }) => <Login pathname={location.pathname} />,
-  [modalTypes.ONBOARD]: () => <OnBoard />
+  [modalTypes.ONBOARD]: () => <OnBoard />,
+  [modalTypes.PAYWALL_MODAL]: () => <PaywallModal />
 };
 
 const ModalContent = ({ modalData, location }) => {

--- a/src/components/Modal/contents/PaywallModal.js
+++ b/src/components/Modal/contents/PaywallModal.js
@@ -3,22 +3,13 @@ import ModalContentWrapper from "../ModalContentWrapper";
 import modalConnector from "../../../connectors/modal";
 import Paywall from "../../Paywall";
 
-class PaywallModal extends React.Component {
-  constructor(props) {
-    super(props);
-  }
-  render() {
-    const { closeModal } = this.props;
-    return (
-      <ModalContentWrapper
-        title={"Complete your registration"}
-        onClose={closeModal}
-        style={{ height: "calc(100vh - 100px)" }}
-      >
-        <Paywall />
-      </ModalContentWrapper>
-    );
-  }
-}
+const PaywallModal = ({ closeModal }) => (
+  <ModalContentWrapper
+    title={"Complete your registration"}
+    onClose={closeModal}
+  >
+    <Paywall />
+  </ModalContentWrapper>
+);
 
 export default modalConnector(PaywallModal);

--- a/src/components/Modal/contents/PaywallModal.js
+++ b/src/components/Modal/contents/PaywallModal.js
@@ -1,0 +1,24 @@
+import React from "react";
+import ModalContentWrapper from "../ModalContentWrapper";
+import modalConnector from "../../../connectors/modal";
+import Paywall from "../../Paywall";
+
+class PaywallModal extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+  render() {
+    const { closeModal } = this.props;
+    return (
+      <ModalContentWrapper
+        title={"Complete your registration"}
+        onClose={closeModal}
+        style={{ height: "calc(100vh - 100px)" }}
+      >
+        <Paywall />
+      </ModalContentWrapper>
+    );
+  }
+}
+
+export default modalConnector(PaywallModal);

--- a/src/components/Modal/modalTypes.js
+++ b/src/components/Modal/modalTypes.js
@@ -2,3 +2,4 @@ export const CONFIRM_ACTION = "CONFIRM_ACTION";
 export const CONFIRM_ACTION_WITH_REASON = "CONFIRM_ACTION_WITH_REASON";
 export const LOGIN = "LOGIN";
 export const ONBOARD = "ONBOARD";
+export const PAYWALL_MODAL = "PAYWALL_MODAL";

--- a/src/components/Paywall/Page.js
+++ b/src/components/Paywall/Page.js
@@ -33,21 +33,18 @@ const Paywall = ({
       <div className="paywall-wrapper" style={{ padding: "10px" }}>
         <div className="paywall-content">
           <p className="paywall-paragraph">
-           To submit your own proposal, comment on a proposal, up/down vote comments on proposals,
-           or vote on a proposal, Politeia requires you to pay a small registration fee ({paywallAmount} DCR).
-           This is to prevent proposal spamming and to prevent users from creating multiple
-           “sock puppet” accounts to manipulate up/down voting on comments.
+          To participate on proposals and to submit your own, Politeia requires you to pay a small
+          registration fee. This helps keep Politeia free of things like spam and vote manipulation.
           </p>
           <p className="paywall-paragraph highlight">
-            To complete your registration and to be able to submit proposals and comments,
-            please send exactly <span className="paywall-amount">{paywallAmount} DCR</span>{" "}
-            to
+            To complete your registration please send exactly
+            <span className="paywall-amount">{paywallAmount} DCR</span>{" "}
+            to:
           </p>
           <AddressViewer paywallAddress={paywallAddress} />
           <p className="paywall-paragraph">
-            Politeia automatically checks for a transaction with this amount sent to
-            this address. After you send it and it reaches 2 confirmations, you will
-            be approved to submit proposals and comments.
+            When the transaction to the address above reaches 2 confirmations, you will have
+            access to participate on and submit proposals.
           </p>
           <PaywallStatus
             { ...{ userPaywallStatus, userPaywallConfirmations } }

--- a/src/components/Paywall/Page.js
+++ b/src/components/Paywall/Page.js
@@ -38,7 +38,7 @@ const Paywall = ({
           </p>
           <p className="paywall-paragraph highlight">
             To complete your registration please send exactly
-            <span className="paywall-amount">{paywallAmount} DCR</span>{" "}
+            <span className="paywall-amount"> {paywallAmount} DCR</span>{" "}
             to:
           </p>
           <AddressViewer paywallAddress={paywallAddress} />

--- a/src/components/Paywall/Page.js
+++ b/src/components/Paywall/Page.js
@@ -1,12 +1,11 @@
 import React from "react";
 import Message from "../Message";
-import QRCode from "../QRCode";
 import ButtonWithLoadingIcon from "../snew/ButtonWithLoadingIcon";
 import {
-  PAYWALL_STATUS_WAITING,
-  PAYWALL_STATUS_LACKING_CONFIRMATIONS,
   PAYWALL_STATUS_PAID
 } from "../../constants";
+import PaywallStatus from "./Status";
+import AddressViewer from "../AddressViewer";
 
 
 const Paywall = ({
@@ -20,16 +19,6 @@ const Paywall = ({
   payWithFaucetTxId,
   payWithFaucetError
 }) => {
-  let userPaywallStatusCls;
-  let userPaywallStatusText;
-
-  if (userPaywallStatus === PAYWALL_STATUS_WAITING) {
-    userPaywallStatusCls = "paywall-payment-status-waiting";
-    userPaywallStatusText = "Waiting for payment";
-  } else if (userPaywallStatus === PAYWALL_STATUS_LACKING_CONFIRMATIONS) {
-    userPaywallStatusCls = "paywall-payment-status-confirmations";
-    userPaywallStatusText = "Waiting for more confirmations";
-  }
 
   return userPaywallStatus === PAYWALL_STATUS_PAID ? (
     <Message
@@ -37,78 +26,73 @@ const Paywall = ({
       className="account-page-message"
       header="Payment received"
       body={(
-        <div className="paywall-wrapper">
-          <div className="paywall-content">
-            <p>Thank you for your payment, your registration is complete!</p>
-          </div>
-        </div>
+        <p>Thank you for your payment, your registration is complete!</p>
       )} />
   ) : (
-    <Message
-      type="error"
-      className="account-page-message"
-      header="Action needed"
-      body={(
-        <div className="paywall-wrapper">
-          <div className="paywall-content">
-            <p>
-              To complete your registration and to be able to submit proposals and comments,
-              please send exactly <span className="paywall-amount">{paywallAmount} DCR</span>{" "}
-              to <span className="paywall-address">{paywallAddress}</span>.
-            </p>
-            <p>
-              Politeia automatically checks for a transaction with this amount sent to
-              this address. After you send it and it reaches 2 confirmations, you will
-              be approved to submit proposals and comments.
-            </p>
-            <div className="paywall-payment-section">
-              <div className={"paywall-payment-status " + userPaywallStatusCls}>
-                Status: {userPaywallStatusText}
-                {userPaywallStatus === PAYWALL_STATUS_LACKING_CONFIRMATIONS &&
-                  <span>{` (${userPaywallConfirmations}/2)`}</span>
-                }
+    (
+      <div className="paywall-wrapper" style={{ padding: "10px" }}>
+        <div className="paywall-content">
+          <p className="paywall-paragraph">
+           To submit your own proposal, comment on a proposal, up/down vote comments on proposals,
+           or vote on a proposal, Politeia requires you to pay a small registration fee (0.1 DCR).
+           This is to prevent proposal spamming and to prevent users from creating multiple
+           “sock puppet” accounts to manipulate up/down voting on comments.
+          </p>
+          <p className="paywall-paragraph highlight">
+            To complete your registration and to be able to submit proposals and comments,
+            please send exactly <span className="paywall-amount">{paywallAmount} DCR</span>{" "}
+            to
+          </p>
+          <AddressViewer paywallAddress={paywallAddress} />
+          <p className="paywall-paragraph">
+            Politeia automatically checks for a transaction with this amount sent to
+            this address. After you send it and it reaches 2 confirmations, you will
+            be approved to submit proposals and comments.
+          </p>
+          <PaywallStatus
+            { ...{ userPaywallStatus, userPaywallConfirmations } }
+          />
+          <div className="paywall-payment-section">
+            {isTestnet ? (
+              <div className="paywall-faucet">
+                <div className="paywall-faucet-testnet">Testnet</div>
+                <p>
+                  This Politeia instance is running on Testnet, which means you can pay
+                  with the Decred faucet:
+                </p>
+                <ButtonWithLoadingIcon
+                  className="c-btn c-btn-primary"
+                  text="Pay with Faucet"
+                  disabled={userPaywallStatus === PAYWALL_STATUS_PAID}
+                  isLoading={isApiRequestingPayWithFaucet}
+                  onClick={() => payWithFaucet(paywallAddress, paywallAmount)} />
+                {payWithFaucetError ? (
+                  <Message
+                    type="error"
+                    header="Faucet error"
+                    body={payWithFaucetError} />
+                ) : null }
+                {payWithFaucetTxId ? (
+                  <Message
+                    type="info"
+                    header="Sent payment">
+                    Sent transaction{" "}
+                    <a
+                      className="paywall-payment-sent"
+                      href={"https://testnet.dcrdata.org/explorer/tx/" + payWithFaucetTxId}
+                      target="_blank">
+                      {payWithFaucetTxId}
+                    </a>{" "}
+                    to the address; it may take a few minutes to be confirmed.
+                  </Message>
+                ) : null}
               </div>
-              {isTestnet ? (
-                <div className="paywall-faucet">
-                  <div className="paywall-faucet-testnet">Testnet</div>
-                  <p>
-                    This Politeia instance is running on Testnet, which means you can pay
-                    with the Decred faucet:
-                  </p>
-                  <ButtonWithLoadingIcon
-                    className="c-btn c-btn-primary"
-                    text="Pay with Faucet"
-                    disabled={userPaywallStatus === PAYWALL_STATUS_PAID}
-                    isLoading={isApiRequestingPayWithFaucet}
-                    onClick={() => payWithFaucet(paywallAddress, paywallAmount)} />
-                  {payWithFaucetError ? (
-                    <Message
-                      type="error"
-                      header="Faucet error"
-                      body={payWithFaucetError} />
-                  ) : null }
-                  {payWithFaucetTxId ? (
-                    <Message
-                      type="info"
-                      header="Sent payment">
-                      Sent transaction{" "}
-                      <a
-                        className="paywall-payment-sent"
-                        href={"https://testnet.dcrdata.org/explorer/tx/" + payWithFaucetTxId}
-                        target="_blank">
-                        {payWithFaucetTxId}
-                      </a>{" "}
-                      to the address; it may take a few minutes to be confirmed.
-                    </Message>
-                  ) : null}
-                </div>
-              ) : null}
-            </div>
-            <QRCode addr={paywallAddress} />
-            <div style={{ clear: "both" }}></div>
+            ) : null}
           </div>
+          <div style={{ clear: "both" }}></div>
         </div>
-      )} />
+      </div>
+    )
   );
 };
 

--- a/src/components/Paywall/Page.js
+++ b/src/components/Paywall/Page.js
@@ -34,7 +34,7 @@ const Paywall = ({
         <div className="paywall-content">
           <p className="paywall-paragraph">
            To submit your own proposal, comment on a proposal, up/down vote comments on proposals,
-           or vote on a proposal, Politeia requires you to pay a small registration fee (0.1 DCR).
+           or vote on a proposal, Politeia requires you to pay a small registration fee ({paywallAmount} DCR).
            This is to prevent proposal spamming and to prevent users from creating multiple
            “sock puppet” accounts to manipulate up/down voting on comments.
           </p>

--- a/src/components/Paywall/PaywallAlert.js
+++ b/src/components/Paywall/PaywallAlert.js
@@ -9,9 +9,10 @@ import { PAYWALL_MODAL } from "../Modal/modalTypes";
 
 const PaywallAlert = ({
   userPaywallStatus,
-  openModal
+  openModal,
+  loggedInAsEmail
 }) => {
-  return (
+  return !loggedInAsEmail ? null : (
     userPaywallStatus === PAYWALL_STATUS_PAID ?
       null :
       <React.Fragment>
@@ -32,9 +33,10 @@ const PaywallAlert = ({
           /> :
           <Message
             type="info"
-            header="Complete your registration"
+            header="Registration payment detected"
             body={<div>
-              Your payment was detected and its waiting the required amount of confirmations.
+              Your payment was detected and your registration will be complete once it
+              reaches the required amount of confirmations.
               <br />
               <span
                 className="linkish"

--- a/src/components/Paywall/PaywallAlert.js
+++ b/src/components/Paywall/PaywallAlert.js
@@ -1,0 +1,52 @@
+import React from "react";
+import Message from "../Message";
+import paywallConnector from "../../connectors/paywall";
+import actionsConnector from "../../connectors/actions";
+import {
+  PAYWALL_STATUS_PAID, PAYWALL_STATUS_WAITING
+} from "../../constants";
+import { PAYWALL_MODAL } from "../Modal/modalTypes";
+
+const PaywallAlert = ({
+  userPaywallStatus,
+  openModal
+}) => {
+  return (
+    userPaywallStatus === PAYWALL_STATUS_PAID ?
+      null :
+      <React.Fragment>
+        {userPaywallStatus === PAYWALL_STATUS_WAITING ?
+          <Message
+            type="info"
+            header="Complete your registration"
+            body={<div>
+              <span
+                className="linkish"
+                onClick={() => openModal(PAYWALL_MODAL)}
+              >
+              Pay the registration fee and complete your registration.
+              </span>
+              <br />
+            You won't be able to submit comments or proposals before that.
+            </div>}
+          /> :
+          <Message
+            type="info"
+            header="Complete your registration"
+            body={<div>
+              Your payment was detected and its waiting the required amount of confirmations.
+              <br />
+              <span
+                className="linkish"
+                onClick={() => openModal(PAYWALL_MODAL)}
+              >
+              Check the payment status.
+              </span>
+            </div>}
+          />
+        }
+      </React.Fragment>
+  );
+};
+
+export default actionsConnector(paywallConnector(PaywallAlert));

--- a/src/components/Paywall/Status.js
+++ b/src/components/Paywall/Status.js
@@ -1,0 +1,21 @@
+import React from "react";
+import { mapPaywallStatusToText, mapPaywallStatusToClassName } from "./helpers";
+import { PAYWALL_STATUS_LACKING_CONFIRMATIONS } from "../../constants";
+
+const PaywallStatus = ({
+  userPaywallStatus,
+  userPaywallConfirmations
+}) => {
+  const className = mapPaywallStatusToClassName[userPaywallStatus];
+  const text = mapPaywallStatusToText[userPaywallStatus];
+  return (
+    <div className={"paywall-payment-status " + className}>
+      Status: {text}
+      {userPaywallStatus === PAYWALL_STATUS_LACKING_CONFIRMATIONS &&
+        <span>{` (${userPaywallConfirmations}/2)`}</span>
+      }
+    </div>
+  );
+};
+
+export default PaywallStatus;

--- a/src/components/Paywall/helpers.js
+++ b/src/components/Paywall/helpers.js
@@ -1,0 +1,14 @@
+import {
+  PAYWALL_STATUS_WAITING,
+  PAYWALL_STATUS_LACKING_CONFIRMATIONS
+} from "../../constants";
+
+export const mapPaywallStatusToText = {
+  [PAYWALL_STATUS_WAITING]: "Waiting for payment",
+  [PAYWALL_STATUS_LACKING_CONFIRMATIONS]: "Waiting for more confirmations"
+};
+
+export const mapPaywallStatusToClassName = {
+  [PAYWALL_STATUS_WAITING]: "paywall-payment-status-waiting",
+  [PAYWALL_STATUS_LACKING_CONFIRMATIONS]: "paywall-payment-status-confirmations"
+};

--- a/src/components/SidebarText.js
+++ b/src/components/SidebarText.js
@@ -2,6 +2,7 @@ import React from "react";
 import Markdown from "./snew/Markdown";
 import modalConnector from "../connectors/modal";
 import { ONBOARD } from "./Modal/modalTypes";
+import PaywallAlert from  "./Paywall/PaywallAlert";
 
 const aboutText = `
 # About Politeia
@@ -33,6 +34,7 @@ const resourcesText = `
 
 const SidebarText = (props) => (
   <div style={{ display: "flex", flexDirection: "column" }}>
+    <PaywallAlert />
     <Markdown body={aboutText} filterXss={false} {...props} />
     <span
       style={{ cursor: "pointer", color: "#2971FF" }}

--- a/src/connectors/actions.js
+++ b/src/connectors/actions.js
@@ -24,7 +24,8 @@ const actions = connect(
     onChangeStatus: act.onSubmitStatusProposal,
     onDeleteDraftProposal: act.onDeleteDraftProposal,
     onStartVote: act.onStartVote,
-    onAuthorizeVote: act.onAuthorizeVote
+    onAuthorizeVote: act.onAuthorizeVote,
+    openModal: act.openModal
   }
 );
 

--- a/src/connectors/loader.js
+++ b/src/connectors/loader.js
@@ -7,6 +7,7 @@ export default connect(
   sel.selectorMap({
     userPubkey: sel.userPubkey,
     loggedInAsEmail: sel.loggedInAsEmail,
+    keyMismatch: sel.getKeyMismatch,
     apiError: sel.apiError,
     userCanExecuteActions: sel.userCanExecuteActions,
     lastLoginTime: sel.lastLoginTimeFromLoginResponse,

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -93,7 +93,7 @@ export const userHasPaid = state => {
   return getUserPaywallStatus(state) === PAYWALL_STATUS_PAID;
 };
 export const userCanExecuteActions = state => {
-  return !getKeyMismatch(state);
+  return userHasPaid(state) && !getKeyMismatch(state);
 };
 
 export const isProposalStatusApproved = state => state.app.isProposalStatusApproved;

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -93,7 +93,7 @@ export const userHasPaid = state => {
   return getUserPaywallStatus(state) === PAYWALL_STATUS_PAID;
 };
 export const userCanExecuteActions = state => {
-  return userHasPaid(state) && !getKeyMismatch(state);
+  return !getKeyMismatch(state);
 };
 
 export const isProposalStatusApproved = state => state.app.isProposalStatusApproved;

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -915,10 +915,6 @@ li p.header-3 {
   color: #41bf53;
 }
 
-.paywall-paragraph {
-  text-align: justify;
-}
-
 .proposal-credits-input {
   height: 36px;
   width: 64px;
@@ -963,6 +959,8 @@ li p.header-3 {
 
 .paywall-content > p {
   margin-bottom: 5px;
+  text-align: left;
+  width: 100%;
 }
 
 .paywall-payment-sent {

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -870,7 +870,18 @@ li p.header-3 {
 }
 
 .paywall-payment-section {
-  float: left;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.paywall-content {
+  padding: 20px;
+}
+
+.paywall-content .highlight {
+  font-weight: bold;
+  color: #0079d3;
 }
 
 .paywall-faucet {
@@ -904,6 +915,10 @@ li p.header-3 {
   color: #41bf53;
 }
 
+.paywall-paragraph {
+  text-align: justify;
+}
+
 .proposal-credits-input {
   height: 36px;
   width: 64px;
@@ -912,9 +927,42 @@ li p.header-3 {
   text-align: center;
 }
 
-.paywall-address,
+.address-viewer {
+  padding: 4px 8px 8px 8px;
+  border: 1px solid #777;
+  border-radius: 8px;
+  background: #d6d6d6;
+  margin-right: 20px;
+}
+
+.address-viewer_menu {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.address-viewer_menu_option { 
+  margin-right: 5px;
+  margin-bottom: 4px;
+  cursor: pointer;
+}
+
+.address-viewer_menu_option:hover {
+  color: #0079d3;
+}
+
+.address-viewer_text,
 .paywall-amount {
   font-weight: bold;
+}
+
+.paywall-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.paywall-content > p {
+  margin-bottom: 5px;
 }
 
 .paywall-payment-sent {
@@ -1294,4 +1342,9 @@ form div.usertext-body.may-blank-within.md-container {
 .readMore {
 	clear: both;
 	cursor: pointer;
+}
+
+.linkish {
+  color: #2971FF;
+  cursor: pointer;
 }


### PR DESCRIPTION
closes #585

Preview:
- Before submitting the payment:

<img width="1256" alt="screen shot 2018-09-18 at 10 46 23 am" src="https://user-images.githubusercontent.com/14864439/45695727-6ad97900-bb38-11e8-972e-79663e400277.png">

<img width="1269" alt="screen shot 2018-09-18 at 10 46 32 am" src="https://user-images.githubusercontent.com/14864439/45695781-8775b100-bb38-11e8-80ba-8afc4809a615.png">

- After the payment is submitted:

<img width="1264" alt="screen shot 2018-09-18 at 10 50 28 am" src="https://user-images.githubusercontent.com/14864439/45695804-9492a000-bb38-11e8-8ec0-4f8e6ead3ea6.png">



