### PR TITLE
Improve UX of external link warning

### DIFF
--- a/src/components/Modal/contents/ConfirmAction.js
+++ b/src/components/Modal/contents/ConfirmAction.js
@@ -19,6 +19,7 @@ class ConfirmAction extends React.Component {
     const { me } = this.props;
     return (
       <ModalContentWrapper
+        style={me.payload.style}
         title={me.payload.title || "Confirm Action"}
         submitText={me.payload.submitText || "Yes"}
         cancelText={me.payload.cancelText || "No"}
@@ -26,13 +27,15 @@ class ConfirmAction extends React.Component {
         onSubmit={this.handleConfirm}
       >
         <div
-          style={{
-            display: "flex",
-            justifyContent: "center",
-            padding: "10px 8px",
-            minHeight: "80px",
-            alignItems: "center"
-          }}
+          style={
+            me.payload.altStyle || {
+              display: "flex",
+              justifyContent: "center",
+              padding: "10px 8px",
+              minHeight: "80px",
+              alignItems: "center"
+            }
+          }
         >
           <span
             style={{

--- a/src/components/ProposalDetail/ProposalDetail.js
+++ b/src/components/ProposalDetail/ProposalDetail.js
@@ -22,9 +22,10 @@ class ProposalDetail extends React.Component {
   }
   componentDidUpdate(prevProps) {
     if (
-      prevProps.proposal &&
-      this.props &&
-      prevProps.proposal.name !== this.props.proposal.name
+      (prevProps.proposal &&
+        this.props &&
+        prevProps.proposal.name !== this.props.proposal.name) ||
+      this.props.openedModals.length < prevProps.openedModals.length
     ) {
       document.title = this.props.proposal.name;
     }

--- a/src/components/snew/Markdown/helpers.js
+++ b/src/components/snew/Markdown/helpers.js
@@ -84,25 +84,59 @@ const verifyExternalLink = (e, link, confirmWithModal) => {
     tmpLink.hostname && tmpLink.hostname !== window.top.location.hostname;
   // if this is an external link, show confirmation dialog
   if (externalLink) {
+    document.title = "Leaving Politeia...";
     confirmWithModal(modalTypes.CONFIRM_ACTION, {
-      title: "External Link Warning",
+      style: {
+        maxWidth: "600px",
+        display: "flex",
+        flexFlow: "column"
+      },
+      altStyle: {
+        maxWidth: "98%",
+        padding: "10px 9px",
+        minHeight: "80px",
+        alignItems: "center"
+      },
+      title: "Warning: Leaving Politeia",
       message: (
-        <React.Fragment>
+        <div style={{ textAlign: "left", alignItems: "center" }}>
           <p style={{ marginBottom: "10px" }}>
-            You are about to be sent to an external website!{" "}
-            <strong className="red">Do not</strong> enter your Politeia
-            credentials or reveal any other sensitive information.
+            You are about to be sent to an external website. This can result in
+            unintended consequences.
+            <strong> DO NOT</strong> enter your Politeia credentials or reveal
+            any other sensitive information.
           </p>
-          <p>
-            <b>External link:</b> {tmpLink.href}
+          <br />
+          <div>
+            <b>External link:</b>
+            <br />
+            <div
+              style={{
+                display: "inline-block",
+                border: "1px solid #dcdcdc",
+                padding: ".5em",
+                borderRadius: "6px",
+                background: "#dcdcdc5c",
+                width: "100%",
+                marginTop: "1em"
+              }}
+            >
+              <span>
+                {" "}
+                {tmpLink.protocol + "//"}
+                <strong className="red">{tmpLink.hostname}</strong>
+                {tmpLink.pathname}
+              </span>
+            </div>
+          </div>
+          <br />
+          <p style={{ marginTop: "12px", textAlign: "center" }}>
+            Are you <strong> sure</strong> you want to open this link?
           </p>
-          <p style={{ marginTop: "10px" }}>
-            <b>External domain:</b>{" "}
-            <strong className="red">{tmpLink.hostname}</strong>
-          </p>
-          <p style={{ marginTop: "10px" }}>Are you sure you want to proceed?</p>
-        </React.Fragment>
-      )
+        </div>
+      ),
+      cancelText: "Cancel",
+      submitText: "Proceed"
     }).then(confirm => {
       if (confirm) {
         const newWindow = window.open();
@@ -113,6 +147,7 @@ const verifyExternalLink = (e, link, confirmWithModal) => {
     });
   } else if (tmpLink.hostname) {
     window.location.href = link;
+    document.title = this.props.proposal.name;
   } else {
     console.log("Blocked potentially malicious link: ", link);
   }

--- a/src/connectors/proposal.js
+++ b/src/connectors/proposal.js
@@ -37,7 +37,8 @@ const proposalConnector = connect(
     ),
     markdownFile: sel.getMarkdownFile,
     otherFiles: sel.getNotMarkdownFile,
-    commentsSortOption: sel.commentsSortOption
+    commentsSortOption: sel.commentsSortOption,
+    openedModals: sel.getopenedModals
   }),
   dispatch =>
     bindActionCreators(


### PR DESCRIPTION
Resolves #770 

This commit works to improve the styling of the external link warning modal. This code also highlights the domain name in red, as opposed to showing it on a separate line. Minor changes to the copy were made as well.