### PR TITLE
Update Dockerfile-serve

### DIFF
--- a/Dockerfile-serve
+++ b/Dockerfile-serve
@@ -5,4 +5,4 @@ LABEL version="1.0"
 LABEL maintainer "holdstockjamie@gmail.com"
 
 COPY ./docker-build/ /usr/local/apache2/htdocs/
-RUN sed -i -e "$ a #CSP Headers\nHeader set Content-Security-Policy \"default-src 'self' *.decred.org *.dcrdata.org; img-src 'self' data:; style-src 'self' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=';\"" /usr/local/apache2/conf/httpd.conf
+RUN sed -i -e "$ a #Security Headers\nHeader set X-Content-Type-Options \"nosniff\"\nHeader set Referrer-Policy \"same-origin\"\n#CSP Header\nHeader set Content-Security-Policy \"default-src 'none'; script-src 'self'; img-src 'self' data:; style-src 'self' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=';font-src 'self';connect-src 'self' faucet.decred.org explorer.dcrdata.org testnet.dcrdata.org testnet.decred.org mainnet.decred.org;manifest-src 'self'; object-src 'none';\"" /usr/local/apache2/conf/httpd.conf


### PR DESCRIPTION
Tightened CSP and added 2 new security headers. 

CSP New rule: default-src 'none'; script-src 'self'; img-src 'self' data:; style-src 'self' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=';font-src 'self';connect-src 'self' faucet.decred.org explorer.dcrdata.org testnet.dcrdata.org testnet.decred.org mainnet.decred.org;manifest-src 'self'; object-src 'none';

1.By default allow none
2.Script allow "self"
3.Images allow "self" and "data:" (used in proposals)
4.Styles (CSS) allow "self" and one whitelisted inline CSS. 
5.Font allow "self"
6.Connect allow "self" ; faucet.decred.org ; explorer.dcrdata.org ; testnet.dcrdata.org ; testnet.decred.org ; mainnet.decred.org
7.Manifest allow "self"
8. Object set to "none"

New Security Headers:

Header set X-Content-Type-Options "nosniff" ==> fixes a chrome and IE specific issue.  https://scotthelme.co.uk/hardening-your-http-response-headers/ look under "X-Content-Type-Options"

Header set Referrer-Policy "same-origin" ==> Defines that "referrer" value should only be given in "same-origin"  requests.  (https://scotthelme.co.uk/a-new-security-header-referrer-policy/)