### PR TITLE
Fetch lastblockheight on proposal detail view

### DIFF
--- a/src/components/RecordDetail/RecordDetail.js
+++ b/src/components/RecordDetail/RecordDetail.js
@@ -21,7 +21,18 @@ class RecordDetail extends React.Component {
       accessTime: 0
     };
   }
-
+  resolveTabTitle = prevProps => {
+    const { isCMS, record } = this.props;
+    const proposal = !isCMS && record;
+    const proposalNameHasBeenUpdated =
+      (proposal &&
+        prevProps.record &&
+        prevProps.record.name !== proposal.name) ||
+      (proposal && proposal.name !== document.title);
+    if (proposalNameHasBeenUpdated) {
+      document.title = proposal.name;
+    }
+  };
   resolveFetchProposalVoteStatus = prevProps => {
     const { isCMS, record, onFetchProposalVoteStatus, token } = this.props;
     const proposal = !isCMS && record;
@@ -41,6 +52,7 @@ class RecordDetail extends React.Component {
     }
   };
   componentDidUpdate(prevProps) {
+    this.resolveTabTitle(prevProps);
     this.resolveFetchProposalVoteStatus(prevProps);
     this.resolveFetchLikedComments(prevProps);
     this.handleUpdateOfComments(prevProps, this.props);
@@ -156,12 +168,6 @@ class RecordDetail extends React.Component {
     const data = !isCMS
       ? proposalToT3(record, 0).data
       : invoiceToT3(record, 0).data;
-    const currentTitle =
-      (data.title !== "(Proposal name hidden)" &&
-        data.url === this.props.location.pathname) === false
-        ? "Politeia"
-        : data.title;
-    document.title = currentTitle;
 
     // when dealing with proposals, extract the text content from the markdown
     // file

--- a/src/components/RecordDetail/RecordDetail.js
+++ b/src/components/RecordDetail/RecordDetail.js
@@ -21,15 +21,7 @@ class RecordDetail extends React.Component {
       accessTime: 0
     };
   }
-  resolveTabTitle = prevProps => {
-    const { isCMS, record } = this.props;
-    const proposal = !isCMS && record;
-    const proposalNameHasBeenUpdated =
-      proposal && prevProps.record && prevProps.record.name !== proposal.name;
-    if (proposalNameHasBeenUpdated) {
-      document.title = proposal.name;
-    }
-  };
+
   resolveFetchProposalVoteStatus = prevProps => {
     const { isCMS, record, onFetchProposalVoteStatus, token } = this.props;
     const proposal = !isCMS && record;
@@ -49,7 +41,6 @@ class RecordDetail extends React.Component {
     }
   };
   componentDidUpdate(prevProps) {
-    this.resolveTabTitle(prevProps);
     this.resolveFetchProposalVoteStatus(prevProps);
     this.resolveFetchLikedComments(prevProps);
     this.handleUpdateOfComments(prevProps, this.props);
@@ -165,6 +156,12 @@ class RecordDetail extends React.Component {
     const data = !isCMS
       ? proposalToT3(record, 0).data
       : invoiceToT3(record, 0).data;
+    const currentTitle =
+      (data.title !== "(Proposal name hidden)" &&
+        data.url === this.props.location.pathname) === false
+        ? "Politeia"
+        : data.title;
+    document.title = currentTitle;
 
     // when dealing with proposals, extract the text content from the markdown
     // file

--- a/src/components/snew/Content.js
+++ b/src/components/snew/Content.js
@@ -250,12 +250,6 @@ class Loader extends Component {
     const { getLastBlockHeight, isTestnet } = this.props;
     if (isFetched) return;
     else if (csrf) {
-      console.log("hello this is where I get blockheight");
-      console.log(
-        "this.props.onFetchProposalsVoteStatus",
-        this.props.onFetchProposalsVoteStatus
-      );
-      console.log("getLastBlockHeigh", getLastBlockHeight);
       this.setState({ isFetched: true });
       this.props.onFetchData && this.props.onFetchData();
       this.props.onFetchStatus && this.props.onFetchStatus();

--- a/src/components/snew/Content.js
+++ b/src/components/snew/Content.js
@@ -256,8 +256,7 @@ class Loader extends Component {
       !this.props.isCMS &&
         ((this.props.onFetchProposalsVoteStatus &&
           this.props.onFetchProposalsVoteStatus()) ||
-          (this.props.onFetchProposalVoteStatus &&
-            this.props.onFetchProposalVoteStatus())) &&
+          this.props.onFetchProposalVoteStatus) &&
         getLastBlockHeight &&
         getLastBlockHeight(isTestnet);
     }

--- a/src/components/snew/Content.js
+++ b/src/components/snew/Content.js
@@ -250,12 +250,20 @@ class Loader extends Component {
     const { getLastBlockHeight, isTestnet } = this.props;
     if (isFetched) return;
     else if (csrf) {
+      console.log("hello this is where I get blockheight");
+      console.log(
+        "this.props.onFetchProposalsVoteStatus",
+        this.props.onFetchProposalsVoteStatus
+      );
+      console.log("getLastBlockHeigh", getLastBlockHeight);
       this.setState({ isFetched: true });
       this.props.onFetchData && this.props.onFetchData();
       this.props.onFetchStatus && this.props.onFetchStatus();
       !this.props.isCMS &&
-        this.props.onFetchProposalsVoteStatus &&
-        this.props.onFetchProposalsVoteStatus() &&
+        ((this.props.onFetchProposalsVoteStatus &&
+          this.props.onFetchProposalsVoteStatus()) ||
+          (this.props.onFetchProposalVoteStatus &&
+            this.props.onFetchProposalVoteStatus())) &&
         getLastBlockHeight &&
         getLastBlockHeight(isTestnet);
     }


### PR DESCRIPTION
Closes #1130 

This commit fixes the incorrect conditional statement which only fetched the last block height whenever `onFetchProposalsVoteStatus` was called. The statement was updated to also fetch the last block height whenever `onFetchProposalVoteStatus` was called.

Commit also fixes the bug where document.title was not being correctly set according to the proposal name