### PR TITLE
Add query string dep and replace imports

### DIFF
--- a/build_docker.sh
+++ b/build_docker.sh
@@ -28,4 +28,6 @@ echo "    docker run -d --rm -p <local port>:80 decred/politeiagui-serve:latest"
 echo ""
 
 # Cleanup
+# TODO: reenable cleanup once it's figured out how to bypass 
+# the permission restrictions
 # rm -rf docker-build

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -28,4 +28,4 @@ echo "    docker run -d --rm -p <local port>:80 decred/politeiagui-serve:latest"
 echo ""
 
 # Cleanup
-rm -rf docker-build
+# rm -rf docker-build

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "normalize.css": "^8.0.1",
     "prop-types": "^15.6.0",
     "qr-image": "^3.2.0",
+    "query-string": "^6.2.0",
     "react": "^16.7.0",
     "react-body": "^0.2.0",
     "react-dom": "^16.7.0",

--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -114,10 +114,10 @@ export const onCreateNewUser = ({ email, username, password }) =>
 
 export const onResetNewUser = act.RESET_NEW_USER;
 
-export const onVerifyNewUser = searchQuery => dispatch => {
-  dispatch(act.REQUEST_VERIFY_NEW_USER(searchQuery));
+export const onVerifyNewUser = (email, verificationToken) => dispatch => {
+  dispatch(act.REQUEST_VERIFY_NEW_USER({ email, verificationToken }));
   return api
-    .verifyNewUser(searchQuery)
+    .verifyNewUser(email, verificationToken)
     .then(res => dispatch(act.RECEIVE_VERIFY_NEW_USER(res)))
     .catch(err => {
       dispatch(act.RECEIVE_VERIFY_NEW_USER(null, err));

--- a/src/actions/tests/api.test.js
+++ b/src/actions/tests/api.test.js
@@ -1,6 +1,7 @@
 import fetchMock from "fetch-mock";
 import configureStore from "redux-mock-store";
 import thunk from "redux-thunk";
+import qs from "query-string";
 import * as api from "../api";
 import * as ea from "../external_api";
 import * as act from "../types";
@@ -19,7 +20,6 @@ import {
 import { getHumanReadableError } from "../../helpers";
 import { MANAGE_USER_CLEAR_USER_PAYWALL } from "../../constants";
 
-const qs = require("querystring");
 const mockStore = configureStore([thunk]);
 
 describe("test api actions (actions/api.js)", () => {
@@ -290,28 +290,29 @@ describe("test api actions (actions/api.js)", () => {
 
   test("on verify new user action", async () => {
     const path = "/api/v1/user/verify";
-    const verificationtoken = "any";
-    const searchQuery = qs.stringify({
-      email: FAKE_USER.email,
-      verificationtoken
-    });
+    const verificationToken = "any";
+    const { email } = FAKE_USER;
+    // const searchQuery = qs.stringify({
+    //   email: FAKE_USER.email,
+    //   verificationtoken
+    // });
 
     await assertApiActionOnError(
       path,
       api.onVerifyNewUser,
-      [searchQuery],
+      [email, verificationToken],
       e => [
         {
           type: act.REQUEST_VERIFY_NEW_USER,
           error: false,
-          payload: searchQuery
+          payload: { email, verificationToken }
         },
         { type: act.RECEIVE_VERIFY_NEW_USER, error: true, payload: e }
       ],
       {
         query: {
-          email: FAKE_USER.email,
-          verificationtoken
+          email,
+          verificationToken
         }
       }
     );
@@ -319,15 +320,18 @@ describe("test api actions (actions/api.js)", () => {
     await assertApiActionOnSuccess(
       path,
       api.onVerifyNewUser,
-      [searchQuery],
+      [email, verificationToken],
       [
-        { type: act.REQUEST_VERIFY_NEW_USER, payload: searchQuery },
+        {
+          type: act.REQUEST_VERIFY_NEW_USER,
+          payload: { email, verificationToken }
+        },
         { type: act.RECEIVE_VERIFY_NEW_USER, error: false }
       ],
       {
         query: {
-          email: FAKE_USER.email,
-          verificationtoken
+          email,
+          verificationToken
         }
       }
     );

--- a/src/components/ForgottenPasswordPage.js
+++ b/src/components/ForgottenPasswordPage.js
@@ -1,7 +1,6 @@
 import React, { Component } from "react";
+import qs from "query-string";
 import ForgottenPassword from "./ForgottenPassword";
-
-const qs = require("querystring");
 
 class ForgottenPasswordPage extends Component {
   constructor(props) {

--- a/src/components/PasswordReset/index.js
+++ b/src/components/PasswordReset/index.js
@@ -2,13 +2,12 @@ import React, { Component } from "react";
 import { autobind } from "core-decorators";
 import { withRouter } from "react-router-dom";
 import assign from "lodash/assign";
+import qs from "query-string";
 import { isRequiredValidator } from "../../validators";
 import PasswordResetForm from "./PasswordResetForm";
 import passwordResetConnector from "../../connectors/passwordReset";
 import validate from "./PasswordResetValidator";
 import { SubmissionError } from "redux-form";
-
-const qs = require("querystring");
 
 class PasswordReset extends Component {
   constructor(props) {

--- a/src/components/ProposalFilter.js
+++ b/src/components/ProposalFilter.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { withRouter } from "react-router-dom";
+import qs from "query-string";
 import { Tabs, Tab } from "./Tabs";
 import {
   PROPOSAL_FILTER_ALL,
@@ -19,8 +20,6 @@ import {
   PROPOSAL_STATUS_ABANDONED
 } from "../constants";
 import { setQueryStringWithoutPageReload } from "../helpers";
-
-const qs = require("querystring");
 
 const adminFilterOptions = [
   {

--- a/src/components/Verify/index.js
+++ b/src/components/Verify/index.js
@@ -1,14 +1,13 @@
 import React, { Component } from "react";
 import { withRouter } from "react-router-dom";
+import qs from "query-string";
 import isEmpty from "lodash/isEmpty";
 import VerifyPage from "./Page";
 import verifyConnector from "../../connectors/verify";
 
-const qs = require("querystring");
-
 class Verify extends Component {
   constructor(props) {
-    super();
+    super(props);
     const { verificationtoken, email } = qs.parse(props.location.search);
     if (
       isEmpty(props.location.search) ||
@@ -21,7 +20,7 @@ class Verify extends Component {
       return;
     }
 
-    props.onVerify(props.location.search).catch(err => {
+    props.onVerify(email, verificationtoken).catch(err => {
       console.error(err.stack || err);
     });
   }

--- a/src/components/VerifyKey/index.js
+++ b/src/components/VerifyKey/index.js
@@ -2,13 +2,12 @@ import React, { Component } from "react";
 import propTypes from "prop-types";
 import { withRouter } from "react-router-dom";
 import isEmpty from "lodash/isEmpty";
+import qs from "query-string";
 import * as pki from "../../lib/pki";
 import PageLoadingIcon from "../snew/PageLoadingIcon";
 import verifyKeyConnector from "../../connectors/verifyKey";
 import Message from "../Message";
 import { verifyUserPubkey } from "../../helpers";
-
-const qs = require("querystring");
 
 class VerifyKey extends Component {
   constructor(props) {

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,6 +1,7 @@
 import "isomorphic-fetch";
 import CryptoJS from "crypto-js";
 import * as pki from "./pki";
+import qs from "query-string";
 import { sha3_256 } from "js-sha3";
 import get from "lodash/fp/get";
 import MerkleTree from "./merkle";
@@ -21,7 +22,6 @@ const STATUS_ERR = {
   404: "Not found"
 };
 
-const qs = require("querystring");
 const apiBase = "/api";
 const getUrl = (path, version = "v1") => `${apiBase}/${version}${path}`;
 const getResponse = get("response");
@@ -184,14 +184,13 @@ export const newUser = (csrf, email, username, password) =>
     }).then(getResponse)
   );
 
-export const verifyNewUser = searchQuery => {
-  const { email, verificationtoken } = qs.parse(searchQuery);
+export const verifyNewUser = (email, verificationToken) => {
   return pki
-    .signStringHex(email, verificationtoken)
+    .signStringHex(email, verificationToken)
     .then(signature =>
       GET(
         "/v1/user/verify?" +
-          qs.stringify({ email, verificationtoken, signature })
+          qs.stringify({ email, verificationToken, signature })
       )
     )
     .then(getResponse);

--- a/src/lib/editors_content_backup.js
+++ b/src/lib/editors_content_backup.js
@@ -1,7 +1,7 @@
 /*
 This lib is designed to handle persisting data for the text editors using session storage
 */
-const qs = require("querystring");
+import qs from "query-string";
 
 export const NEW_PROPOSAL_PATH = "/proposals/new";
 

--- a/src/lib/tests/api.test.js
+++ b/src/lib/tests/api.test.js
@@ -9,8 +9,6 @@ import {
 } from "./support/helpers";
 import { PROPOSAL_STATUS_UNREVIEWED } from "../../constants";
 
-const qs = require("querystring");
-
 describe("api integration modules (lib/api.js)", () => {
   const MOCKS_PATH = "../../../mocks/api/";
   const FAKE_CSRF = "itsafake";
@@ -236,18 +234,15 @@ describe("api integration modules (lib/api.js)", () => {
 
   test("verify new user (api/v1/user/verify)", async () => {
     const PATH = "/api/v1/user/verify";
-    const SEARCH_QUERY = qs.stringify({
-      email: EMAIL,
-      verificationtoken: VERIFICATION_TOKEN
-    });
+
     await assertRouteIsCalledWithQueryParams(
       PATH,
       {
         email: EMAIL,
-        verificationtoken: VERIFICATION_TOKEN
+        verificationToken: VERIFICATION_TOKEN
       },
       api.verifyNewUser,
-      [SEARCH_QUERY]
+      [EMAIL, VERIFICATION_TOKEN]
     );
   });
 

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -5,6 +5,7 @@ import filter from "lodash/fp/filter";
 import find from "lodash/fp/find";
 import orderBy from "lodash/fp/orderBy";
 import { or, constant, not } from "../lib/fp";
+import qs from "query-string";
 import {
   apiProposal,
   apiProposalComments,
@@ -52,8 +53,6 @@ import {
   countPublicProposals,
   isProposalApproved
 } from "../helpers";
-
-const qs = require("querystring");
 
 export const replyTo = or(get(["app", "replyParent"]), constant(0));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7114,6 +7114,14 @@ query-string@^4.1.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.2.0.tgz#468edeb542b7e0538f9f9b1aeb26f034f19c86e1"
+  integrity sha512-5wupExkIt8RYL4h/FE+WTg3JHk62e6fFPWtAZA9J5IWK1PfTfKkMS93HBUHcFpeYi9KsY5pFbh+ldvEyaz5MyA==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -8357,6 +8365,11 @@ stream-http@^2.7.2:
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-argv@^0.0.2:
   version "0.0.2"


### PR DESCRIPTION
This PR reverts some of the modification introduced on https://github.com/decred/politeiagui/pull/961. 
#961 was assuming a node version >= 11.6 which has a `querystring` package built-in but we are currently running on node v10.15.
closes #975