### PR TITLE
Update email validator

### DIFF
--- a/src/validators/util.js
+++ b/src/validators/util.js
@@ -1,7 +1,7 @@
 import { SubmissionError } from "redux-form";
 
 export function emailValidator(email) {
-  return /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(email);
+  return /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,24}$/i.test(email);
 }
 
 export function arrayToRegex(arr) {


### PR DESCRIPTION
closes #782

Setting the max length for email domain extension of 24 characters. 
This length was based on the following sources:

https://jasontucker.blog/8945/what-is-the-longest-tld-you-can-get-for-a-domain-name
https://stackoverflow.com/questions/9238640/how-long-can-a-tld-possibly-be