### PR TITLE
Fixes selection of comment sort options

### DIFF
--- a/src/components/Modal/ModalStack.js
+++ b/src/components/Modal/ModalStack.js
@@ -42,7 +42,11 @@ class ModalStack extends React.Component {
   }
   //function which closes all modals if user clicks outside of modal window
   modalClickHandler = event => {
-    if (event.target.closest(".modal-content")) return;
+    if (
+      event.target.closest(".modal-content") ||
+      this.props.openedModals.length === 0
+    )
+      return;
     this.props.closeAllModals();
   };
   renderModalContent = modalData => (


### PR DESCRIPTION
Turns out every click we do in the gui, we invoke `modalClickHandler`, and therefore it ran the `closeAllModals()` function. The select is being treated as a modal, so it would close out once we clicked the selection box. Now it checks if there is any modal opened by us in the state before closing anything.

Closes #970 