### PR TITLE
Remove references to insight

### DIFF
--- a/src/actions/tests/external_api.test.js
+++ b/src/actions/tests/external_api.test.js
@@ -29,7 +29,6 @@ describe("test actions/external_api", () => {
 
   const mockPiVerifyPaymentPath = "/api/v1/user/verifypayment";
   const mockDcrDataPath = `https://testnet.dcrdata.org/api/address/${FAKE_ADDRESS}/raw`;
-  const mockInsightPath = `https://testnet.decred.org/api/addr/${FAKE_ADDRESS}/utxo?noCache=1`;
   const mockDcrDataResponseLackingConfirmation = [
     {
       size: 251,
@@ -154,9 +153,6 @@ describe("test actions/external_api", () => {
 
   test("test verify user payment action", async () => {
     const params = [FAKE_ADDRESS, AMOUNT, FAKE_TX_NOT_BEFORE];
-
-    //mock dcr insight response
-    setGetSuccessResponse(mockInsightPath, {}, []);
 
     //test with payment confirmed by the network
     setGetSuccessResponse(mockDcrDataPath, {}, mockDcrDataResponseComplete);

--- a/src/lib/external_api.js
+++ b/src/lib/external_api.js
@@ -1,22 +1,15 @@
-import { TESTNET, MAINNET, EXPLORER } from "../constants";
+import { TESTNET, EXPLORER } from "../constants";
 
 const getSubdomainForDcrdata = isTestnet => (isTestnet ? TESTNET : EXPLORER);
-const getSubdomainForInsight = isTestnet => (isTestnet ? TESTNET : MAINNET);
 
 const dcrdataURL = isTestnet =>
   `https://${getSubdomainForDcrdata(isTestnet)}.dcrdata.org/api`;
-const insightURL = isTestnet =>
-  `https://${getSubdomainForInsight(isTestnet)}.decred.org/insight/api`;
 
 export const dcrddataBlockHeightURL = isTestnet =>
   `${dcrdataURL(isTestnet)}/block/best/height`;
-export const insightBlockHeightURL = isTestnet =>
-  `${insightURL(isTestnet)}/status`;
 
 const dcrdataAddressURL = (isTestnet, address) =>
   `${dcrdataURL(isTestnet)}/address/${address}/raw`;
-const insightAddressURL = (isTestnet, address) =>
-  `${insightURL(isTestnet)}/addr/${address}/utxo?noCache=1`;
 const FAUCET_URL = "https://faucet.decred.org/requestfaucet";
 
 const POST = (path, params, method = "POST") => {
@@ -58,17 +51,9 @@ const addressFromTestnet = addr => addr[0] === "T";
 export const getHeightByDcrdata = isTestnet =>
   getRawTransactions(dcrddataBlockHeightURL(isTestnet));
 
-export const getHeightByInsight = isTestnet =>
-  getRawTransactions(insightBlockHeightURL(isTestnet));
-
 export const getPaymentsByAddressDcrdata = address => {
   const isTestnet = addressFromTestnet(address);
   return getRawTransactions(dcrdataAddressURL(isTestnet, address));
-};
-
-export const getPaymentsByAddressInsight = address => {
-  const isTestnet = addressFromTestnet(address);
-  return getRawTransactions(insightAddressURL(isTestnet, address));
 };
 
 export const payWithFaucet = (address, amount) => {

--- a/src/lib/tests/external_api.test.js
+++ b/src/lib/tests/external_api.test.js
@@ -9,8 +9,6 @@ describe("test external api lib (lib/api.js)", () => {
   const FAKE_MAINNET_ADDRESS = "M_fake_address";
   const dcrdataTestnetUrl = "https://testnet.dcrdata.org/api";
   const dcrdataExplorerUrl = "https://explorer.dcrdata.org/api";
-  const insightTestnetUrl = "https://testnet.decred.org/insight/api";
-  const insightMainnetUrl = "https://mainnet.decred.org/insight/api";
   const faucetUrl = "https://faucet.decred.org/requestfaucet";
 
   test("get height from dcrd data", async () => {
@@ -27,19 +25,6 @@ describe("test external api lib (lib/api.js)", () => {
     );
   });
 
-  test("get height from Insight", async () => {
-    await assertGETOnRouteIsCalled(
-      `${insightTestnetUrl}/status`,
-      ea.getHeightByInsight,
-      [true]
-    );
-    await assertGETOnRouteIsCalled(
-      `${insightMainnetUrl}/status`,
-      ea.getHeightByInsight,
-      [false]
-    );
-  });
-
   test("get payment by address from dcr data", async () => {
     fetchMock.restore();
     await assertGETOnRouteIsCalled(
@@ -50,19 +35,6 @@ describe("test external api lib (lib/api.js)", () => {
     await assertGETOnRouteIsCalled(
       `${dcrdataExplorerUrl}/address/${FAKE_MAINNET_ADDRESS}/raw`,
       ea.getPaymentsByAddressDcrdata,
-      [FAKE_MAINNET_ADDRESS]
-    );
-  });
-
-  test("get payment by address from Insight", async () => {
-    await assertGETOnRouteIsCalled(
-      `${insightTestnetUrl}/addr/${FAKE_TESTNET_ADDRESS}/utxo?noCache=1`,
-      ea.getPaymentsByAddressInsight,
-      [FAKE_TESTNET_ADDRESS]
-    );
-    await assertGETOnRouteIsCalled(
-      `${insightMainnetUrl}/addr/${FAKE_MAINNET_ADDRESS}/utxo?noCache=1`,
-      ea.getPaymentsByAddressInsight,
       [FAKE_MAINNET_ADDRESS]
     );
   });


### PR DESCRIPTION
Closes #1050 

This commit removes all references to the Insight API as this route is now deprecated. 