### PR TITLE
Adds registration fee to history; minor changes to table ui

### DIFF
--- a/src/components/ProposalCreditsManager/Page.js
+++ b/src/components/ProposalCreditsManager/Page.js
@@ -11,13 +11,22 @@ class ProposalCreditsPage extends React.Component {
       proposalCreditPrice,
       isApiRequestingProposalPaywall,
       proposalCredits,
-      proposalCreditPurchases,
 
       // Testnet only
       isTestnet,
       proposalPaywallPaymentTxid,
       ...props
     } = this.props;
+
+    const proposalCreditPurchases = this.props.proposalCreditPurchases.unshift({
+      numberPurchased: 1,
+      price: 0.1,
+      confirming: false,
+      amount: 1,
+      type: "fee",
+      txId: this.props.paywallTxid
+    });
+
     return isApiRequestingProposalPaywall ?
       <PageLoadingIcon />
       : (

--- a/src/components/ProposalCreditsManager/Page.js
+++ b/src/components/ProposalCreditsManager/Page.js
@@ -1,7 +1,6 @@
 import React from "react";
 import ProposalCreditsSummary from "./Summary";
 import { PageLoadingIcon } from "../snew";
-import { PAYWALL_REGISTER_FEE_AMOUNT } from "../../constants";
 
 class ProposalCreditsPage extends React.Component {
   componentDidMount() {
@@ -19,11 +18,11 @@ class ProposalCreditsPage extends React.Component {
       ...props
     } = this.props;
 
+    // adds registration fee to history table
     const proposalCreditPurchases = this.props.proposalCreditPurchases.unshift({
-      numberPurchased: 1,
-      price: PAYWALL_REGISTER_FEE_AMOUNT,
+      numberPurchased: "N/A",
+      price: "click on the transaction link for more information",
       confirming: false,
-      amount: 1,
       type: "fee",
       txId: this.props.paywallTxid
     });

--- a/src/components/ProposalCreditsManager/Page.js
+++ b/src/components/ProposalCreditsManager/Page.js
@@ -1,6 +1,7 @@
 import React from "react";
 import ProposalCreditsSummary from "./Summary";
 import { PageLoadingIcon } from "../snew";
+import { PAYWALL_REGISTER_FEE_AMOUNT } from "../../constants";
 
 class ProposalCreditsPage extends React.Component {
   componentDidMount() {
@@ -20,7 +21,7 @@ class ProposalCreditsPage extends React.Component {
 
     const proposalCreditPurchases = this.props.proposalCreditPurchases.unshift({
       numberPurchased: 1,
-      price: 0.1,
+      price: PAYWALL_REGISTER_FEE_AMOUNT,
       confirming: false,
       amount: 1,
       type: "fee",

--- a/src/components/ProposalCreditsManager/Summary.js
+++ b/src/components/ProposalCreditsManager/Summary.js
@@ -67,17 +67,21 @@ const ProposalCreditsSummary = ({
               <div className="credit-purchase-row" key={i}>
                 <div className="credit-purchase-cell credit-purchase-number">{creditPurchase.numberPurchased}</div>
                 <div className="credit-purchase-cell credit-purchase-price">
-                  {(creditPurchase.numberPurchased*creditPurchase.price).toFixed(2)} DCR
+                  {
+                    creditPurchase.numberPurchased === "N/A" ?
+                      creditPurchase.price
+                      :
+                      (creditPurchase.numberPurchased*creditPurchase.price).toFixed(2) + " DCR"
+                  }
                 </div>
                 <div className="credit-purchase-cell credit-purchase-tx">
                   <DcrdataTxLink isTestnet={isTestnet} txId={creditPurchase.txId} />
                 </div>
                 <div className="credit-purchase-cell credit-purchase-status">
                   { creditPurchase.confirming ?
-                    (<div className="user-proposal-credits-cell" ><div>
-                    confirming: </div>({creditPurchase.confirmations} of {CONFIRMATIONS_REQUIRED })</div>)
-                    :
-                    <div className="user-proposal-credits-cell"> ✔ </div>
+                    (<div className="user-proposal-credits-cell" style={{ color: "#ff8100" }}><div>
+											waiting confirmations: </div>({creditPurchase.confirmations} of {CONFIRMATIONS_REQUIRED})</div>)
+                    : <div style={{ color: "green" }}>confirmed</div>
                   }
                 </div>
                 <div className="credit-purchase-cell credit-purchase-date-text">

--- a/src/components/ProposalCreditsManager/Summary.js
+++ b/src/components/ProposalCreditsManager/Summary.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { exportToCsv, formatDate } from "../../helpers";
+import { CONFIRMATIONS_REQUIRED } from "../../constants";
 import DcrdataTxLink from "../DcrdataTxLink";
 
 const exportData = (data) => {
@@ -73,7 +74,8 @@ const ProposalCreditsSummary = ({
                 </div>
                 <div className="credit-purchase-cell credit-purchase-status">
                   { creditPurchase.confirming ?
-                    (<div className="user-proposal-credits-cell"><div className="logo"></div></div>)
+                    (<div className="user-proposal-credits-cell" ><div>
+                    confirming: </div>({creditPurchase.confirmations} of {CONFIRMATIONS_REQUIRED })</div>)
                     :
                     <div className="user-proposal-credits-cell"> ✔ </div>
                   }

--- a/src/components/ProposalCreditsManager/Summary.js
+++ b/src/components/ProposalCreditsManager/Summary.js
@@ -1,5 +1,4 @@
 import React from "react";
-import { CONFIRMATIONS_REQUIRED } from "../../constants";
 import { exportToCsv, formatDate } from "../../helpers";
 import DcrdataTxLink from "../DcrdataTxLink";
 
@@ -19,8 +18,7 @@ const ProposalCreditsSummary = ({
   isTestnet,
   proposalPaywallPaymentTxid,
   proposalPaywallPaymentAmount,
-  proposalPaywallPaymentConfirmations,
-  paywallTxid
+  proposalPaywallPaymentConfirmations
 }) => {
   const isThereAnyCompletedPurchase = proposalCreditPurchases && proposalCreditPurchases.length > 0;
 
@@ -40,11 +38,7 @@ const ProposalCreditsSummary = ({
 
   return (
     <div className="proposal-credits-summary">
-      <div className="available-credits">
-        <div>
-          <span><b>Register fee payment:</b> <DcrdataTxLink isTestnet={isTestnet} txId={paywallTxid} /> </span>
-        </div>
-      </div>
+
       {isThereAnyCompletedPurchase ?
         <div className="credits-purchase-menu">
           <button
@@ -58,11 +52,12 @@ const ProposalCreditsSummary = ({
         <div className="credit-purchase-table">
           <div className="credit-purchase-header">
             <div className="credit-purchase-row">
-              <div className="credit-purchase-cell credit-purchase-number">#</div>
-              <div className="credit-purchase-cell credit-purchase-price">DCR per credit</div>
+              <div className="credit-purchase-cell credit-purchase-number">Amount</div>
+              <div className="credit-purchase-cell credit-purchase-price">DCRs</div>
               <div className="credit-purchase-cell credit-purchase-tx">Transaction</div>
               <div className="credit-purchase-cell credit-purchase-status">Status</div>
               <div className="credit-purchase-cell credit-purchase-date">Date</div>
+              <div className="credit-purchase-cell credit-purchase-type">Type</div>
               <div className="clear"></div>
             </div>
           </div>
@@ -70,15 +65,17 @@ const ProposalCreditsSummary = ({
             {reverseProposalCreditPurchases.map((creditPurchase, i) => (
               <div className="credit-purchase-row" key={i}>
                 <div className="credit-purchase-cell credit-purchase-number">{creditPurchase.numberPurchased}</div>
-                <div className="credit-purchase-cell credit-purchase-price">{creditPurchase.price} DCR</div>
+                <div className="credit-purchase-cell credit-purchase-price">
+                  {(creditPurchase.numberPurchased*creditPurchase.price).toFixed(2)} DCR
+                </div>
                 <div className="credit-purchase-cell credit-purchase-tx">
                   <DcrdataTxLink isTestnet={isTestnet} txId={creditPurchase.txId} />
                 </div>
                 <div className="credit-purchase-cell credit-purchase-status">
                   { creditPurchase.confirming ?
-                    (<div className="user-proposal-credits-cell" style={{ color: "#ff8100", fontWeight: "bold" }}><div>
-											Awaiting confirmations: </div>({creditPurchase.confirmations} of {CONFIRMATIONS_REQUIRED })</div>)
-                    : <div style={{ fontWeight: "bold", color: "green" }}>Confirmed</div>
+                    (<div className="user-proposal-credits-cell"><div className="logo"></div></div>)
+                    :
+                    <div className="user-proposal-credits-cell"> ✔ </div>
                   }
                 </div>
                 <div className="credit-purchase-cell credit-purchase-date-text">
@@ -87,6 +84,12 @@ const ProposalCreditsSummary = ({
                       creditPurchase.datePurchased === "just now" ? "just now" :
                         formatDate(creditPurchase.datePurchased)
                       : ""
+                  }
+                </div>
+                <div className="credit-purchase-cell credit-purchase-type">
+                  { creditPurchase.type === "fee" ?
+                    "registration fee" :
+                    "credits"
                   }
                 </div>
                 <div className="clear"></div>

--- a/src/constants.js
+++ b/src/constants.js
@@ -17,6 +17,7 @@ export const PAYWALL_STATUS_LACKING_CONFIRMATIONS = 1;
 export const PAYWALL_STATUS_PAID = 2;
 export const CONFIRMATIONS_REQUIRED = 2;
 
+export const PAYWALL_REGISTER_FEE_AMOUNT = 0.1;
 
 export const PUB_KEY_STATUS_LOADING = 0;
 export const PUB_KEY_STATUS_LOADED = 1;

--- a/src/constants.js
+++ b/src/constants.js
@@ -17,8 +17,6 @@ export const PAYWALL_STATUS_LACKING_CONFIRMATIONS = 1;
 export const PAYWALL_STATUS_PAID = 2;
 export const CONFIRMATIONS_REQUIRED = 2;
 
-export const PAYWALL_REGISTER_FEE_AMOUNT = 0.1;
-
 export const PUB_KEY_STATUS_LOADING = 0;
 export const PUB_KEY_STATUS_LOADED = 1;
 

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -1308,6 +1308,10 @@ li p.header-3 {
 	width: 40% !important;
   text-align: center;
 }
+
+.credit-purchase-type {
+  text-align: center;
+}
 .credit-purchase-price {
   text-align: center;
 }


### PR DESCRIPTION
Now user can see his tx from register fee on the history table.

Minor changes do UI, wanted to see how y'all feel about it. One thing I see as a bottleneck on our current UI is that we don't have a very harmonious colour palette. So I changed some things on the table to make it more neutral.

![acchist](https://user-images.githubusercontent.com/2729122/47328027-c0c4a380-d645-11e8-98da-046eb4553d06.gif)

from: 

![image](https://user-images.githubusercontent.com/2729122/47328038-cc17cf00-d645-11e8-8a39-92bb2157b04f.png)

closes #716 