### PR TITLE
Fix proposal credit localStorage logic

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -591,7 +591,19 @@ export const onUpdateProposalCredits = () => dispatch => {
 };
 
 export const onAddProposalCredits = ({ amount, txNotBefore }) => (dispatch, getState) => {
-  const creditPrice = getState().api.proposalPaywallDetails.response.creditprice / 100000000;
+  const propPaywallDetails = getState().api.proposalPaywallDetails;
+  let creditPrice = 0.1;
+  if (propPaywallDetails) {
+    creditPrice = propPaywallDetails.response.creditprice / 100000000;
+  } else {
+    api
+      .proposalPaywallDetails()
+      .then(response => {
+        dispatch(act.RECEIVE_PROPOSAL_PAYWALL_DETAILS(response));
+        creditPrice = response.creditprice / 100000000;
+      });
+  }
+
   return amount ? dispatch(act.ADD_PROPOSAL_CREDITS({ amount: Math.round(amount * 1/creditPrice), txid: txNotBefore })) : null;
 };
 

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -97,7 +97,6 @@ export const onFetchProposal = (token) => (dispatch, getState) =>
 
 export const onLoadMe = me => dispatch => {
   dispatch(act.LOAD_ME(me));
-  dispatch(act.SET_PROPOSAL_CREDITS(me.response.proposalcredits));
 };
 
 export const onChangeAdminFilter = (option) => act.CHANGE_ADMIN_FILTER_VALUE(option);

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -117,6 +117,13 @@ const app = (state = DEFAULT_STATE, action) => (({
     ...state,
     proposalCredits: state.proposalCredits - (action.payload || 0)
   }),
+  [act.LOAD_ME]: () => {
+    const proposalCredits = action.payload.response.proposalcredits;
+    return ({
+      ...state,
+      proposalCredits: proposalCredits || state.proposalCredits
+    });
+  },
   [act.ADD_PROPOSAL_CREDITS]: () => ({
     ...state,
     recentPayments: state.recentPayments ?


### PR DESCRIPTION
To test it:

1. Open two tabs with politeia.
2. Open `Manage proposal credits` in one of them. **IMPORTANT:** only one of the tabs should open the `manage proposal credits` modal, otherwise the test will be useless.
3. Buy some credits.
4. Wait for the confirmations and make sure it's updated on both tabs.
5. Close `manage proposal credits` modal and spend some proposal credits.
6. Make sure it's consistent among the tabs.

Fixes #661, fixes #662 