### PR TITLE
Adjustments to prevent XSS attacks in the Markdown component

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "lint-staged": "^6.1.0",
     "nightwatch": "^0.9.16",
     "pem": "^1.12.0",
+    "react-test-renderer": "^16.5.2",
     "redux-actions-assertions": "^1.3.0",
     "redux-devtools-extension": "^2.13.2",
     "redux-mock-store": "^1.5.1",

--- a/src/components/SidebarText.js
+++ b/src/components/SidebarText.js
@@ -35,12 +35,12 @@ const resourcesText = `
 const SidebarText = (props) => (
   <div style={{ display: "flex", flexDirection: "column" }}>
     <PaywallAlert />
-    <Markdown body={aboutText} filterXss={false} {...props} />
+    <Markdown body={aboutText} filterXss={false} confirmWithModal={null} displayExternalLikWarning={false} {...props} />
     <span
       style={{ cursor: "pointer", color: "#2971FF" }}
       onClick={(e) => { e.preventDefault(); props.openModal(ONBOARD); }}
     >Learn More about Politiea</span>
-    <Markdown body={resourcesText} filterXss={false} {...props} />
+    <Markdown body={resourcesText} filterXss={false} displayExternalLikWarning={false} {...props} />
   </div>
 );
 export default modalConnector(SidebarText);

--- a/src/components/snew/Markdown/Markdown.js
+++ b/src/components/snew/Markdown/Markdown.js
@@ -3,11 +3,17 @@ import ReactMarkdown from "react-markdown";
 import { customRenderers } from "./helpers";
 import modalConnector from "../../../connectors/modal";
 
-const MarkdownRenderer = ({ body, className, confirmWithModal, filterXss = true }) => (
+const MarkdownRenderer = ({
+  body,
+  className,
+  confirmWithModal,
+  filterXss = true,
+  displayExternalLikWarning = true
+}) => (
   <div className={className}>
     <ReactMarkdown
       className="md"
-      renderers={customRenderers(filterXss, confirmWithModal)}
+      renderers={customRenderers(filterXss, displayExternalLikWarning && confirmWithModal)}
       source={body}
     />
   </div>

--- a/src/components/snew/Markdown/helpers.js
+++ b/src/components/snew/Markdown/helpers.js
@@ -83,10 +83,20 @@ const verifyExternalLink = (e, link, confirmWithModal) => {
 
 export const customRenderers = (filterXss, confirmWithModal) => ({
   image: ({ src, alt }) => {
-    return <a rel="nofollow" onClick={(e) => confirmWithModal && verifyExternalLink(e, src, confirmWithModal)} href={src}>{alt}</a>;
+    return <a
+      target="_blank"
+      rel="nofollow"
+      onClick={(e) => confirmWithModal && verifyExternalLink(e, src, confirmWithModal)}
+      href={src}>{alt}
+    </a>;
   },
   link: ({ href, children }) => {
-    return <a rel="nofollow" onClick={(e) => confirmWithModal && verifyExternalLink(e, href, confirmWithModal)} href={href}>{children[0]}</a>;
+    return <a
+      target="_blank"
+      rel="nofollow"
+      onClick={(e) => confirmWithModal && verifyExternalLink(e, href, confirmWithModal)}
+      href={href}
+    >{children[0]}</a>;
   },
   root: (el) => {
     if(filterXss) {

--- a/src/components/snew/Markdown/helpers.js
+++ b/src/components/snew/Markdown/helpers.js
@@ -13,9 +13,14 @@ export const traverseChildren = (el, cb) => {
       children: filterChildren(el.children)
     };
   } else if (el.props && el.props.children) {
+    const filteredChildren = filterChildren(el.props.children);
     newElement = {
       ...el,
-      children: filterChildren(el.props.children)
+      props: {
+        ...el.props,
+        children: filteredChildren
+      },
+      children: filterChildren
     };
   }
   return newElement ? cb(newElement) : cb(el);
@@ -78,10 +83,10 @@ const verifyExternalLink = (e, link, confirmWithModal) => {
 
 export const customRenderers = (filterXss, confirmWithModal) => ({
   image: ({ src, alt }) => {
-    return <a rel="nofollow" onClick={(e) => verifyExternalLink(e, src, confirmWithModal)} href={src}>{alt}</a>;
+    return <a rel="nofollow" onClick={(e) => confirmWithModal && verifyExternalLink(e, src, confirmWithModal)} href={src}>{alt}</a>;
   },
   link: ({ href, children }) => {
-    return <a rel="nofollow" onClick={(e) => verifyExternalLink(e, href, confirmWithModal)} href={href}>{children[0]}</a>;
+    return <a rel="nofollow" onClick={(e) => confirmWithModal && verifyExternalLink(e, href, confirmWithModal)} href={href}>{children[0]}</a>;
   },
   root: (el) => {
     if(filterXss) {

--- a/src/components/snew/Markdown/helpers.js
+++ b/src/components/snew/Markdown/helpers.js
@@ -19,8 +19,7 @@ export const traverseChildren = (el, cb) => {
       props: {
         ...el.props,
         children: filteredChildren
-      },
-      children: filteredChildren
+      }
     };
   }
   return newElement ? cb(newElement) : cb(el);

--- a/src/components/snew/Markdown/helpers.js
+++ b/src/components/snew/Markdown/helpers.js
@@ -20,7 +20,7 @@ export const traverseChildren = (el, cb) => {
         ...el.props,
         children: filteredChildren
       },
-      children: filterChildren
+      children: filteredChildren
     };
   }
   return newElement ? cb(newElement) : cb(el);

--- a/src/components/snew/Markdown/helpers.js
+++ b/src/components/snew/Markdown/helpers.js
@@ -49,7 +49,7 @@ const verifyExternalLink = (e, link, confirmWithModal) => {
   e.preventDefault();
   const tmpLink = document.createElement("a");
   tmpLink.href = link;
-  const externalLink = (tmpLink.hostname !== window.top.location.hostname);
+  const externalLink = (tmpLink.hostname && tmpLink.hostname !== window.top.location.hostname);
   // if this is an external link, show confirmation dialog
   if (externalLink) {
     confirmWithModal(modalTypes.CONFIRM_ACTION, {
@@ -72,11 +72,13 @@ const verifyExternalLink = (e, link, confirmWithModal) => {
       )
     }).then(confirm => {
       if (confirm) {
-        window.location.href = link;
+        window.open(link, "_newtab");
       }
     });
-  } else {
+  } else if(tmpLink.hostname) {
     window.location.href = link;
+  } else {
+    console.log("Blocked potentially malicious link: ", link);
   }
 };
 

--- a/src/components/snew/Markdown/test/Markdown.test.js
+++ b/src/components/snew/Markdown/test/Markdown.test.js
@@ -1,0 +1,16 @@
+import React from "react";
+import ReactMarkdown from "react-markdown";
+import renderer from "react-test-renderer";
+import { customRenderers } from "../helpers";
+
+const maliciousBodyText = "![clickforxss](javascript:alert('XSS'))  [clickforxss](javascript:alert('XSS'))";
+
+it("filter potencial 'XSS' attackers", () => {
+  const tree = renderer.create(
+    <ReactMarkdown
+      source={maliciousBodyText}
+      renderers={customRenderers(true)}
+    />
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/components/snew/Markdown/test/__snapshots__/Markdown.test.js.snap
+++ b/src/components/snew/Markdown/test/__snapshots__/Markdown.test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`filter potencial 'XSS' attackers 1`] = `
+<div>
+  <p>
+    <a
+      href="x-javascript:alert('XSS')"
+      onClick={[Function]}
+      rel="nofollow"
+    >
+      clickforxss
+    </a>
+      
+    <a
+      href="javascript:void(0)"
+      onClick={[Function]}
+      rel="nofollow"
+    >
+      clickforxss
+    </a>
+  </p>
+</div>
+`;

--- a/src/components/snew/Markdown/test/__snapshots__/Markdown.test.js.snap
+++ b/src/components/snew/Markdown/test/__snapshots__/Markdown.test.js.snap
@@ -7,6 +7,7 @@ exports[`filter potencial 'XSS' attackers 1`] = `
       href="x-javascript:alert('XSS')"
       onClick={[Function]}
       rel="nofollow"
