### PR TITLE
Proposal created info box has a couple of extraneous words #632

### DIFF
--- a/src/components/snew/ThingLink.js
+++ b/src/components/snew/ThingLink.js
@@ -226,7 +226,6 @@ const ThingLinkComp = ({
                   to prove that your submission has been accepted for review by
                   Politeia. If your proposal is censored by an admin, you won't be
                   able to access it's contents.
-                  and use
 
                 </p>
               </span>


### PR DESCRIPTION
Removed the random "and use" after the paragraph in the proposal created info box. It seems to be a random copy from within the paragraph.