### PR TITLE
Show external link from a tag href

### DIFF
--- a/src/components/snew/Markdown/helpers.js
+++ b/src/components/snew/Markdown/helpers.js
@@ -59,7 +59,7 @@ const verifyExternalLink = (e, link, confirmWithModal) => {
             You are about to be sent to an external website! <strong className="red">Do not</strong> enter your Politeia credentials or reveal any other sensitive information.
           </p>
           <p>
-            <b>External link:</b> {link}
+            <b>External link:</b> {tmpLink.href}
           </p>
           <p style={{ marginTop: "10px" }}>
             <b>External domain:</b> <strong className="red">{tmpLink.hostname}</strong>


### PR DESCRIPTION
For: Not ebay http://ebаy.com

<img width="770" alt="screen shot 2018-10-23 at 14 58 54" src="https://user-images.githubusercontent.com/13955303/47380733-7a6a5580-d6d4-11e8-92bb-2ddb4cd78912.png">

For: http://2899945070

<img width="773" alt="screen shot 2018-10-23 at 14 58 41" src="https://user-images.githubusercontent.com/13955303/47380797-a08ff580-d6d4-11e8-9475-497e2df3e049.png">


Fixes https://github.com/decred/politeiagui/issues/757