+      target="_blank"
     >
       clickforxss
     </a>
@@ -15,6 +16,7 @@ exports[`filter potencial 'XSS' attackers 1`] = `
       href="javascript:void(0)"
       onClick={[Function]}
       rel="nofollow"
+      target="_blank"
     >
       clickforxss
     </a>

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -551,7 +551,7 @@ button .logo {
   width: 100%;
   margin-top: 0px !important;
   height: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .react-mde-dropdown {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7481,6 +7481,10 @@ react-input-autosize@^2.2.1:
   dependencies:
     prop-types "^15.5.8"
 
+react-is@^16.5.2:
+  version "16.5.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.5.2.tgz#e2a7b7c3f5d48062eb769fcb123505eb928722e3"
+
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
@@ -7587,6 +7591,15 @@ react-select@^2.0.0:
     raf "^3.4.0"
     react-input-autosize "^2.2.1"
     react-transition-group "^2.2.1"
+
+react-test-renderer@^16.5.2:
+  version "16.5.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.5.2.tgz#92e9d2c6f763b9821b2e0b22f994ee675068b5ae"
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    react-is "^16.5.2"
+    schedule "^0.5.0"
 
 react-transition-group@^2.2.1:
   version "2.4.0"
@@ -8125,6 +8138,12 @@ sax@>=0.6.0, sax@^1.2.1, sax@^1.2.4, sax@~1.2.1:
 schedule@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/schedule/-/schedule-0.3.0.tgz#1be2ab2fc2e768536269ce7326efb478d6c045e8"
+  dependencies:
+    object-assign "^4.1.1"
+
+schedule@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/schedule/-/schedule-0.5.0.tgz#c128fffa0b402488b08b55ae74bb9df55cc29cc8"
   dependencies:
     object-assign "^4.1.1"
 


### PR DESCRIPTION
closes #620 

This PR covers a missing corner case for the "XSS filtering" on markdowns. It also:
- Disable the "external link" warning for the link on the right sidebar text.
- Add snapshot testing for the markdown rendered. Making sure potential attackers are correctly neutralized. It is also helpful for testing other "custom rendering" situations which may be needed in the future.