### PR TITLE
Hide 'edited' label for props with one version

### DIFF
--- a/src/components/snew/ThingLink.js
+++ b/src/components/snew/ThingLink.js
@@ -211,7 +211,7 @@ class ThingLinkComp extends React.Component {
                 <span className="font-12 warning-color">(edited)</span>
               ) : null}
             </Link>{" "}
-            {expanded && displayVersion ? (
+            {expanded && displayVersion && version > 1 ? (
               <VersionPicker
                 onSelectVersion={selVersion => {
                   openModal(modalTypes.PROPOSAL_VERSION_DIFF, {


### PR DESCRIPTION
Resolves #957 

Commit adds a conditional to only show edited label when there are more than one versions.