### PR TITLE
Persist comment sort option

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -40,6 +40,7 @@ class Loader extends Component {
 
     if (!prevProps.loggedInAsEmail && this.props.loggedInAsEmail) {
       this.props.onLoadDraftProposals(this.props.loggedInAsEmail);
+      this.props.onLoadCommentsSortOption(this.props.loggedInAsEmail);
     }
     if (prevProps.userPubkey && this.props.userPubkey) {
       verifyUserPubkey(

--- a/src/App.js
+++ b/src/App.js
@@ -40,7 +40,6 @@ class Loader extends Component {
 
     if (!prevProps.loggedInAsEmail && this.props.loggedInAsEmail) {
       this.props.onLoadDraftProposals(this.props.loggedInAsEmail);
-      this.props.onLoadCommentsSortOption(this.props.loggedInAsEmail);
     }
     if (prevProps.userPubkey && this.props.userPubkey) {
       verifyUserPubkey(

--- a/src/components/ProposalDetail/helpers.js
+++ b/src/components/ProposalDetail/helpers.js
@@ -8,7 +8,7 @@ const getSort = sortOption => {
     [SORT_BY_TOP]: orderBy(["resultvotes", "timestamp"], ["desc", "desc"])
   };
 
-  return mapOptionToSort[sortOption.value] || mapOptionToSort[SORT_BY_NEW];
+  return mapOptionToSort[sortOption.value] || mapOptionToSort[SORT_BY_TOP];
 };
 
 const mergeCommentsAndVotes = (comments, votes) => {

--- a/src/components/ProposalFilter.js
+++ b/src/components/ProposalFilter.js
@@ -19,7 +19,7 @@ import {
   PROPOSAL_VOTING_AUTHORIZED,
   PROPOSAL_STATUS_ABANDONED
 } from "../constants";
-import { setQueryStringWithoutPageReload } from "../helpers";
+import { setQueryStringValue } from "../lib/queryString";
 
 const adminFilterOptions = [
   {
@@ -131,7 +131,7 @@ class ProposalFilter extends React.Component {
     const optionLabel = selectedOption.label;
 
     if (filterValueTabHasChanged) {
-      setQueryStringWithoutPageReload(`?tab=${optionLabel}`);
+      setQueryStringValue("tab", optionLabel);
     }
   };
   render() {

--- a/src/components/UserDetail/index.js
+++ b/src/components/UserDetail/index.js
@@ -8,8 +8,10 @@ import {
   USER_DETAIL_TAB_PROPOSALS,
   USER_DETAIL_TAB_COMMENTS
 } from "../../constants";
-import { setQueryStringWithoutPageReload } from "../../helpers";
-import qs from "query-string";
+import {
+  setQueryStringValue,
+  getQueryStringValue
+} from "../../lib/queryString";
 
 const userDetailOptions = [
   {
@@ -42,9 +44,8 @@ class UserDetail extends Component {
     this.handleUpdateQueryForFilterValueChange(prevState);
   }
 
-  handleUpdateFilterValueForQueryValue = props => {
-    const { location } = props;
-    const { tab } = qs.parse(location.search);
+  handleUpdateFilterValueForQueryValue = () => {
+    const tab = getQueryStringValue("tab");
     const validTabOption = userDetailOptions.find(op => op.label === tab);
     return validTabOption ? validTabOption.value : USER_DETAIL_TAB_GENERAL;
   };
@@ -54,7 +55,7 @@ class UserDetail extends Component {
       op => op.value === this.state.tabId
     );
     filterValueTabHasChanged &&
-      setQueryStringWithoutPageReload(`?tab=${selectedOption.label}`);
+      setQueryStringValue("tab", selectedOption.label);
   };
 
   componentDidMount() {

--- a/src/components/snew/CommentArea.js
+++ b/src/components/snew/CommentArea.js
@@ -11,14 +11,28 @@ import {
   SORT_BY_NEW,
   PROPOSAL_STATUS_UNREVIEWED_CHANGES
 } from "../../constants";
-import qs from "query-string";
+import {
+  setQueryStringValue,
+  getQueryStringValue
+} from "../../lib/queryString";
 
 class CommentArea extends React.Component {
   componentDidMount() {
     const { comments } = this.props;
-    const { comments: scrollToComments } = qs.parse(this.props.location.search);
+    // see if the comment parameter is in the query string if it is the page is
+    // scrolled to the top of the comments area
+    const scrollToComments = getQueryStringValue("comments");
     if (comments && scrollToComments) {
       this.scrollToCommentArea();
+    }
+
+    // get the comment sort option from the query string. If it specified
+    // and valid, the sort option should be changed.
+    const sort = getQueryStringValue("sort");
+    const validSortOptionFromQueryString =
+      sort && [SORT_BY_NEW, SORT_BY_OLD, SORT_BY_TOP].find(o => o === sort);
+    if (validSortOptionFromQueryString) {
+      this.props.onSetCommentsSortOption({ value: sort, label: sort });
     }
   }
   scrollToCommentArea = () => {
@@ -30,12 +44,18 @@ class CommentArea extends React.Component {
       window.scrollTo(0, window.scrollY - additionalHeightToBypassHeader);
     }
   };
+  onSetCommentsSortOption = option => {
+    // set the coment option in the query string
+    setQueryStringValue("sort", option.value);
+
+    // set the comment option in the app state
+    this.props.onSetCommentsSortOption(option);
+  };
   render() {
     const {
       comments,
       loggedInAsEmail,
       proposal,
-      onSetCommentsSortOption,
       commentsSortOption,
       commentid,
       onViewAllClick,
@@ -72,7 +92,7 @@ class CommentArea extends React.Component {
                   isClearable={false}
                   escapeClearsValue={false}
                   value={commentsSortOption}
-                  onChange={onSetCommentsSortOption}
+                  onChange={this.onSetCommentsSortOption}
                   options={[SORT_BY_NEW, SORT_BY_OLD, SORT_BY_TOP].map(op => ({
                     value: op,
                     label: op

--- a/src/configureStore.js
+++ b/src/configureStore.js
@@ -2,38 +2,41 @@ import { createStore, applyMiddleware, compose } from "redux";
 import thunkMiddleware from "redux-thunk";
 import { createLogger } from "redux-logger";
 import rootReducer from "./reducers";
-import { loadStateLocalStorage } from "./lib/local_storage";
 
-const configureStore = preloadedState => {
-  if (process.env.NODE_ENV === "production") {
-    return createStore(
-      rootReducer,
-      {
-        ...loadStateLocalStorage,
-        ...preloadedState
-      },
-      compose(applyMiddleware(thunkMiddleware))
-    );
-  } else {
-    const composeEnhancers =
-      typeof window === "object" && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
-        ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
-            // Specify extension’s options like name, actionsBlacklist, actionsCreators, serialize...
-          })
-        : compose;
-    const loggerMiddleware = createLogger();
+const getComposer = () => {
+  const isProductionEnv = process.env.NODE_ENV === "production";
+  const browserHasReduxDevTools =
+    typeof window === "object" && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__;
 
-    const middlewares = [
-      thunkMiddleware,
-      process.env.REACT_APP_USE_REDUX_LOGGER && loggerMiddleware
-    ].filter(Boolean);
-
-    return createStore(
-      rootReducer,
-      { ...loadStateLocalStorage, ...preloadedState },
-      composeEnhancers(applyMiddleware(...middlewares))
-    );
+  if (!isProductionEnv && browserHasReduxDevTools) {
+    return window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
+      // Specify extension’s options like name, actionsBlacklist, actionsCreators, serialize...
+    });
   }
+
+  return compose;
+};
+
+const getMiddlewares = () => {
+  const loggerMiddleware = createLogger();
+  const isProductionEnv = process.env.NODE_ENV === "production";
+  const reduxLoggerIsOn = process.env.REACT_APP_USE_REDUX_LOGGER;
+  const middlewares = [
+    thunkMiddleware,
+    !isProductionEnv && reduxLoggerIsOn && loggerMiddleware
+  ].filter(Boolean);
+
+  return middlewares;
+};
+
+const configureStore = (preloadedState = {}) => {
+  const composeEnhancers = getComposer();
+  const middlewares = getMiddlewares();
+  return createStore(
+    rootReducer,
+    preloadedState,
+    composeEnhancers(applyMiddleware(...middlewares))
+  );
 };
 
 export default configureStore;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -277,16 +277,6 @@ export const formatDate = date => {
   return `${year}-${month}-${day}-${hours}:${minutes}:${seconds}`;
 };
 
-export const setQueryStringWithoutPageReload = qs => {
-  const newurl =
-    window.location.protocol +
-    "//" +
-    window.location.host +
-    window.location.pathname +
-    qs;
-  window.history.pushState({ path: newurl }, "", newurl);
-};
-
 export const getJsonData = base64 => {
   const data = atob(base64.split(",").pop());
   try {

--- a/src/lib/queryString.js
+++ b/src/lib/queryString.js
@@ -1,0 +1,32 @@
+import qs from "query-string";
+
+export const setQueryStringWithoutPageReload = qsValue => {
+  const newurl =
+    window.location.protocol +
+    "//" +
+    window.location.host +
+    window.location.pathname +
+    qsValue;
+  window.history.pushState({ path: newurl }, "", newurl);
+};
+
+export const getQueryStringValue = (
+  key,
+  queryString = window.location.search
+) => {
+  const values = qs.parse(queryString);
+  return values[key];
+};
+
+export const setQueryStringValue = (
+  key,
+  value,
+  queryString = window.location.search
+) => {
+  const values = qs.parse(queryString);
+  const newQsValue = qs.stringify({
+    ...values,
+    [key]: value
+  });
+  setQueryStringWithoutPageReload(`?${newQsValue}`);
+};

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -6,7 +6,7 @@ import {
   PROPOSAL_FILTER_ALL,
   PAYWALL_STATUS_PAID,
   PROPOSAL_USER_FILTER_SUBMITTED,
-  SORT_BY_NEW
+  SORT_BY_TOP
 } from "../constants";
 
 export const DEFAULT_STATE = {
@@ -26,7 +26,7 @@ export const DEFAULT_STATE = {
   draftProposals: null,
   identityImportResult: { errorMsg: "", successMsg: "" },
   onboardViewed: false,
-  commentsSortOption: { value: SORT_BY_NEW, label: SORT_BY_NEW },
+  commentsSortOption: { value: SORT_BY_TOP, label: SORT_BY_TOP },
   pollingCreditsPayment: false,
   redirectedFrom: null
 };

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -366,10 +366,10 @@ export const getUnvettedProposalFilterCounts = state => {
     : {};
 };
 
-const countAbandonedProposals = proposals =>
+const countAbandonedProposals = (proposals = []) =>
   proposals.filter(p => p.status === PROPOSAL_STATUS_ABANDONED).length;
 
-const countApprovedProps = votesstatus =>
+const countApprovedProps = (votesstatus = []) =>
   votesstatus.filter(vs => {
     if (vs.status === PROPOSAL_VOTING_FINISHED) {
       return isProposalApproved(vs);
@@ -377,7 +377,7 @@ const countApprovedProps = votesstatus =>
     return false;
   }).length;
 
-const countRejectedProps = votesstatus =>
+const countRejectedProps = (votesstatus = []) =>
   votesstatus.filter(vs => {
     if (vs.status === PROPOSAL_VOTING_FINISHED) {
       return !isProposalApproved(vs);


### PR DESCRIPTION
This PR:
1. Set "Top" as the default comment sort option.
2. Persist the comment sort option in the local storage.

1 and 2 were mentioned on #1022
