### PR TITLE
Add proposal summary field

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -333,11 +333,12 @@ export const onSubmitProposal = (
   username,
   name,
   description,
-  files
+  files,
+  summary
 ) =>
   withCsrf((dispatch, getState, csrf) => {
-    dispatch(act.REQUEST_NEW_PROPOSAL({ name, description, files }));
-    return Promise.resolve(api.makeProposal(name, description, files))
+    dispatch(act.REQUEST_NEW_PROPOSAL({ name, description, files, summary }));
+    return Promise.resolve(api.makeProposal(name, description, files, summary))
       .then(proposal => api.signProposal(loggedInAsEmail, proposal))
       .then(proposal => api.newProposal(csrf, proposal))
       .then(proposal => {
@@ -348,7 +349,8 @@ export const onSubmitProposal = (
             userid,
             username,
             name,
-            description
+            description,
+            summary
           })
         );
         resetNewProposalData();
@@ -368,11 +370,12 @@ export const onSubmitEditedProposal = (
   name,
   description,
   files,
-  token
+  token,
+  summary
 ) =>
   withCsrf((dispatch, _, csrf) => {
-    dispatch(act.REQUEST_EDIT_PROPOSAL({ name, description, files }));
-    return Promise.resolve(api.makeProposal(name, description, files))
+    dispatch(act.REQUEST_EDIT_PROPOSAL({ name, description, files, summary }));
+    return Promise.resolve(api.makeProposal(name, description, files, summary))
       .then(proposal => api.signProposal(loggedInAsEmail, proposal))
       .then(proposal => api.editProposal(csrf, { ...proposal, token }))
       .then(proposal => {

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -41,10 +41,11 @@ export const onSetReplyParent = (
     dispatch(act.SET_REPLY_PARENT(parentId)),
     dispatch(reset("form/reply"))
   ]);
-export const onSaveNewProposal = ({ name, description, files }, _, props) => (
-  dispatch,
-  getState
-) =>
+export const onSaveNewProposal = (
+  { name, description, files, summary },
+  _,
+  props
+) => (dispatch, getState) =>
   dispatch(
     onSubmitProposal(
       props.loggedInAsEmail,
@@ -52,12 +53,13 @@ export const onSaveNewProposal = ({ name, description, files }, _, props) => (
       props.username,
       name.trim(),
       description,
-      files
+      files,
+      summary
     )
   ).then(() => sel.newProposalToken(getState()));
 
 export const onEditProposal = (
-  { name, description, files },
+  { name, description, files, summary },
   _,
   props
 ) => dispatch =>
@@ -67,18 +69,26 @@ export const onEditProposal = (
       name.trim(),
       description,
       files,
-      props.token
+      props.token,
+      summary
     )
   );
 
-export const onSaveDraftProposal = ({ name, description, files, draftId }) => {
+export const onSaveDraftProposal = ({
+  name,
+  description,
+  files,
+  draftId,
+  summary
+}) => {
   resetNewProposalData();
   return act.SAVE_DRAFT_PROPOSAL({
     name: name.trim(),
     description,
     files,
     timestamp: Date.now() / 1000,
-    draftId
+    draftId,
+    summary
   });
 };
 

--- a/src/actions/tests/api.test.js
+++ b/src/actions/tests/api.test.js
@@ -32,6 +32,7 @@ describe("test api actions (actions/api.js)", () => {
   const FAKE_CSRF = "fake_csrf_token";
   const FAKE_PROPOSAL_NAME = "Fake prop name";
   const FAKE_PROPOSAL_DESCRIPTION = "Fake prop description";
+  const FAKE_PROPOSAL_SUMMARY = "Fake prop summary";
   const FAKE_PROPOSAL_TOKEN = "fake_prop_token";
   const FAKE_PROPOSAL_VERSION = "2";
   const FAKE_COMMENT = "fake comment text";
@@ -570,7 +571,8 @@ describe("test api actions (actions/api.js)", () => {
       FAKE_USER.username,
       FAKE_PROPOSAL_NAME,
       FAKE_PROPOSAL_DESCRIPTION,
-      []
+      [],
+      FAKE_PROPOSAL_SUMMARY
     ];
 
     // this needs a custom assertion for success response as the common one doesn't work for this case
@@ -593,7 +595,8 @@ describe("test api actions (actions/api.js)", () => {
           payload: {
             name: FAKE_PROPOSAL_NAME,
             description: FAKE_PROPOSAL_DESCRIPTION,
-            files: []
+            files: [],
+            summary: FAKE_PROPOSAL_SUMMARY
           }
         },
         { type: act.RECEIVE_NEW_PROPOSAL, error: true, payload: e }
@@ -980,7 +983,8 @@ describe("test api actions (actions/api.js)", () => {
       FAKE_PROPOSAL_NAME,
       FAKE_PROPOSAL_DESCRIPTION,
       [],
-      FAKE_PROPOSAL_TOKEN
+      FAKE_PROPOSAL_TOKEN,
+      FAKE_PROPOSAL_SUMMARY
     ];
     const keys = await pki.generateKeys(FAKE_USER.email);
     await pki.loadKeys(FAKE_USER.email, keys);
@@ -1005,7 +1009,8 @@ describe("test api actions (actions/api.js)", () => {
           payload: {
             name: FAKE_PROPOSAL_NAME,
             description: FAKE_PROPOSAL_DESCRIPTION,
-            files: []
+            files: [],
+            summary: FAKE_PROPOSAL_SUMMARY
           }
         },
         { type: act.RECEIVE_EDIT_PROPOSAL, error: true, payload: e }

--- a/src/actions/tests/app.test.js
+++ b/src/actions/tests/app.test.js
@@ -38,7 +38,8 @@ describe("test app actions (actions/app.js)", () => {
           name: "test",
           description: "Description",
           files: [],
-          timestamp: Date.now() / 1000
+          timestamp: Date.now() / 1000,
+          summary: "summary"
         }
       }
     }
@@ -52,7 +53,8 @@ describe("test app actions (actions/app.js)", () => {
     token: "fake_token",
     name: "fake name",
     description: "fake description",
-    files: []
+    files: [],
+    summary: "fake_proposal_summary"
   };
   const FAKE_USER = {
     id: "2",
@@ -93,7 +95,8 @@ describe("test app actions (actions/app.js)", () => {
           props.username,
           proposal.name,
           proposal.description,
-          proposal.files
+          proposal.files,
+          proposal.summary
         )
       ],
       done

--- a/src/components/Form/Fields/TextAreaWithError.js
+++ b/src/components/Form/Fields/TextAreaWithError.js
@@ -1,0 +1,34 @@
+import React from "react";
+
+class TextAreaWithError extends React.Component {
+  render() {
+    const {
+      input,
+      label,
+      placeholder,
+      tabIndex,
+      type,
+      style,
+      meta: { touched, error, warning }
+    } = this.props;
+    return (
+      <div className="input-with-error">
+        <label>{label}</label>
+        <textarea
+          {...input}
+          tabIndex={tabIndex}
+          placeholder={placeholder}
+          type={type}
+          style={style}
+        />
+        <div className="input-subline">
+          {touched &&
+            ((error && <div className="input-error">{error}</div>) ||
+              (warning && <div className="input-warning">{warning}</div>))}
+        </div>
+      </div>
+    );
+  }
+}
+
+export default TextAreaWithError;

--- a/src/components/ProposalDetail/ProposalDetail.js
+++ b/src/components/ProposalDetail/ProposalDetail.js
@@ -3,7 +3,7 @@ import isEqual from "lodash/isEqual";
 import { withRouter } from "react-router-dom";
 import { Content } from "../snew";
 import { commentsToT1, proposalToT3 } from "../../lib/snew";
-import { getTextFromIndexMd } from "../../helpers";
+import { getTextFromIndexMd, getSummaryFromIndexMd } from "../../helpers";
 import { DEFAULT_TAB_TITLE } from "../../constants";
 import Message from "../Message";
 import {
@@ -144,6 +144,7 @@ class ProposalDetail extends React.Component {
     } = this.props;
     const comments = this.state.sortedComments;
     const tempTree = tempThreadTree[commentid];
+    const proposalHeader = "** Proposal ** \n \n";
     return (
       <div className="content" role="main">
         <div className="page proposal-page">
@@ -169,10 +170,15 @@ class ProposalDetail extends React.Component {
                               ...proposalToT3(proposal, 0).data,
                               otherFiles,
                               selftext: markdownFile
-                                ? getTextFromIndexMd(markdownFile)
+                                ? proposalHeader +
+                                  getTextFromIndexMd(markdownFile)
                                 : null,
                               selftext_html: markdownFile
-                                ? getTextFromIndexMd(markdownFile)
+                                ? proposalHeader +
+                                  getTextFromIndexMd(markdownFile)
+                                : null,
+                              selftext_summary: markdownFile
+                                ? getSummaryFromIndexMd(markdownFile)
                                 : null
                             }
                           }

--- a/src/components/snew/SubmitPage.js
+++ b/src/components/snew/SubmitPage.js
@@ -5,6 +5,7 @@ import MarkdownEditorField from "../Form/Fields/MarkdownEditorField";
 import FilesField from "../Form/Fields/FilesField";
 import ErrorField from "../Form/Fields/ErrorField";
 import InputFieldWithError from "../Form/Fields/InputFieldWithError";
+import TextAreaWithError from "../Form/Fields/TextAreaWithError";
 import Message from "../Message";
 import MultipleItemsBodyMessage from "../MultipleItemsBodyMessage";
 import isArray from "lodash/isArray";
@@ -111,11 +112,23 @@ class SubmitPage extends React.Component {
                         </div>
                       ) : null}
                     </div>
-                    <input name="kind" type="hidden" defaultValue="self" />
-                    <div className="usertext">
-                      <input name="thing_id" type="hidden" defaultValue />
-                      <div className="usertext-edit md-container" style={{}}>
-                        <div className="md">
+                    <div className="md">
+                      <a
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        href={PROPOSAL_GUIDELINES}
+                        style={{
+                          fontSize: ".75em",
+                          marginRight: ".75em",
+                          float: "right"
+                        }}
+                      >
+                        Learn how to format your proposal
+                      </a>
+                      <input name="kind" type="hidden" defaultValue="self" />
+                      <div className="usertext">
+                        <input name="thing_id" type="hidden" defaultValue />
+                        <div className="usertext-edit md-container">
                           <Field
                             name="description"
                             component={MarkdownEditorField}
@@ -124,14 +137,20 @@ class SubmitPage extends React.Component {
                             rows={20}
                             cols={80}
                           />
-                          <a
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            href={PROPOSAL_GUIDELINES}
-                            style={{ fontSize: "1.01em" }}
-                          >
-                            Learn how to format your proposal
-                          </a>
+                          <Field
+                            name="summary"
+                            component={TextAreaWithError}
+                            tabIndex={3}
+                            type="text"
+                            placeholder="Proposal Summary"
+                            style={{
+                              width: "35%",
+                              marginTop: "2.5em",
+                              height: "10em",
+                              resize: "auto",
+                              whiteSpace: "pre-wrap"
+                            }}
+                          />
                           <Field
                             name="files"
                             className="attach-button greenprimary"

--- a/src/components/snew/ThingLink.js
+++ b/src/components/snew/ThingLink.js
@@ -12,6 +12,8 @@ import thingLinkConnector from "../../connectors/thingLink";
 import Tooltip from "../Tooltip";
 import VoteStats from "../VoteStats";
 import VersionPicker from "../VersionPicker";
+import Markdown from "./Markdown/Markdown";
+
 // import Diff from "./Markdown/Diff";
 
 import {
@@ -110,7 +112,8 @@ class ThingLinkComp extends React.Component {
       startVoteToken,
       startVoteError,
       isApiRequestingSetProposalStatusByToken,
-      commentid
+      commentid,
+      selftext_summary
     } = this.props;
     const voteStatus = getVoteStatus(id) && getVoteStatus(id).status;
     const isAbandoned = review_status === PROPOSAL_STATUS_ABANDONED;
@@ -412,6 +415,21 @@ class ThingLinkComp extends React.Component {
                 <DownloadBundle type="proposal" /> <br />
               </div>
             ))}
+          {selftext_html && this.state.expanded && (
+            <form
+              action="#"
+              className="usertext warn-on-unload"
+              id="form-t4_5rve"
+            >
+              <Markdown
+                className="usertext-body may-blank-within md-container"
+                body={`** Summary ** \n \n ${selftext_summary}`}
+                filterXss={true}
+                confirmWithModal={true}
+                displayExternalLikWarning={false}
+              />
+            </form>
+          )}
           {censorMessage && <CensorMessage message={censorMessage} />}
           <Expando
             {...{
@@ -423,7 +441,9 @@ class ThingLinkComp extends React.Component {
               expandIcon: ToggleIcon("expand", this.handleExpandToggle),
               compressIcon: ToggleIcon("compress", this.handleExpandToggle)
             }}
-          />
+          >
+            Proposal{" "}
+          </Expando>
           {this.state.expanded && (
             <ProposalImages readOnly files={otherFiles} />
           )}

--- a/src/configureStore.js
+++ b/src/configureStore.js
@@ -18,6 +18,7 @@ const configureStore = preloadedState => {
     const composeEnhancers =
       typeof window === "object" && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
         ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
+            trace: true
             // Specify extension’s options like name, actionsBlacklist, actionsCreators, serialize...
           })
         : compose;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -30,11 +30,22 @@ export const atou = str => decodeURIComponent(escape(window.atob(str)));
 // formatted as:
 //
 //  <proposal name>\n
-//  <proposal description>
+//  <proposal description>\n
 //
 export const getTextFromIndexMd = file => {
   const text = atou(file.payload);
-  return text.substring(text.indexOf("\n") + 1);
+  return text.substring(text.indexOf("\r"));
+};
+
+export const getSummaryFromIndexMd = file => {
+  const text = atou(file.payload);
+  const summary = text.slice(text.indexOf("\n") + 1, text.indexOf("\r"));
+  //If statement to hide empty summaries for pre-existing proposals
+  if (summary.length > 1) {
+    return summary;
+  } else {
+    return null;
+  }
 };
 
 export const getHumanReadableError = (errorCode, errorContext = []) => {

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -39,9 +39,9 @@ export const convertMarkdownToFile = markdown => ({
   payload: utoa(markdown)
 });
 
-export const makeProposal = (name, markdown, attachments = []) => ({
+export const makeProposal = (name, markdown, attachments = [], summary) => ({
   files: [
-    convertMarkdownToFile(name + "\n" + markdown),
+    convertMarkdownToFile(name + "\n" + summary + "\r" + markdown),
     ...(attachments || [])
   ].map(({ name, mime, payload }) => ({
     name,

--- a/src/lib/editors_content_backup.js
+++ b/src/lib/editors_content_backup.js
@@ -14,6 +14,7 @@ export const getProposalPath = location => {
 
 export const PROPOSAL_FORM_NAME = "name";
 export const PROPOSAL_FORM_DESC = "description";
+export const PROPOSAL_FORM_SUMMARY = "summary";
 
 export const getProposalBackupKey = (key, path) => `proposal-${key}::${path}`;
 
@@ -22,7 +23,8 @@ const updateFormData = state => {
   const newProposalData = (proposalFormState && proposalFormState.values) || {};
   const name = newProposalData[PROPOSAL_FORM_NAME];
   const description = newProposalData[PROPOSAL_FORM_DESC];
-  if (!name && !description) {
+  const summary = newProposalData[PROPOSAL_FORM_SUMMARY];
+  if (!name && !description && !summary) {
     return;
   }
 
@@ -35,6 +37,10 @@ const updateFormData = state => {
     getProposalBackupKey(PROPOSAL_FORM_DESC, path),
     newProposalData[PROPOSAL_FORM_DESC]
   );
+  sessionStorage.setItem(
+    getProposalBackupKey(PROPOSAL_FORM_SUMMARY, path),
+    newProposalData[PROPOSAL_FORM_SUMMARY]
+  );
 };
 
 export const resetNewProposalData = () => {
@@ -44,6 +50,10 @@ export const resetNewProposalData = () => {
   );
   sessionStorage.setItem(
     getProposalBackupKey(PROPOSAL_FORM_DESC, NEW_PROPOSAL_PATH),
+    ""
+  );
+  sessionStorage.setItem(
+    getProposalBackupKey(PROPOSAL_FORM_SUMMARY, NEW_PROPOSAL_PATH),
     ""
   );
 };
@@ -57,6 +67,10 @@ export const getNewProposalData = () => {
     description:
       sessionStorage.getItem(
         getProposalBackupKey(PROPOSAL_FORM_DESC, NEW_PROPOSAL_PATH)
+      ) || "",
+    summary:
+      sessionStorage.getItem(
+        getProposalBackupKey(PROPOSAL_FORM_SUMMARY, NEW_PROPOSAL_PATH)
       ) || ""
   };
 };

--- a/src/lib/tests/api.test.js
+++ b/src/lib/tests/api.test.js
@@ -20,6 +20,7 @@ describe("api integration modules (lib/api.js)", () => {
   const PROPOSAL_TOKEN = "FAKE_TOKEN";
   const PROPOSAL_VERSION = "2";
   const MARKDOWN = "# This is a test proposal";
+  const SUMMARY = "Test prop summary";
   const FILE = {
     name: "example.jpeg",
     mime: "image/jpeg",
@@ -46,9 +47,9 @@ describe("api integration modules (lib/api.js)", () => {
   });
 
   test("make a proposal", () => {
-    let proposal = api.makeProposal(PROPOSAL_NAME, MARKDOWN, [FILE]);
+    let proposal = api.makeProposal(PROPOSAL_NAME, MARKDOWN, [FILE], SUMMARY);
     let fileFromMarkdown = api.convertMarkdownToFile(
-      PROPOSAL_NAME + "\n" + MARKDOWN
+      PROPOSAL_NAME + "\n" + SUMMARY + "\r" + MARKDOWN
     );
     expect(proposal).toEqual({
       files: [
@@ -63,9 +64,9 @@ describe("api integration modules (lib/api.js)", () => {
       ]
     });
     // test without providing attachment object
-    proposal = api.makeProposal(PROPOSAL_NAME, MARKDOWN);
+    proposal = api.makeProposal(PROPOSAL_NAME, MARKDOWN, [], SUMMARY);
     fileFromMarkdown = api.convertMarkdownToFile(
-      PROPOSAL_NAME + "\n" + MARKDOWN
+      PROPOSAL_NAME + "\n" + SUMMARY + "\r" + MARKDOWN
     );
     expect(proposal).toEqual({
       files: [
@@ -77,9 +78,9 @@ describe("api integration modules (lib/api.js)", () => {
     });
 
     // test with a falsy attachment
-    proposal = api.makeProposal(PROPOSAL_NAME, MARKDOWN, false);
+    proposal = api.makeProposal(PROPOSAL_NAME, MARKDOWN, false, SUMMARY);
     fileFromMarkdown = api.convertMarkdownToFile(
-      PROPOSAL_NAME + "\n" + MARKDOWN
+      PROPOSAL_NAME + "\n" + SUMMARY + "\r" + MARKDOWN
     );
     expect(proposal).toEqual({
       files: [
@@ -124,7 +125,7 @@ describe("api integration modules (lib/api.js)", () => {
 
   test("signs a proposal", async () => {
     expect.assertions(3);
-    const proposal = api.makeProposal(PROPOSAL_NAME, MARKDOWN, [FILE]);
+    const proposal = api.makeProposal(PROPOSAL_NAME, MARKDOWN, [FILE], SUMMARY);
     const keys = await pki.generateKeys(EMAIL);
     await pki.loadKeys(EMAIL, keys);
     const pubKey = await pki.myPubKeyHex(EMAIL);

--- a/src/lib/tests/editors_content_backup.test.js
+++ b/src/lib/tests/editors_content_backup.test.js
@@ -5,12 +5,14 @@ describe("Persist editors content on session storage", () => {
   const NAME = "test title";
   const DESCRIPTION = "test description";
   const COMMENT = "test comment";
+  const SUMMARY = "test summary";
   const mockState = {
     form: {
       "form/proposal": {
         values: {
           name: NAME,
-          description: DESCRIPTION
+          description: DESCRIPTION,
+          summary: SUMMARY
         }
       },
       "form/reply": {
@@ -33,7 +35,8 @@ describe("Persist editors content on session storage", () => {
     // retrieve data from session storage
     expect(ecb.getNewProposalData()).toEqual({
       name: NAME,
-      description: DESCRIPTION
+      description: DESCRIPTION,
+      summary: SUMMARY
     });
     // clear saved data
     ecb.resetNewProposalData();

--- a/src/lib/tests/local_storage.test.js
+++ b/src/lib/tests/local_storage.test.js
@@ -21,7 +21,8 @@ describe("save state chunks to local storage (lib/local_storage.js", () => {
           name: "test",
           description: "Description",
           files: [],
-          timestamp: Date.now() / 1000
+          timestamp: Date.now() / 1000,
+          summary: "summary"
         }
       }
     }

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -14,7 +14,8 @@ export const DEFAULT_STATE = {
   replyParent: TOP_LEVEL_COMMENT_PARENTID,
   newProposal: {
     name: "",
-    description: ""
+    description: "",
+    summary: ""
   },
   replyThreadTree: {},
   adminProposalsShow: PROPOSAL_STATUS_UNREVIEWED,

--- a/src/reducers/tests/app.test.js
+++ b/src/reducers/tests/app.test.js
@@ -12,7 +12,8 @@ describe("test app reducer", () => {
         name: "draft",
         description: "Description",
         files: [],
-        timestamp: Date.now() / 1000
+        timestamp: Date.now() / 1000,
+        summary: "summary"
       }
     }
   };
@@ -109,7 +110,8 @@ describe("test app reducer", () => {
         draftId: "randomDraftId",
         description: "Description",
         files: [],
-        timestamp: Date.now() / 1000
+        timestamp: Date.now() / 1000,
+        summary: "summary"
       },
       error: false
     };
@@ -121,7 +123,8 @@ describe("test app reducer", () => {
         draftId: "randomDraftId2",
         description: "Description",
         files: [],
-        timestamp: Date.now() / 1000
+        timestamp: Date.now() / 1000,
+        summary: "summary"
       },
       error: false
     };

--- a/src/selectors/api.js
+++ b/src/selectors/api.js
@@ -525,6 +525,10 @@ export const newProposalDescription = compose(
   get("description"),
   apiNewProposalPayload
 );
+export const newProposalSummary = compose(
+  get("summary"),
+  apiNewProposalPayload
+);
 export const newProposalFiles = compose(
   get("files"),
   apiNewProposalPayload

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -51,7 +51,8 @@ import {
 import {
   getTextFromIndexMd,
   countPublicProposals,
-  isProposalApproved
+  isProposalApproved,
+  getSummaryFromIndexMd
 } from "../helpers";
 
 export const replyTo = or(get(["app", "replyParent"]), constant(0));
@@ -104,10 +105,12 @@ export const getEditProposalValues = state => {
 
   const files = name ? getNotMarkdownFile(state) : [];
   const description = name ? getTextFromIndexMd(getMarkdownFile(state)) : "";
+  const summary = name ? getSummaryFromIndexMd(getMarkdownFile(state)) : "";
   return {
     name,
     description,
-    files
+    files,
+    summary
   };
 };
 

--- a/src/selectors/tests/api.test.js
+++ b/src/selectors/tests/api.test.js
@@ -189,6 +189,10 @@ describe("test api selectors", () => {
       MOCK_STATE.api.newProposal.payload.description
     );
 
+    expect(sel.newProposalSummary(MOCK_STATE)).toEqual(
+      MOCK_STATE.api.newProposal.payload.summary
+    );
+
     expect(sel.newProposalFiles(MOCK_STATE)).toEqual(
       MOCK_STATE.api.newProposal.payload.files
     );

--- a/src/selectors/tests/app.test.js
+++ b/src/selectors/tests/app.test.js
@@ -1,6 +1,6 @@
 import * as sel from "../app";
 import { MOCK_STATE } from "./mock_state";
-import { getTextFromIndexMd } from "../../helpers";
+import { getTextFromIndexMd, getSummaryFromIndexMd } from "../../helpers";
 import {
   PAYWALL_STATUS_PAID,
   PROPOSAL_STATUS_UNREVIEWED,
@@ -23,7 +23,8 @@ describe("test app selector", () => {
     expect(sel.getEditProposalValues(MOCK_STATE)).toEqual({
       name: MOCK_STATE.api.proposal.response.proposal.name,
       description: getTextFromIndexMd(sel.getMarkdownFile(MOCK_STATE)),
-      files: sel.getNotMarkdownFile(MOCK_STATE)
+      files: sel.getNotMarkdownFile(MOCK_STATE),
+      summary: getSummaryFromIndexMd(sel.getMarkdownFile(MOCK_STATE))
     });
 
     const state = {
@@ -33,7 +34,8 @@ describe("test app selector", () => {
     expect(sel.getEditProposalValues(state)).toEqual({
       name: undefined,
       description: "",
-      files: []
+      files: [],
+      summary: ""
     });
   });
 

--- a/src/selectors/tests/mock_state.js
+++ b/src/selectors/tests/mock_state.js
@@ -209,7 +209,8 @@ export const MOCK_STATE = {
       payload: {
         name: "fake_proposal_name",
         description: "fake_proposal_desc",
-        files: ["file1", "file2"]
+        files: ["file1", "file2"],
+        summary: "fake_proposal_summary"
       },
       response: {
         censorshiprecord: {
@@ -236,7 +237,8 @@ export const MOCK_STATE = {
           ],
           censorshiprecord: {
             token: FAKE_TOKEN
-          }
+          },
+          summary: "fake_proposal_summary"
         }
       }
     },


### PR DESCRIPTION
Resolves #1000 

Depends on https://github.com/decred/politeia/issues/685

Also will require changes to dcrdocs (https://github.com/decred/dcrdocs/issues/828)

This commit adds a summary field to the markdown file. A new form has been added to the submit page, along with an additional field being added to the proposal detail view.

Adding the summary field will require changes in the backend policy, along with updating Politeia on dcrdocs.