### PR TITLE
Fix incorrect proposal title insertion

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -40,7 +40,7 @@ export const atou = str => decodeURIComponent(escape(window.atob(str)));
 //
 export const getTextFromIndexMd = file => {
   const text = atou(file.payload);
-  return text.substring(text.indexOf("\n") + 1);
+  return text.substring(text.indexOf("\n\n") + 1);
 };
 
 export const getTextFromJsonToCsv = file => {

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -49,7 +49,7 @@ export const convertJsonToFile = json => ({
 
 export const makeProposal = (name, markdown, attachments = []) => ({
   files: [
-    convertMarkdownToFile(name + "\n" + markdown),
+    convertMarkdownToFile(name + "\n\n" + markdown),
     ...(attachments || [])
   ].map(({ name, mime, payload }) => ({
     name,

--- a/src/lib/tests/api.test.js
+++ b/src/lib/tests/api.test.js
@@ -48,7 +48,7 @@ describe("api integration modules (lib/api.js)", () => {
   test("make a proposal", () => {
     let proposal = api.makeProposal(PROPOSAL_NAME, MARKDOWN, [FILE]);
     let fileFromMarkdown = api.convertMarkdownToFile(
-      PROPOSAL_NAME + "\n" + MARKDOWN
+      PROPOSAL_NAME + "\n\n" + MARKDOWN
     );
     expect(proposal).toEqual({
       files: [
@@ -65,7 +65,7 @@ describe("api integration modules (lib/api.js)", () => {
     // test without providing attachment object
     proposal = api.makeProposal(PROPOSAL_NAME, MARKDOWN);
     fileFromMarkdown = api.convertMarkdownToFile(
-      PROPOSAL_NAME + "\n" + MARKDOWN
+      PROPOSAL_NAME + "\n\n" + MARKDOWN
     );
     expect(proposal).toEqual({
       files: [
@@ -79,7 +79,7 @@ describe("api integration modules (lib/api.js)", () => {
     // test with a falsy attachment
     proposal = api.makeProposal(PROPOSAL_NAME, MARKDOWN, false);
     fileFromMarkdown = api.convertMarkdownToFile(
-      PROPOSAL_NAME + "\n" + MARKDOWN
+      PROPOSAL_NAME + "\n\n" + MARKDOWN
     );
     expect(proposal).toEqual({
       files: [


### PR DESCRIPTION
Closes #1041 

This commit adds an additional newline character to our markdown file after the proposal title, addressing the missing newline in rendered markdown files