### PR TITLE
fix external link handler and url preview

### DIFF
--- a/src/components/Modal/ModalStack.js
+++ b/src/components/Modal/ModalStack.js
@@ -13,7 +13,7 @@ class ModalStack extends React.Component {
 
   componentDidUpdate(prevProps) {
     const { openedModals, location, closeAllModals } = this.props;
-    const welcomeModal = openedModals.filter(
+    const welcomeModalOpened = openedModals.find(
       modal => modal.type === WELCOME_MODAL
     );
     const { modals } = this.state;
@@ -34,7 +34,10 @@ class ModalStack extends React.Component {
         else document.querySelector("body").style.overflowY = "scroll";
       });
     // closes modals if user path has changed except when it's the user's first access
-    if (location.pathname !== prevProps.location.pathname && !welcomeModal) {
+    if (
+      location.pathname !== prevProps.location.pathname &&
+      !welcomeModalOpened
+    ) {
       closeAllModals();
     }
   }

--- a/src/components/snew/Markdown/helpers.js
+++ b/src/components/snew/Markdown/helpers.js
@@ -215,7 +215,7 @@ const verifyExternalLink = (e, link, confirmWithModal) => {
                 {" "}
                 {tmpLink.protocol + "//"}
                 <strong className="red">{tmpLink.hostname}</strong>
-                {tmpLink.pathname}
+                {tmpLink.pathname + tmpLink.search + tmpLink.hash}
               </span>
             </div>
           </div>


### PR DESCRIPTION
Closes #1047 

Fixes onClose behavior when path changes for modals. Also updates URL preview in external link modal to show entire url, including query strings and fragment identifiers