### PR TITLE
Hide prop images for comment permalink

### DIFF
--- a/src/components/snew/ThingLink.js
+++ b/src/components/snew/ThingLink.js
@@ -370,7 +370,9 @@ class ThingLinkComp extends React.Component {
               compressIcon: ToggleIcon("compress", this.hanldeExpandToggle)
             }}
           />
-          <ProposalImages readOnly files={otherFiles} />
+          {this.state.expanded && (
+            <ProposalImages readOnly files={otherFiles} />
+          )}
           {enableAdminActionsForUnvetted ? (
             <ul style={{ display: "flex" }}>
               <li key="spam">


### PR DESCRIPTION
Resolves #926 

This commit makes the proposal image behavior consistent with proposal text on the permalink routes.