### PR TITLE
Add privacy policy to separate page

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -36,6 +36,7 @@ import UserDetail from "./components/UserDetail";
 import AuthenticatedRoute from "./components/Router/AuthenticatedRoute";
 import AdminAuthenticatedRoute from "./components/Router/AdminAuthenticatedRoute";
 import PublicProposalsPage from "./components/PublicProposalsPage/PublicProposalsPage";
+import PrivacyPolicy from "./components/snew/PrivacyPolicy";
 
 // CMS CONNECTORS
 import adminCMS from "./connectors/adminCMS";
@@ -175,6 +176,7 @@ const RoutesForPoliteia = () => {
         path="/user/resend/next"
         component={ResendVerificationEmailSuccess}
       />
+      <Route path="/privacy-policy/" component={PrivacyPolicy} />
       <AdminAuthenticatedRoute
         path="/admin"
         component={admin(ProposalListing)}

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -85,6 +85,7 @@ const RoutesForCMS = () => {
         path="/user/resend/next"
         component={ResendVerificationEmailSuccess}
       />
+      <Route path="/privacy-policy/" component={PrivacyPolicy} />
       <AdminAuthenticatedRoute
         path="/admin"
         component={adminCMS(ProposalListing)}

--- a/src/components/snew/LoginForm.js
+++ b/src/components/snew/LoginForm.js
@@ -4,7 +4,6 @@ import Message from "../Message";
 import ButtonWithLoadingIcon from "./ButtonWithLoadingIcon";
 import ErrorField from "../Form/Fields/ErrorField";
 import loginConnector from "../../connectors/login";
-import PrivacyPolicy from "./PrivacyPolicy";
 
 const LoginForm = ({
   Link,
@@ -14,10 +13,7 @@ const LoginForm = ({
   loggedInAsEmail,
   apiLoginError,
   onLogin,
-  handleSubmit,
-  onTogglePrivacyPolicy,
-  onHidePrivacyPolicy,
-  showPrivacyPolicy
+  handleSubmit
 }) =>
   loggedInAsEmail ? null : (
     <form
@@ -89,18 +85,14 @@ const LoginForm = ({
         >
           Reset Password
         </Link>
-        <span
-          className="linkish c-pull-right reset-password-link"
-          tabIndex={5}
-          onClick={onTogglePrivacyPolicy}
-          style={{ cursor: "pointer" }}
+        <Link
+          className="c-pull-right reset-password-link"
+          href="/privacy-policy"
+          tabIndex={4}
         >
           Privacy Policy
-        </span>
+        </Link>
       </div>
-      {showPrivacyPolicy && (
-        <PrivacyPolicy onHidePrivacyPolicy={onHidePrivacyPolicy} />
-      )}
     </form>
   );
 

--- a/src/components/snew/LoginFormSide.js
+++ b/src/components/snew/LoginFormSide.js
@@ -4,7 +4,6 @@ import ErrorField from "../Form/Fields/ErrorField";
 import Message from "../Message";
 import ButtonWithLoadingIcon from "./ButtonWithLoadingIcon";
 import loginConnector from "../../connectors/login";
-import PrivacyPolicy from "./PrivacyPolicy";
 
 const LoginFormSide = ({
   Link,
@@ -14,10 +13,7 @@ const LoginFormSide = ({
   loggedInAsEmail,
   formAction = "/post/login",
   onLogin,
-  handleSubmit,
-  onTogglePrivacyPolicy,
-  onHidePrivacyPolicy,
-  showPrivacyPolicy
+  handleSubmit
 }) =>
   loggedInAsEmail ? null : (
     <div className="spacer">
@@ -67,13 +63,13 @@ const LoginFormSide = ({
             type="checkbox"
           />
           <label htmlFor="rem-login-main">remember me</label>
-          <span
-            onClick={onTogglePrivacyPolicy}
-            className="linkish"
+          <Link
+            className="recover-password"
+            href="/privacy-policy"
             style={{ marginRight: "10px" }}
           >
             Privacy Policy
-          </span>
+          </Link>
           <Link className="recover-password" href="/password">
             Reset Password
           </Link>
@@ -86,9 +82,6 @@ const LoginFormSide = ({
           />
         </div>
         <div className="clear" />
-        {showPrivacyPolicy && (
-          <PrivacyPolicy onHidePrivacyPolicy={onHidePrivacyPolicy} />
-        )}
       </form>
     </div>
   );

--- a/src/components/snew/PrivacyPolicy.js
+++ b/src/components/snew/PrivacyPolicy.js
@@ -1,10 +1,15 @@
 import React from "react";
 import Link from "./Link";
-import { PROPOSALS_REPOSITORY } from "../../constants";
+import {
+  TESTNET_PROPOSALS_REPOSITORY,
+  MAINNET_PROPOSALS_REPOSITORY
+} from "../../constants";
+import privacyConnector from "../../connectors/privacy";
 
 class PrivacyPolicy extends React.Component {
   render() {
-    const { isCMS } = this.props;
+    const { isCMS, isTestnet } = this.props;
+    console.log(this.props);
     return (
       <div
         className="content page signup-next-step-page"
@@ -31,19 +36,65 @@ class PrivacyPolicy extends React.Component {
                   <li>
                     In the interests of transparency, data associating your
                     public key with content contributions will be published
-                    openly in the Decred-proposals repository here: {" "}
+                    openly in the Decred-proposals repository here:{" "}
                     <a
                       target="_blank"
                       rel="noopener noreferrer"
-                      href={PROPOSALS_REPOSITORY}
+                      href={
+                        isTestnet
+                          ? TESTNET_PROPOSALS_REPOSITORY
+                          : MAINNET_PROPOSALS_REPOSITORY
+                      }
                       style={{ fontSize: "1.01em" }}
                     >
-                      {`${PROPOSALS_REPOSITORY}`}
+                      {`${
+                        isTestnet
+                          ? TESTNET_PROPOSALS_REPOSITORY
+                          : MAINNET_PROPOSALS_REPOSITORY
+                      }`}
                     </a>
                   </li>
                 </ul>
               </React.Fragment>
-            ) : null}
+            ) : (
+              <React.Fragment>
+                <h3>Privacy Policy</h3>
+                <ul>
+                  <li>
+                    The <Link href="/">proposals.decred.org</Link> database
+                    stores your account email address, username, cryptographic
+                    identity public key(s), IP addresses and payment transaction
+                    details - and associates this data with all of your
+                    proposals, comments and up/down votes.
+                  </li>
+                  <li>
+                    Your email address will be kept private and will not be
+                    shared with any third parties.
+                  </li>
+                  <li>
+                    In the interests of transparency, data associating your
+                    public key with content contributions will be published
+                    openly in the Decred-proposals repository here:{" "}
+                    <a
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      href={
+                        isTestnet
+                          ? TESTNET_PROPOSALS_REPOSITORY
+                          : MAINNET_PROPOSALS_REPOSITORY
+                      }
+                      style={{ fontSize: "1.01em" }}
+                    >
+                      {`${
+                        isTestnet
+                          ? TESTNET_PROPOSALS_REPOSITORY
+                          : MAINNET_PROPOSALS_REPOSITORY
+                      }`}
+                    </a>
+                  </li>
+                </ul>
+              </React.Fragment>
+            )}
           </div>
         </div>
       </div>
@@ -51,4 +102,4 @@ class PrivacyPolicy extends React.Component {
   }
 }
 
-export default PrivacyPolicy;
+export default privacyConnector(PrivacyPolicy);

--- a/src/components/snew/PrivacyPolicy.js
+++ b/src/components/snew/PrivacyPolicy.js
@@ -74,23 +74,7 @@ class PrivacyPolicy extends React.Component {
                   <li>
                     In the interests of transparency, data associating your
                     public key with content contributions will be published
-                    openly in the Decred-proposals repository here:{" "}
-                    <a
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      href={
-                        isTestnet
-                          ? TESTNET_PROPOSALS_REPOSITORY
-                          : MAINNET_PROPOSALS_REPOSITORY
-                      }
-                      style={{ fontSize: "1.01em" }}
-                    >
-                      {`${
-                        isTestnet
-                          ? TESTNET_PROPOSALS_REPOSITORY
-                          : MAINNET_PROPOSALS_REPOSITORY
-                      }`}
-                    </a>
+                    openly in the Decred-proposals repository here:
                   </li>
                 </ul>
               </React.Fragment>

--- a/src/components/snew/PrivacyPolicy.js
+++ b/src/components/snew/PrivacyPolicy.js
@@ -1,4 +1,6 @@
 import React from "react";
+import Link from "./Link";
+import { PROPOSALS_REPOSITORY } from "../../constants";
 
 class PrivacyPolicy extends React.Component {
   render() {
@@ -16,11 +18,11 @@ class PrivacyPolicy extends React.Component {
                 <h3>Privacy Policy</h3>
                 <ul>
                   <li>
-                    The proposals.decred.org database stores your account email
-                    address, user-name, cryptographic identity public key(s), IP
-                    addresses and payment transaction details - and associates
-                    this data with all of your proposals, comments and up/down
-                    votes.
+                    The <Link href="/">proposals.decred.org</Link> database
+                    stores your account email address, username, cryptographic
+                    identity public key(s), IP addresses and payment transaction
+                    details - and associates this data with all of your
+                    proposals, comments and up/down votes.
                   </li>
                   <li>
                     Your email address will be kept private and will not be
@@ -29,7 +31,15 @@ class PrivacyPolicy extends React.Component {
                   <li>
                     In the interests of transparency, data associating your
                     public key with content contributions will be published
-                    openly in the Decred-proposals repository.
+                    openly in the Decred-proposals repository here: {" "}
+                    <a
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      href={PROPOSALS_REPOSITORY}
+                      style={{ fontSize: "1.01em" }}
+                    >
+                      {`${PROPOSALS_REPOSITORY}`}
+                    </a>
                   </li>
                 </ul>
               </React.Fragment>

--- a/src/components/snew/PrivacyPolicy.js
+++ b/src/components/snew/PrivacyPolicy.js
@@ -1,27 +1,44 @@
 import React from "react";
-import Message from "../Message";
 
-const PrivacyPolicy = ({ onHidePrivacyPolicy }) => (
-  <div>
-    <Message type="info" header="Privacy Policy">
-      <p>
-        The Politeia database stores your account email address, user-name,
-        cryptographic identity public key(s) [and IP] and associates this with
-        all of your proposals, comments and up/down votes. Your email address
-        will be kept private and will not be shared with any third parties. Data
-        associating your user-name with content contributions will be published
-        openly, in the interests of transparency.
-      </p>
-      <span
-        className="linkish"
-        onClick={onHidePrivacyPolicy}
-        tabIndex={6}
-        style={{ cursor: "pointer" }}
+class PrivacyPolicy extends React.Component {
+  render() {
+    const { isCMS } = this.props;
+    return (
+      <div
+        className="content page signup-next-step-page"
+        role="main"
+        style={{ minHeight: "calc(100vh - 350px)" }}
       >
-        Hide
-      </span>
-    </Message>
-  </div>
-);
+        <div className="text-wrapper">
+          <div className="centered">
+            {!isCMS ? (
+              <React.Fragment>
+                <h3>Privacy Policy</h3>
+                <ul>
+                  <li>
+                    The proposals.decred.org database stores your account email
+                    address, user-name, cryptographic identity public key(s), IP
+                    addresses and payment transaction details - and associates
+                    this data with all of your proposals, comments and up/down
+                    votes.
+                  </li>
+                  <li>
+                    Your email address will be kept private and will not be
+                    shared with any third parties.
+                  </li>
+                  <li>
+                    In the interests of transparency, data associating your
+                    public key with content contributions will be published
+                    openly in the Decred-proposals repository.
+                  </li>
+                </ul>
+              </React.Fragment>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
 
 export default PrivacyPolicy;

--- a/src/components/snew/PrivacyPolicy.js
+++ b/src/components/snew/PrivacyPolicy.js
@@ -61,20 +61,15 @@ class PrivacyPolicy extends React.Component {
                 <h3>Privacy Policy</h3>
                 <ul>
                   <li>
-                    The <Link href="/">proposals.decred.org</Link> database
-                    stores your account email address, username, cryptographic
-                    identity public key(s), IP addresses and payment transaction
-                    details - and associates this data with all of your
-                    proposals, comments and up/down votes.
+                    The <Link href="/">cms.decred.org</Link> database stores
+                    your account email address, username, cryptographic identity
+                    public key(s), IP addresses and invoice transaction details
+                    - and associates this data with all of your invoices,
+                    comments and up/down votes.
                   </li>
                   <li>
                     Your email address will be kept private and will not be
                     shared with any third parties.
-                  </li>
-                  <li>
-                    In the interests of transparency, data associating your
-                    public key with content contributions will be published
-                    openly in the Decred-proposals repository here:
                   </li>
                 </ul>
               </React.Fragment>

--- a/src/components/snew/PrivacyPolicy.js
+++ b/src/components/snew/PrivacyPolicy.js
@@ -9,7 +9,6 @@ import privacyConnector from "../../connectors/privacy";
 class PrivacyPolicy extends React.Component {
   render() {
     const { isCMS, isTestnet } = this.props;
-    console.log(this.props);
     return (
       <div
         className="content page signup-next-step-page"

--- a/src/connectors/privacy.js
+++ b/src/connectors/privacy.js
@@ -1,0 +1,13 @@
+import { connect } from "react-redux";
+import { bindActionCreators } from "redux";
+import * as sel from "../selectors";
+
+const privacyConnector = connect(
+  sel.selectorMap({
+    isCMS: sel.isCMS,
+    isTestnet: sel.isTestNet
+  }),
+  dispatch => bindActionCreators({}, dispatch)
+);
+
+export default privacyConnector;

--- a/src/constants.js
+++ b/src/constants.js
@@ -84,7 +84,9 @@ export const LOAD_KEY_FAILED =
 export const PI_DOCS = "https://docs.decred.org/governance/politeia/politeia/";
 export const PROPOSAL_GUIDELINES =
   "https://docs.decred.org/governance/politeia/proposal-guidelines/";
-export const PROPOSALS_REPOSITORY =
+export const TESTNET_PROPOSALS_REPOSITORY =
+  "https://github.com/decred-proposals/testnet3";
+export const MAINNET_PROPOSALS_REPOSITORY =
   "https://github.com/decred-proposals/mainnet/";
 
 export const INVOICE_STATUS_INVALID = 0; // Invalid status XXX?

--- a/src/constants.js
+++ b/src/constants.js
@@ -84,6 +84,8 @@ export const LOAD_KEY_FAILED =
 export const PI_DOCS = "https://docs.decred.org/governance/politeia/politeia/";
 export const PROPOSAL_GUIDELINES =
   "https://docs.decred.org/governance/politeia/proposal-guidelines/";
+export const PROPOSALS_REPOSITORY =
+  "https://github.com/decred-proposals/mainnet/";
 
 export const INVOICE_STATUS_INVALID = 0; // Invalid status XXX?
 export const INVOICE_STATUS_NOTFOUND = 1; // Invoice not found XXX?


### PR DESCRIPTION
Closes #771 

This commit adds a new route (`/privacy-policy`) to show the privacy policy on a separate page. This route replaces the current link on the login page as well as the sidebar, which simply opens up a message box.

Commit also updates the copy to reflect @RichardRed0x 's minor changes

edit:
Here's a screenshot of the new page 

<img width="1279" alt="privacy-policy-screenshot" src="https://user-images.githubusercontent.com/42082827/56917441-1bb9d600-6a81-11e9-9ec9-609d5683aea0.png">
