### PR TITLE
Update commentslikes test route

### DIFF
--- a/src/actions/tests/api.test.js
+++ b/src/actions/tests/api.test.js
@@ -508,20 +508,40 @@ describe("test api actions (actions/api.js)", () => {
   });
 
   test("on fetch liked comments action", async () => {
-    const path = `/api/v1/proposals/${FAKE_PROPOSAL_TOKEN}/commentslikes`;
-    const params = [FAKE_PROPOSAL_TOKEN];
-    await assertApiActionOnSuccess(path, api.onFetchLikedComments, params, [
-      { type: act.REQUEST_LIKED_COMMENTS },
-      { type: act.RECEIVE_LIKED_COMMENTS, error: false, payload: {} }
-    ]);
-    await assertApiActionOnError(path, api.onFetchLikedComments, params, () => [
+    const path = `/api/v1/user/proposals/${FAKE_PROPOSAL_TOKEN}/commentslikes`;
+    const params = [FAKE_PROPOSAL_TOKEN, FAKE_USER.id];
+    await assertApiActionOnSuccess(
+      path,
+      api.onFetchLikedComments,
+      params,
+      [
+        { type: act.REQUEST_LIKED_COMMENTS },
+        { type: act.RECEIVE_LIKED_COMMENTS, error: false, payload: {} }
+      ],
       {
-        type: act.REQUEST_LIKED_COMMENTS,
-        error: false,
-        payload: FAKE_PROPOSAL_TOKEN
-      },
-      { type: act.RECEIVE_LIKED_COMMENTS, error: false, payload: {} }
-    ]);
+        query: {
+          userid: FAKE_USER.id
+        }
+      }
+    );
+    await assertApiActionOnError(
+      path,
+      api.onFetchLikedComments,
+      params,
+      () => [
+        {
+          type: act.REQUEST_LIKED_COMMENTS,
+          error: false,
+          payload: FAKE_PROPOSAL_TOKEN
+        },
+        { type: act.RECEIVE_LIKED_COMMENTS, error: false, payload: {} }
+      ],
+      {
+        query: {
+          userid: FAKE_USER.id
+        }
+      }
+    );
   });
 
   test("on fetch proposal action", async () => {


### PR DESCRIPTION
Closes #1115 

This updates the incorrect route for `commentslikes`. 