### PR TITLE
Multiple enhancements on proposal's list

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -439,7 +439,7 @@ export const onVerifyUserKey = (loggedInAsEmail, verificationtoken) =>
       });
   });
 
-export const onSubmitStatusProposal = (loggedInAsEmail, token, status, censorMessage = "") =>
+export const onSubmitStatusProposal = (authorid, loggedInAsEmail, token, status, censorMessage = "") =>
   withCsrf((dispatch, getState, csrf) => {
     dispatch(act.REQUEST_SETSTATUS_PROPOSAL({ status, token }));
     if (status === 4) {
@@ -448,8 +448,13 @@ export const onSubmitStatusProposal = (loggedInAsEmail, token, status, censorMes
 
     return api
       .proposalSetStatus(loggedInAsEmail, csrf, token, status, censorMessage)
-      .then(response => {
-        dispatch(act.RECEIVE_SETSTATUS_PROPOSAL(response));
+      .then(({ proposal }) => {
+        dispatch(act.RECEIVE_SETSTATUS_PROPOSAL({
+          proposal: {
+            ...proposal,
+            userid: authorid
+          }
+        }));
         dispatch(onFetchUnvettedStatus());
       })
       .catch(error => {

--- a/src/components/UserDetail/ProposalsTab.js
+++ b/src/components/UserDetail/ProposalsTab.js
@@ -1,29 +1,28 @@
 import React from "react";
 import userConnector from "../../connectors/user";
 import { Content as ProposalListing } from "../../components/snew";
-import { removeProposalsDuplicates } from "../../helpers";
 
 const ProposalsTab = ({
   user,
   loggedInAsEmail,
   isAdmin,
   onFetchUserProposals,
-  loggedInAsUserId,
-  userProposals,
   count,
   lastLoadedProposal,
-  lastLoadedUserDetailProposal
+  lastLoadedUserDetailProposal,
+  getSubmittedUserProposals,
+  isLoadingProposals
 }) => {
-  const proposals = removeProposalsDuplicates(user.proposals, userProposals);
   return (
     <div className="detail-proposals">
       <ProposalListing
+        isLoading={isLoadingProposals}
         loggedInAsEmail={loggedInAsEmail}
         isAdmin={isAdmin}
         count={count}
-        userid={loggedInAsUserId}
+        userid={user.id}
         lastLoadedProposal={lastLoadedProposal && Object.keys(lastLoadedProposal).length > 0 ? lastLoadedProposal : lastLoadedUserDetailProposal}
-        proposals={proposals}
+        proposals={getSubmittedUserProposals(user.id)}
         onFetchUserProposals={onFetchUserProposals}
         emptyProposalsMessage={"This user has not submitted any proposals"} />
     </div>

--- a/src/components/UserDetail/index.js
+++ b/src/components/UserDetail/index.js
@@ -15,6 +15,7 @@ class UserDetail extends Component {
 
   componentDidMount() {
     this.props.onFetchData(this.props.userId);
+    this.props.onFetchProposalsVoteStatus();
   }
 
   componentDidUpdate() {

--- a/src/components/snew/Content.js
+++ b/src/components/snew/Content.js
@@ -123,9 +123,9 @@ class Loader extends Component {
       return;
     else if (csrf) {
       this.setState({ isFetched: true });
-      this.props.onFetchProposalsVoteStatus && this.props.onFetchProposalsVoteStatus();
       this.props.onFetchData && this.props.onFetchData();
       this.props.onFetchStatus && this.props.onFetchStatus();
+      this.props.onFetchProposalsVoteStatus && this.props.onFetchProposalsVoteStatus();
     }
   }
 

--- a/src/components/snew/ThingLink.js
+++ b/src/components/snew/ThingLink.js
@@ -285,6 +285,7 @@ const ThingLinkComp = ({
                     reasonPlaceholder: "Please provide a reason to censor this proposal"
                   }).then(
                     ({ reason, confirm }) => confirm && onChangeStatus(
+                      authorid,
                       loggedInAsEmail,
                       id,
                       PROPOSAL_STATUS_CENSORED,
@@ -305,6 +306,7 @@ const ThingLinkComp = ({
                     }).then(
                       confirm => confirm &&
                         onChangeStatus(
+                          authorid,
                           loggedInAsEmail,
                           id,
                           PROPOSAL_STATUS_PUBLIC

--- a/src/components/snew/ThingLink.js
+++ b/src/components/snew/ThingLink.js
@@ -71,7 +71,8 @@ const ThingLinkComp = ({
   authorizeVoteError,
   isRequestingStartVote,
   startVoteToken,
-  startVoteError
+  startVoteError,
+  isApiRequestingSetProposalStatusByToken
 }) => {
   const voteStatus = getVoteStatus(id) && getVoteStatus(id).status;
   const isUnvetted = review_status === PROPOSAL_STATUS_UNREVIEWED || review_status === PROPOSAL_STATUS_UNREVIEWED_CHANGES;
@@ -101,6 +102,10 @@ const ThingLinkComp = ({
   // loading flags
   const loadingStartVote = isRequestingStartVote && startVoteToken === id;
   const loadingAuthorizeVote = isRequestingAuthorizeVote && authorizeVoteToken === id;
+
+  const status = isApiRequestingSetProposalStatusByToken(id);
+  const loadingCensor = status && status === PROPOSAL_STATUS_CENSORED;
+  const loadingApprove = status && status === PROPOSAL_STATUS_PUBLIC;
 
   return (
     <div
@@ -274,9 +279,9 @@ const ThingLinkComp = ({
           {enableAdminActionsForUnvetted ?
             [
               <li key="spam">
-                <form
-                  className="toggle remove-button"
-                  onSubmit={e => confirmWithModal(modalTypes.CONFIRM_ACTION_WITH_REASON, {
+                <ButtonWithLoadingIcon
+                  className={`c-btn c-btn-primary${!userCanExecuteActions ? " not-active disabled" : ""}`}
+                  onClick={e => confirmWithModal(modalTypes.CONFIRM_ACTION_WITH_REASON, {
                     reasonPlaceholder: "Please provide a reason to censor this proposal"
                   }).then(
                     ({ reason, confirm }) => confirm && onChangeStatus(
@@ -286,20 +291,15 @@ const ThingLinkComp = ({
                       reason
                     )
                   ) && e.preventDefault()}
-                >
-                  <button
-                    className={`togglebutton access-required${!userCanExecuteActions ? " not-active disabled" : ""}`}
-                    data-event-action="spam"
-                    type="submit"
-                  >
-                    spam
-                  </button>
-                </form>
+                  text="Spam"
+                  data-event-action="spam"
+                  isLoading={loadingCensor}
+                />
               </li>,
               <li key="approve">
-                <form
-                  className="toggle approve-button"
-                  onSubmit={e =>
+                <ButtonWithLoadingIcon
+                  className={`c-btn c-btn-primary${!userCanExecuteActions ? " not-active disabled" : ""}`}
+                  onClick={e =>
                     confirmWithModal(modalTypes.CONFIRM_ACTION, {
                       message: "Are you sure you want to publish this proposal?"
                     }).then(
@@ -311,16 +311,10 @@ const ThingLinkComp = ({
                         )
                     ) && e.preventDefault()
                   }
-                >
-                  <button
-                    className={`togglebutton access-required${!userCanExecuteActions ? " not-active disabled" : ""}`}
-                    data-event-action="approve"
-                    type="submit"
-                    disabled={!userCanExecuteActions}
-                  >
-                    approve
-                  </button>
-                </form>
+                  text="approve"
+                  data-event-action="approve"
+                  isLoading={loadingApprove}
+                />
               </li>
             ] : null
           }
@@ -401,19 +395,6 @@ const ThingLinkComp = ({
   );
 };
 
-export const Comp = actions(ThingLinkComp);
-
-class ThingLink extends React.Component {
-
-  componentDidMount() {
-    const { isProposalStatusApproved, history } = this.props;
-    if (isProposalStatusApproved)
-      history.push("/");
-  }
-
-  render() {
-    return <Comp {...this.props} />;
-  }
-}
+export const ThingLink = actions(ThingLinkComp);
 
 export default thingLinkConnector(withRouter(ThingLink));

--- a/src/connectors/actions.js
+++ b/src/connectors/actions.js
@@ -18,6 +18,7 @@ const actions = connect(
     isRequestingAuthorizeVote: sel.isApiRequestingAuthorizeVote,
     startVoteToken: sel.apiStartVoteToken,
     isRequestingStartVote: sel.isApiRequestingStartVote,
+    isApiRequestingSetProposalStatusByToken: sel.isApiRequestingSetProposalStatusByToken,
     startVoteError: sel.apiStartVoteError
   }),
   {

--- a/src/connectors/admin.js
+++ b/src/connectors/admin.js
@@ -9,7 +9,7 @@ export default connect(
     proposals: sel.getUnvettedFilteredProposals,
     proposalCounts: sel.getUnvettedProposalFilterCounts,
     error: sel.unvettedProposalsError,
-    isLoading: or(sel.unvettedProposalsIsRequesting, sel.setStatusProposalIsRequesting),
+    isLoading: or(sel.unvettedProposalsIsRequesting),
     filterValue: sel.getAdminFilterValue,
     header: () => LIST_HEADER_UNVETTED,
     emptyProposalsMessage: sel.getUnvettedEmptyProposalsMessage,

--- a/src/connectors/user.js
+++ b/src/connectors/user.js
@@ -23,12 +23,14 @@ export default connect(
     user: sel.user,
     error: sel.apiUserError,
     isLoading: or(sel.isApiRequestingUser, sel.isApiRequestingMe),
+    isLoadingProposals: or(sel.userProposalsIsRequesting, sel.isApiRequestingPropsVoteStatus),
     isTestnet: sel.isTestNet,
     loggedInAsEmail: sel.loggedInAsEmail,
     userProposals: sel.getUserProposals,
     isAdmin: sel.isAdmin,
     lastLoadedUserDetailProposal: sel.lastLoadedUserDetailProposal,
     lastLoadedProposal: sel.lastLoadedUserProposal,
+    getSubmittedUserProposals: sel.getSubmittedUserProposals,
     isApiRequestingMarkAsPaid: state => (
       sel.isApiRequestingEditUser(state) && sel.editUserAction(state) === EDIT_USER_CLEAR_USER_PAYWALL
     ),
@@ -48,6 +50,7 @@ export default connect(
   }),
   dispatch => bindActionCreators({
     onFetchUserProposals: act.onFetchUserProposals,
+    onFetchProposalsVoteStatus: act.onFetchProposalsVoteStatus,
     onFetchData: act.onFetchUser,
     onEditUser: act.onEditUser
   }, dispatch)

--- a/src/connectors/userProposals.js
+++ b/src/connectors/userProposals.js
@@ -3,6 +3,7 @@ import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import * as sel from "../selectors";
 import * as act from "../actions";
+import { or } from "../lib/fp";
 import { LIST_HEADER_USER, PROPOSAL_USER_FILTER_SUBMITTED, PROPOSAL_USER_FILTER_DRAFT } from "../constants";
 
 const userProposalsConnector = connect(
@@ -11,7 +12,7 @@ const userProposalsConnector = connect(
     loggedInAsEmail: sel.loggedInAsEmail,
     isAdmin: sel.isAdmin,
     error: sel.userProposalsError,
-    isLoading: sel.userProposalsIsRequesting,
+    isLoading: or(sel.userProposalsIsRequesting, sel.isApiRequestingPropsVoteStatus),
     proposals: sel.getUserProposals,
     proposalCounts: sel.getUserProposalFilterCounts,
     filterValue: sel.getUserFilterValue,
@@ -23,7 +24,8 @@ const userProposalsConnector = connect(
     bindActionCreators(
       {
         onFetchUserProposals: act.onFetchUserProposals,
-        onChangeFilter: act.onChangeUserFilter
+        onChangeFilter: act.onChangeUserFilter,
+        onFetchProposalsVoteStatus: act.onFetchProposalsVoteStatus
       },
       dispatch
     )

--- a/src/reducers/tests/api.test.js
+++ b/src/reducers/tests/api.test.js
@@ -89,7 +89,8 @@ describe("test api reducer", () => {
         ]
       }
     },
-    vetted: DEFAULT_REQUEST_STATE
+    vetted: DEFAULT_REQUEST_STATE,
+    userProposals: DEFAULT_REQUEST_STATE
   };
 
   const MOCK_PROPOSALS_LOAD = [

--- a/src/selectors/api.js
+++ b/src/selectors/api.js
@@ -93,6 +93,9 @@ export const apiStartVoteError = getApiError("startVote");
 export const isApiRequestingStartVote = getIsApiRequesting("startVote");
 export const apiStartVoteToken = compose(get("token"), apiStartVotePayload);
 
+export const isApiRequestingSetProposalStatusByToken = state => token => {
+  return setStatusProposalIsRequesting(state) && setStatusProposalToken(state) === token && setStatusProposalStatus(state);
+};
 
 const apiProposalPaywallDetailsResponse = getApiResponse("proposalPaywallDetails");
 export const proposalPaywallAddress = compose(get("paywalladdress"), apiProposalPaywallDetailsResponse);
@@ -255,17 +258,23 @@ export const getPropVoteStatus = state => token => {
 export const userid = state => state.api.me.response && state.api.me.response.userid;
 export const censoredComment = state => state.api.censorComment.response;
 
-const lastLoaded = (func, state) => func(state) ? func(state).lastloaded : {};
+// const lastLoaded = (func, state) => func(state) ? func(state).lastloaded : {};
+// export const lastLoadedUnvettedProposal = state => lastLoaded(apiUnvettedResponse, state);
+// export const lastLoadedVettedProposal = state => lastLoaded(apiVettedResponse, state);
+// export const lastLoadedUserProposal = state => lastLoaded(apiUserProposalsResponse, state);
 
-export const lastLoadedUnvettedProposal = state => lastLoaded(apiUnvettedResponse, state);
-export const lastLoadedVettedProposal = state => lastLoaded(apiVettedResponse, state);
-export const lastLoadedUserProposal = state => lastLoaded(apiUserProposalsResponse, state);
+export const getApiLastLoaded = key => get([ "api", "lastLoaded", key ]);
 
-export const lastLoadedUserDetailProposal = state => {
-  const vp = user(state) ? user(state).proposals : [];
-  const last = Object.keys(vp).length - 1;
-  return last > -1 ? vp[last] : {};
-};
+export const lastLoadedUnvettedProposal = getApiLastLoaded("unvetted");
+export const lastLoadedVettedProposal = getApiLastLoaded("vetted");
+export const lastLoadedUserProposal = getApiLastLoaded("userProposals");
+export const lastLoadedUserDetailProposal = getApiLastLoaded("user");
+
+// export const lastLoadedUserDetailProposal = state => {
+//   const vp = user(state) ? user(state).proposals : [];
+//   const last = Object.keys(vp).length - 1;
+//   return last > -1 ? vp[last] : {};
+// };
 
 export const serverPubkey = compose(get("pubkey"), apiInitResponse);
 export const userPubkey = compose(get("publickey"), apiMeResponse);
@@ -275,8 +284,8 @@ export const isLoadingSubmit = or(isApiRequestingPolicy, isApiRequestingInit);
 export const apiVettedProposals = or(compose(get("proposals"), apiVettedResponse), constant([]));
 export const vettedProposalsIsRequesting = isApiRequestingVetted;
 export const vettedProposalsError = or(apiInitError, apiVettedError);
-export const apiUserProposals = or(compose(get("proposals"), apiUserProposalsResponse), constant(null));
 export const numOfUserProposals = or(compose(get("numofproposals"), apiUserProposalsResponse), constant(0));
+export const apiUserProposals = or(compose(get("proposals"), apiUserProposalsResponse), constant([]));
 export const userProposalsIsRequesting = isApiRequestingUserProposals;
 export const userProposalsError = or(apiInitError, apiUserProposalsError);
 export const apiUnvettedProposals = or(compose(get("proposals"), apiUnvettedResponse), constant([]));
@@ -304,6 +313,7 @@ export const newProposalFiles = compose(get("files"), apiNewProposalPayload);
 export const setStatusProposal = compose(get("status"), apiSetStatusProposalResponse);
 export const setStatusProposalIsRequesting = isApiRequestingSetStatusProposal;
 export const setStatusProposalToken = compose(get("token"), apiSetStatusProposalPayload);
+export const setStatusProposalStatus = compose(get("status"), apiSetStatusProposalPayload);
 export const setStatusProposalError = apiSetStatusProposalError;
 export const redirectedFrom = get([ "api", "login", "redirectedFrom" ]);
 export const verificationToken = compose(get("verificationtoken"), apiNewUserResponse);

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -4,6 +4,7 @@ import eq from "lodash/fp/eq";
 import filter from "lodash/fp/filter";
 import find from "lodash/fp/find";
 import qs from "query-string";
+import orderBy from "lodash/fp/orderBy";
 import { or, constant, not } from "../lib/fp";
 import {
   apiProposal,
@@ -14,11 +15,12 @@ import {
   apiUnvettedProposals,
   apiVettedProposals,
   getPropVoteStatus,
-  apiUserProposals,
   proposalCreditPurchases,
   apiUnvettedStatusResponse,
-  numOfUserProposals
+  numOfUserProposals,
+  userid
 } from "./api";
+
 import { globalUsernamesById } from "../actions/app";
 import {
   PAYWALL_STATUS_PAID,
@@ -184,10 +186,22 @@ export const getDraftProposals = (state) => {
   return drafts;
 };
 
+export const getSubmittedUserProposals = (state) => (userID) => {
+  const isUserProp = prop => prop.userid === userID;
+  const vettedProps = vettedProposals(state).filter(isUserProp);
+  const unvettedProps = unvettedProposals(state).filter(isUserProp);
+
+  const sortByNewestFirst = orderBy(["timestamp"], ["desc"]);
+
+  return sortByNewestFirst(vettedProps.concat(unvettedProps));
+};
+
 export const getUserProposals = (state) => {
   const userFilterValue = getUserFilterValue(state);
+  const userID = userid(state);
+
   if (userFilterValue === PROPOSAL_USER_FILTER_SUBMITTED) {
-    return apiUserProposals(state);
+    return getSubmittedUserProposals(state)(userID);
   } else if (userFilterValue === PROPOSAL_USER_FILTER_DRAFT) {
     return getDraftProposals(state);
   }
@@ -246,6 +260,7 @@ export const getVettedEmptyProposalsMessage = (state) => {
     return "There are no proposals";
   }
 };
+
 
 export const votesEndHeight = (state) => state.app.votesEndHeight || {};
 

--- a/src/selectors/tests/app.test.js
+++ b/src/selectors/tests/app.test.js
@@ -84,7 +84,7 @@ describe("test app selector", () => {
 
   it("test selector getUnvettedFilteredProposals", () => {
     expect(sel.getUnvettedFilteredProposals(MOCK_STATE))
-      .toEqual([ MOCK_STATE.api.unvetted.response.proposals[0], MOCK_STATE.api.unvetted.response.proposals[2] ]);
+      .toEqual([ MOCK_STATE.api.unvetted.response.proposals[2], MOCK_STATE.api.unvetted.response.proposals[0] ]);
 
     const state = { ...MOCK_STATE, app: { ...MOCK_STATE.app, adminProposalsShow: 0 } };
 

--- a/src/selectors/tests/app.test.js
+++ b/src/selectors/tests/app.test.js
@@ -6,65 +6,73 @@ import { globalUsernamesById } from "../../actions/app";
 
 describe("test app selector", () => {
 
-  test("testing conditional selectors", () => {
-    let state;
-
-    // proposal
+  it("test selector proposal", () => {
     expect(sel.proposal(MOCK_STATE)).toEqual(MOCK_STATE.api.proposal.response.proposal);
+  });
 
+  it("test const globalUsernamesById", () => {
     expect(globalUsernamesById[2]).toEqual(MOCK_STATE.api.proposal.response.proposal.username);
+  });
 
-    // getEditProposalValues
+  it("test selector getEditProposalsValues", () => {
     expect(sel.getEditProposalValues(MOCK_STATE)).toEqual({
       name: MOCK_STATE.api.proposal.response.proposal.name,
       description: getTextFromIndexMd(sel.getMarkdownFile(MOCK_STATE)),
       files: sel.getNotMarkdownFile(MOCK_STATE)
     });
 
-    state = { api: { ...MOCK_STATE.api, proposal: { response: { proposal: {} } } } };
+    const state = { api: { ...MOCK_STATE.api, proposal: { response: { proposal: {} } } } };
 
     expect(sel.getEditProposalValues(state)).toEqual({
       name: undefined,
       description: "",
       files: []
     });
+  });
 
+  it("test selectors userHasPaid and userCanExecute actions", () => {
     // userCanExecuteActions && userHasPaid
     expect(sel.userHasPaid(MOCK_STATE)).toBeFalsy();
 
     expect(sel.userCanExecuteActions(MOCK_STATE)).toBeFalsy();
 
-    state = { ...MOCK_STATE, app: { ...MOCK_STATE.app, userPaywallStatus: PAYWALL_STATUS_PAID } };
+    const state = { ...MOCK_STATE, app: { ...MOCK_STATE.app, userPaywallStatus: PAYWALL_STATUS_PAID } };
 
     expect(sel.userHasPaid(state)).toBeTruthy();
 
     expect(sel.userCanExecuteActions(state)).toBeTruthy();
+  });
 
+  it("test selector getUserPaywallStatus", () => {
     // getUserPaywallStatus
     expect(sel.getUserPaywallStatus(MOCK_STATE)).toEqual(PAYWALL_STATUS_LACKING_CONFIRMATIONS);
 
-    state = { ...MOCK_STATE, api: { ...MOCK_STATE.api, me: { response: { paywalladdress: "" } } } };
+    const state = { ...MOCK_STATE, api: { ...MOCK_STATE.api, me: { response: { paywalladdress: "" } } } };
 
     expect(sel.getUserPaywallStatus(state)).toEqual(PAYWALL_STATUS_PAID);
+  });
 
-    // getUserPaywallConfirmation
+  it("test selector getUserPaywallConfirmation", () => {
     expect(sel.getUserPaywallConfirmations(MOCK_STATE)).toEqual(MOCK_STATE.app.userPaywallConfirmations);
-
-    state = { ...MOCK_STATE, api: { ...MOCK_STATE.api, me: { response: { paywalladdress: "" } } } };
-
+    const state = { ...MOCK_STATE, api: { ...MOCK_STATE.api, me: { response: { paywalladdress: "" } } } };
     expect(sel.getUserPaywallConfirmations(state)).toEqual(null);
+  });
 
-    // proposalComments
+  it("test selector proposalComments", () => {
     globalUsernamesById[2] = "username";
     expect(sel.proposalComments(MOCK_STATE)).toEqual(MOCK_STATE.api.proposalComments.response.comments);
+  });
 
-    // unvettedProposals
+  it("test selector unvettedProposals", () => {
     expect(sel.unvettedProposals(MOCK_STATE)).toEqual(MOCK_STATE.api.unvetted.response.proposals);
 
     for (const p of MOCK_STATE.api.unvetted.response.proposals) {
       expect(globalUsernamesById[p.userid]).toEqual(p.username);
     }
 
+  });
+
+  it("test selector vettedProposals", () => {
     // vettedProposals
     expect(sel.vettedProposals(MOCK_STATE)).toEqual(MOCK_STATE.api.vetted.response.proposals);
 
@@ -72,52 +80,50 @@ describe("test app selector", () => {
       expect(globalUsernamesById[p.userid]).toEqual(p.username);
     }
 
-    // getUnvettedFilteredProposals
-    expect(sel.getUnvettedFilteredProposals(MOCK_STATE))
-      .toEqual([MOCK_STATE.api.unvetted.response.proposals[1]]);
+  });
 
-    state = { ...MOCK_STATE, app: { ...MOCK_STATE.app, adminProposalsShow: 0 } };
+  it("test selector getUnvettedFilteredProposals", () => {
+    expect(sel.getUnvettedFilteredProposals(MOCK_STATE))
+      .toEqual([ MOCK_STATE.api.unvetted.response.proposals[0], MOCK_STATE.api.unvetted.response.proposals[2] ]);
+
+    const state = { ...MOCK_STATE, app: { ...MOCK_STATE.app, adminProposalsShow: 0 } };
 
     expect(sel.getUnvettedFilteredProposals(state))
       .toEqual(MOCK_STATE.api.unvetted.response.proposals);
+  });
 
-
-
-    // getVettedFilteredProposals
+  it("test selector getVettedFilteredProposals", () => {
     expect(sel.getVettedFilteredProposals(MOCK_STATE))
       .toEqual(MOCK_STATE.api.vetted.response.proposals);
-
-    state = { ...MOCK_STATE, app: { ...MOCK_STATE.app, publicProposalsShow: PROPOSAL_STATUS_UNREVIEWED } };
-
+    const state = { ...MOCK_STATE, app: { ...MOCK_STATE.app, publicProposalsShow: PROPOSAL_STATUS_UNREVIEWED } };
     expect(sel.getVettedFilteredProposals(state)).toEqual([]);
+  });
 
-    // draftProposals
+  it("test selector getDraftProposals", () => {
     expect(sel.getDraftProposals(MOCK_STATE)).toEqual([]);
+  });
 
+  it("test selectors draftProposals and draftProposalsById", () => {
     expect(sel.draftProposals(MOCK_STATE)).toEqual(MOCK_STATE.app.draftProposals);
 
     expect(sel.draftProposalById(MOCK_STATE)).toBeFalsy();
+  });
 
-    // getUserProposals
-    expect(sel.getUserProposals(MOCK_STATE)).toEqual(MOCK_STATE.api.userProposals.response.proposals);
-
-    state = { ...MOCK_STATE, app: { ...MOCK_STATE.app, userProposalsShow: PROPOSAL_USER_FILTER_DRAFT } };
-
-    expect(sel.getUserProposals(state)).toEqual([]);
-
-    state = { ...MOCK_STATE, app: { ...MOCK_STATE.app, userProposalsShow: undefined } };
-
-    expect(sel.getUserProposals(state)).toEqual([]);
-
-    // __FilterCounts
+  it("test selector getUserProposalFilterCounts", () => {
     //TODO: Write test for filterCounts
     expect(sel.getUserProposalFilterCounts(MOCK_STATE)).toBeDefined();
+  });
 
+  it("test selector getUnvettedProposalFilterCounts", () => {
     expect(sel.getUnvettedProposalFilterCounts(MOCK_STATE)).toBeDefined();
+  });
 
+
+  it("test selector getVettedProposalFilterCounts", () => {
     expect(sel.getVettedProposalFilterCounts(MOCK_STATE)).toBeDefined();
+  });
 
-    // __EmptyProposalsMessage
+  it("test selector getUnvettedEmptyProposalsMessage", () => {
     expect(sel.getUnvettedEmptyProposalsMessage({ app: { adminProposalsShow: 12 } }))
       .toBeDefined();
 
@@ -126,7 +132,9 @@ describe("test app selector", () => {
 
     expect(sel.getUnvettedEmptyProposalsMessage({ app: { adminProposalsShow: PROPOSAL_STATUS_CENSORED } }))
       .toBeDefined();
+  });
 
+  it("test selector getVettedEmptyProposalsMessage", () => {
     expect(sel.getVettedEmptyProposalsMessage(MOCK_STATE))
       .toBeDefined();
 
@@ -138,24 +146,43 @@ describe("test app selector", () => {
 
     expect(sel.getVettedEmptyProposalsMessage({ app: { publicProposalsShow: PROPOSAL_VOTING_NOT_AUTHORIZED } }))
       .toBeDefined();
+  });
 
-
-    // ternary selectors
+  it("test selector votesEndHeight", () => {
     expect(sel.votesEndHeight(MOCK_STATE)).toEqual({});
-
-    state = { ...MOCK_STATE, app: { ...MOCK_STATE.app, votesEndHeight: 15 } };
-
+    const state = { ...MOCK_STATE, app: { ...MOCK_STATE.app, votesEndHeight: 15 } };
     expect(sel.votesEndHeight(state)).toEqual(15);
+  });
 
+  it("test selector getCsrfIsNeeded", () => {
     expect(sel.getCsrfIsNeeded(MOCK_STATE)).toBeTruthy();
+  });
 
+  it("test selectors identityImportError and identityImportSuccess", () => {
     expect(sel.identityImportError(MOCK_STATE)).toEqual(MOCK_STATE.app.identityImportResult.errorMsg);
 
     expect(sel.identityImportSuccess(MOCK_STATE)).toEqual(MOCK_STATE.app.identityImportResult.successMsg);
+  });
 
+  it("test selector newProposalInitialValues", () => {
     expect(sel.newProposalInitialValues(MOCK_STATE)).toEqual({});
+  });
 
+  it("test selector proposalCredits", () => {
     expect(sel.proposalCredits(MOCK_STATE)).toEqual(MOCK_STATE.app.proposalCredits);
+  });
+
+  it("test getUserProposals selector", () => {
+    // getUserProposals
+    expect(sel.getUserProposals(MOCK_STATE)).toEqual(MOCK_STATE.api.userProposals.response.proposals);
+
+    let state = { ...MOCK_STATE, app: { ...MOCK_STATE.app, userProposalsShow: PROPOSAL_USER_FILTER_DRAFT } };
+
+    expect(sel.getUserProposals(state)).toEqual([]);
+
+    state = { ...MOCK_STATE, app: { ...MOCK_STATE.app, userProposalsShow: undefined } };
+
+    expect(sel.getUserProposals(state)).toEqual([]);
   });
 
 });

--- a/src/selectors/tests/mock_state.js
+++ b/src/selectors/tests/mock_state.js
@@ -12,6 +12,26 @@ const FAKE_PUBKEY = "fake_pub_key";
 const FAKE_CSRF   = "fake_csrf_token";
 const FAKE_TOKEN  = "fake_token";
 
+const MOCK_USER_PROPS = [
+  {
+    name:
+      "Proposal to mitigate risks regarding identity theft and forgery",
+    status: 2,
+    numcomments: 3,
+    timestamp: 1505940194,
+    censorshiprecord: {
+      token:
+        "6284c5f8fba5664453b8e6651ebc8747b289fed242d2f880f64a284496bb4ca11",
+      merkle:
+        "0dd10219cd79342166085cbe6f737bd54efe119b24c84cbc053023ed6b7da4c8",
+      signature:
+        "f5ea17d547d8347a2f2d009dcb7e89fcc96613d7aaff1f2a26761779763d77688b57b423f1e7d2da8cd433ef2cfe6f58c7cf1c43065fa6716a03a3726d902d0a"
+    },
+    files: [],
+    userid: "fake_id"
+  }
+];
+
 export const MOCK_STATE = {
   api: {
     user: {
@@ -21,22 +41,7 @@ export const MOCK_STATE = {
     },
     userProposals: {
       response: {
-        proposals: [{
-          name:
-            "Proposal to mitigate risks regarding identity theft and forgery",
-          status: 0,
-          numcomments: 3,
-          timestamp: 1505940194,
-          censorshiprecord: {
-            token:
-              "6284c5f8fba5664453b8e6651ebc8747b289fed242d2f880f64a284496bb4ca11",
-            merkle:
-              "0dd10219cd79342166085cbe6f737bd54efe119b24c84cbc053023ed6b7da4c8",
-            signature:
-              "f5ea17d547d8347a2f2d009dcb7e89fcc96613d7aaff1f2a26761779763d77688b57b423f1e7d2da8cd433ef2cfe6f58c7cf1c43065fa6716a03a3726d902d0a"
-          },
-          files: []
-        }]
+        proposals: MOCK_USER_PROPS
       }
     },
     login: {
@@ -87,6 +92,7 @@ export const MOCK_STATE = {
         email: "testme@email.com",
         username: "testusername",
         isadmin: true,
+        userid: "fake_id",
         paywalladdress: FAKE_PAYWALL.address,
         paywallamount: FAKE_PAYWALL.amount,
         paywalltxnotbefore: FAKE_PAYWALL.txNotBefore,
@@ -111,6 +117,7 @@ export const MOCK_STATE = {
     unvetted: {
       response: {
         proposals: [
+          ...MOCK_USER_PROPS,
           {
             name: "This is an example proposal",
             status: 3,


### PR DESCRIPTION
closes #650 
- [x] Centralize proposals in one cache in order to have a single source of truth
- [x] Replace approve/censor buttons for loading buttons
- [x] Make sure every route have access to the proposal's vote status