### PR TITLE
[Modals] Enable closing modal by pressing “Esc” and handle focus of inputs inside the modal

### DIFF
--- a/src/components/Modal/ModalContentWrapper.js
+++ b/src/components/Modal/ModalContentWrapper.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 
 const CancelButton = ({ onClick, text }) => (
   <button
@@ -19,32 +20,63 @@ const SubmitButton = ({ onClick, text, disabled }) => (
   </button>
 );
 
-const ModalContentWrapper = ({
-  onClose,
-  onCancel,
-  onSubmit,
-  submitDisabled = false,
-  title,
-  submitText = "OK",
-  cancelText = "Cancel",
-  children,
-  style
-}) => {
-  return (
-    <div className="modal-content" style={{ minWidth: "700px", ...style }}>
-      <div className="modal-content-header">
-        <h2 style={{ fontSize: "18px", textTransform: "uppercase" }} >{title}</h2>
-        <div style={{ display: "flex", justifyContent: "flex-end", flex: 1 }}>
-          {onClose && <span style={{ fontSize: "18px", cursor: "pointer" }} onClick={onClose}>✖</span>}
+class ModalContentWrapper extends React.Component {
+  handleKeyUp = (e) => {
+    if (e.keyCode === 27 && !this.props.disableCloseOnEsc) {
+      if(this.props.onClose) {
+        this.props.onClose();
+      } else if(this.props.onCancel) {
+        this.props.onCancel();
+      }
+    }
+  }
+  componentWillMount(){
+    window.addEventListener("keyup", this.handleKeyUp);
+  }
+  componentWillUnmount() {
+    window.removeEventListener("keyup", this.handleKeyUp);
+  }
+  render() {
+    const {
+      onClose,
+      onCancel,
+      onSubmit,
+      submitDisabled = false,
+      title,
+      submitText = "OK",
+      cancelText = "Cancel",
+      children,
+      style
+    } = this.props;
+
+    return (
+      <div className="modal-content" style={{ minWidth: "700px", ...style }}>
+        <div className="modal-content-header">
+          <h2 style={{ fontSize: "18px", textTransform: "uppercase" }} >{title}</h2>
+          <div style={{ display: "flex", justifyContent: "flex-end", flex: 1 }}>
+            {onClose && <span style={{ fontSize: "18px", cursor: "pointer" }} onClick={onClose}>✖</span>}
+          </div>
         </div>
+        {children}
+        {(onCancel || onSubmit) && <div className="modal-content-actions">
+          {onCancel && <CancelButton onClick={onCancel} text={cancelText} />}
+          {onSubmit && <SubmitButton onClick={onSubmit} text={submitText} disabled={submitDisabled} />}
+        </div>}
       </div>
-      {children}
-      {(onCancel || onSubmit) && <div className="modal-content-actions">
-        {onCancel && <CancelButton onClick={onCancel} text={cancelText} />}
-        {onSubmit && <SubmitButton onClick={onSubmit} text={submitText} disabled={submitDisabled} />}
-      </div>}
-    </div>
-  );
+    );
+  }
+}
+
+ModalContentWrapper.propTypes = {
+  onClose: PropTypes.func,
+  onCancel: PropTypes.func,
+  onSubmit: PropTypes.func,
+  submitDisabled: PropTypes.bool,
+  title: PropTypes.oneOfType([ PropTypes.string, PropTypes.element ]),
+  submitText: PropTypes.string,
+  cancelText: PropTypes.string,
+  style: PropTypes.object,
+  disableCloseOnEsc: PropTypes.bool
 };
 
 export default ModalContentWrapper;

--- a/src/components/Modal/ModalContentWrapper.js
+++ b/src/components/Modal/ModalContentWrapper.js
@@ -29,13 +29,11 @@ class ModalContentWrapper extends React.Component {
     };
   }
   handleKeyUp = (e) => {
-    if (e.keyCode === 27 && !this.props.disableCloseOnEsc) {
-      if(this.props.onClose) {
-        this.props.onClose();
-      } else if(this.props.onCancel) {
-        this.props.onCancel();
-      }
-    }
+    const ESC_KEY = 27;
+    const pressedEscKey = e.keyCode === ESC_KEY && !this.props.disableCloseOnEsc;
+    const action = this.props.onClose || this.props.onCancel;
+    if(pressedEscKey && action)
+      action();
   }
   focusFirstInputOnModal = () => {
     const modal = document.getElementById(this.state.modalID);

--- a/src/components/Modal/ModalContentWrapper.js
+++ b/src/components/Modal/ModalContentWrapper.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { uniqueID } from "../../helpers";
 
 const CancelButton = ({ onClick, text }) => (
   <button
@@ -21,6 +22,12 @@ const SubmitButton = ({ onClick, text, disabled }) => (
 );
 
 class ModalContentWrapper extends React.Component {
+  constructor(props){
+    super(props);
+    this.state = {
+      modalID: uniqueID("modal")
+    };
+  }
   handleKeyUp = (e) => {
     if (e.keyCode === 27 && !this.props.disableCloseOnEsc) {
       if(this.props.onClose) {
@@ -30,11 +37,21 @@ class ModalContentWrapper extends React.Component {
       }
     }
   }
+  focusFirstInputOnModal = () => {
+    const modal = document.getElementById(this.state.modalID);
+    const inputs = modal && modal.querySelectorAll("input");
+    if (inputs && inputs.length) {
+      inputs[0].focus();
+    }
+  }
   componentWillMount(){
     window.addEventListener("keyup", this.handleKeyUp);
   }
   componentWillUnmount() {
     window.removeEventListener("keyup", this.handleKeyUp);
+  }
+  componentDidMount() {
+    this.focusFirstInputOnModal();
   }
   render() {
     const {
@@ -50,7 +67,7 @@ class ModalContentWrapper extends React.Component {
     } = this.props;
 
     return (
-      <div className="modal-content" style={{ minWidth: "700px", ...style }}>
+      <div id={this.state.modalID} className="modal-content" style={{ minWidth: "700px", ...style }}>
         <div className="modal-content-header">
           <h2 style={{ fontSize: "18px", textTransform: "uppercase" }} >{title}</h2>
           <div style={{ display: "flex", justifyContent: "flex-end", flex: 1 }}>


### PR DESCRIPTION
@sndurkin regarding the first issue you mentioned, I couldn't find any modal where the input wasn't being focused. Is there any specific modal where you saw that?
closes #768