### PR TITLE
Improve formatting and functionality of modal windows

### DIFF
--- a/src/components/Modal/ModalStack.js
+++ b/src/components/Modal/ModalStack.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import Modal from "./Modal";
 import ModalContent from "./ModalContent";
 import modalStackConnector from "../../connectors/modalStack";
+import { withRouter } from "react-router-dom";
 
 class ModalStack extends React.Component {
   constructor(props) {
@@ -11,8 +12,14 @@ class ModalStack extends React.Component {
       modals: []
     };
   }
-  componentDidUpdate() {
-    const { openedModals } = this.props;
+  componentWillMount() {
+    document.addEventListener("click", this.modalClickHandler);
+  }
+  componentWillUnmount() {
+    document.removeEventListener("click", this.modalClickHandler);
+  }
+  componentDidUpdate(prevProps) {
+    const { openedModals, location, closeAllModals } = this.props;
     const { modals } = this.state;
     let modalChanged = false;
     if (modals.length > openedModals.length) {
@@ -30,7 +37,17 @@ class ModalStack extends React.Component {
           document.querySelector("body").style.overflowY = "hidden";
         else document.querySelector("body").style.overflowY = "scroll";
       });
+
+    // closes modals if user path has changed
+    if (location.pathname !== prevProps.location.pathname) {
+      closeAllModals();
+    }
   }
+  //function which closes all modals if user clicks outside of modal window
+  modalClickHandler = event => {
+    if (event.target.closest(".modal-content")) return;
+    this.props.closeAllModals();
+  };
   renderModalContent = modalData => (
     <Modal key={modalData.type}>
       <ModalContent modalData={modalData} />
@@ -45,4 +62,4 @@ ModalStack.propTypes = {
   openedModals: PropTypes.array.isRequired
 };
 
-export default modalStackConnector(ModalStack);
+export default withRouter(modalStackConnector(ModalStack));

--- a/src/components/snew/Markdown/helpers.js
+++ b/src/components/snew/Markdown/helpers.js
@@ -121,7 +121,7 @@ const verifyExternalLink = (e, link, confirmWithModal) => {
                 marginTop: "1em"
               }}
             >
-              <span>
+              <span style={{ wordWrap: "break-word" }}>
                 {" "}
                 {tmpLink.protocol + "//"}
                 <strong className="red">{tmpLink.hostname}</strong>

--- a/src/connectors/modalStack.js
+++ b/src/connectors/modalStack.js
@@ -10,7 +10,8 @@ export default connect(
   dispatch =>
     bindActionCreators(
       {
-        closeModal: act.closeModal
+        closeModal: act.closeModal,
+        closeAllModals: act.closeAllModals
       },
       dispatch
     )


### PR DESCRIPTION
Resolves #959 and #960 

This commit fixes a few things concerning modal behavior:

- Text wrapping for the URL in external link warnings 
- Improved exiting of modals for when user either navigates away from the current page OR clicks outside of the modal window