### PR TITLE
Add dropdown and tweak some aspects of the datasheet

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -31,7 +31,6 @@ import {
   PROPOSAL_APPROVED,
   PROPOSAL_REJECTED
 } from "../constants";
-import { convertGridToLineItems } from "../components/InvoiceDatasheet/helpers";
 import { fromUSDUnitsToUSDCents } from "../helpers";
 
 export const SET_REPLY_PARENT = "SET_REPLY_PARENT";
@@ -57,14 +56,14 @@ export const onSaveNewInvoice = (
     contact,
     rate,
     address,
-    datasheet,
+    lineitems,
     exchangerate,
     files
   },
   _,
   props
 ) => (dispatch, getState) => {
-  const lineItems = convertGridToLineItems(datasheet);
+  // const lineItems = convertGridToLineItems(datasheet);
   dispatch(
     onSubmitInvoice(
       props.loggedInAsEmail,
@@ -78,7 +77,7 @@ export const onSaveNewInvoice = (
       contact,
       fromUSDUnitsToUSDCents(+rate),
       address,
-      lineItems,
+      lineitems,
       files
     )
   ).then(() => sel.newInvoiceToken(getState()));
@@ -123,14 +122,13 @@ export const onEditInvoice = (
     contact,
     rate,
     address,
-    datasheet,
+    lineitems,
     exchangerate,
     files
   },
   _,
   props
 ) => dispatch => {
-  const lineItems = convertGridToLineItems(datasheet);
   dispatch(
     onSubmitEditedInvoice(
       props.loggedInAsEmail,
@@ -144,7 +142,7 @@ export const onEditInvoice = (
       contact,
       fromUSDUnitsToUSDCents(+rate),
       address,
-      lineItems,
+      lineitems,
       files,
       props.token
     )

--- a/src/components/InvoiceContent.js
+++ b/src/components/InvoiceContent.js
@@ -1,6 +1,6 @@
 import React from "react";
 import Field, { FieldSeparator } from "./DescriptiveField";
-import InvoiceDatasheet, { convertLineItemsToGrid } from "./InvoiceDatasheet";
+import InvoiceDatasheet from "./InvoiceDatasheet";
 import { fromUSDCentsToUSDUnits } from "../helpers";
 
 const InvoiceContent = ({
@@ -36,7 +36,7 @@ const InvoiceContent = ({
         <FieldSeparator />
         <Field label="Payment address">{paymentaddress}</Field>
       </div>
-      <InvoiceDatasheet readOnly value={convertLineItemsToGrid(lineitems)} />
+      <InvoiceDatasheet readOnly value={lineitems} />
     </>
   );
 };

--- a/src/components/InvoiceDatasheet/InvoiceDatasheet.js
+++ b/src/components/InvoiceDatasheet/InvoiceDatasheet.js
@@ -1,10 +1,16 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import ReactDataSheet from "react-datasheet";
 import dropRight from "lodash/dropRight";
 import "react-datasheet/lib/react-datasheet.css";
 import "./styles.css";
-import { createNewRow, errorsMessage, processCellsChange } from "./helpers";
+import {
+  errorsMessage,
+  processCellsChange,
+  convertLineItemsToGrid,
+  convertGridToLineItems,
+  generateBlankLineItem
+} from "./helpers";
 
 const InvoiceDatasheet = ({
   policy,
@@ -14,20 +20,7 @@ const InvoiceDatasheet = ({
   onChangeErrors: setErrors,
   readOnly
 }) => {
-  const grid = value;
-
-  const handleAddNewRow = e => {
-    e.preventDefault();
-    const newGrid = grid.concat([createNewRow(grid.length)]);
-    onChange(newGrid);
-  };
-
-  const handleRemoveLastRow = e => {
-    e.preventDefault();
-    if (grid.length > 2) {
-      onChange(dropRight(grid, 1));
-    }
-  };
+  const [grid, setGrid] = useState([]);
 
   const handleCellsChange = changes => {
     const { grid: newGrid, errors: newErrors } = processCellsChange(
@@ -35,8 +28,31 @@ const InvoiceDatasheet = ({
       grid,
       changes
     );
-    onChange(newGrid);
+    const lineItems = convertGridToLineItems(newGrid);
+    onChange(lineItems);
     setErrors([...newErrors]);
+  };
+
+  const handleAddNewRow = e => {
+    e.preventDefault();
+    const newValue = value.concat([generateBlankLineItem()]);
+    onChange(newValue);
+  };
+
+  // const
+  useEffect(
+    function updateGridOnValueChange() {
+      const grid = convertLineItemsToGrid(value, readOnly);
+      setGrid(grid);
+    },
+    [value.length, JSON.stringify(value)]
+  );
+
+  const handleRemoveLastRow = e => {
+    e.preventDefault();
+    if (grid.length > 2) {
+      onChange(dropRight(value, 1));
+    }
   };
 
   const anyError = !!errors && !!errors.length;

--- a/src/components/InvoiceDatasheet/SelectEditor.js
+++ b/src/components/InvoiceDatasheet/SelectEditor.js
@@ -1,0 +1,57 @@
+import React from "react";
+import Select from "react-select";
+
+const customStyles = {
+  container: provided => ({
+    ...provided,
+    height: 20
+  }),
+  valueContainer: provided => ({
+    ...provided,
+    height: 20,
+    fontWeight: "normal",
+    display: "flex",
+    alignItems: "center"
+  }),
+  control: provided => ({
+    ...provided,
+    minHeight: 20,
+    height: 20
+  }),
+  option: provided => ({
+    ...provided,
+    padding: "4px 8px",
+    textAlign: "left",
+    fontWeight: "normal"
+  }),
+  dropdownIndicator: provided => ({
+    ...provided,
+    padding: 0
+  }),
+  input: provided => ({
+    ...provided,
+    padding: 0,
+    margin: 0
+  })
+};
+
+const SelectEditor = ({ value, options, onCommit }) => {
+  const handleChange = ({ value }) => {
+    onCommit(value);
+  };
+  const getValueObj = value => options.find(op => op.value === value);
+  return (
+    <Select
+      classNamePrefix="t"
+      styles={customStyles}
+      autoFocus
+      openOnFocus
+      closeOnSelect
+      options={options}
+      value={getValueObj(value)}
+      onChange={handleChange}
+    />
+  );
+};
+
+export default SelectEditor;

--- a/src/components/InvoiceDatasheet/helpers.js
+++ b/src/components/InvoiceDatasheet/helpers.js
@@ -138,7 +138,7 @@ export const convertLineItemsToGrid = (lineItems, readOnly = true) => {
 export const convertGridToLineItems = grid => {
   const copyGrid = grid.map(row => [...row]);
   return copyGrid.reduce((acc, rowValues, row) => {
-    // skip first row as it is exclusive for table headers
+    // skip first and last rows
     if (row === 0 || row === copyGrid.length - 1) return acc;
 
     const lineItem = rowValues.reduce((acc, cell, col) => {

--- a/src/components/InvoiceDatasheet/styles.css
+++ b/src/components/InvoiceDatasheet/styles.css
@@ -3,6 +3,11 @@
   text-align: center;
 }
 
+.value-viewer, .data-editor {
+  text-align: left !important;
+  padding-left: 10px;
+}
+
 .row-handle.cell {
   width: 1rem;
 }
@@ -94,7 +99,8 @@ pre {
     color: red;
 }
 
-.data-grid-container .data-grid .cell .value-viewer {
-    overflow: hidden;
-    text-overflow: ellipsis;
+.total-label {
+  color: black;
+  font-size: 12px;
+  font-weight: bold;
 }

--- a/src/components/snew/SubmitPage/SubmitPageInvoice.js
+++ b/src/components/snew/SubmitPage/SubmitPageInvoice.js
@@ -212,7 +212,7 @@ const InvoiceSubmit = props => {
                   </div>
                   <div className="usertext">
                     <Field
-                      name="datasheet"
+                      name="lineitems"
                       onChangeErrors={setDatasheetErrors}
                       errors={datasheetErrors}
                       component={InvoiceDatasheetField}

--- a/src/hocs/editInvoice.js
+++ b/src/hocs/editInvoice.js
@@ -6,7 +6,6 @@ import compose from "lodash/fp/compose";
 import get from "lodash/fp/get";
 import { validate } from "../validators/invoice";
 import { arg, or } from "../lib/fp";
-import { convertLineItemsToGrid } from "../components/InvoiceDatasheet/helpers";
 import { fromUSDCentsToUSDUnits } from "../helpers";
 
 const editInvoiceConnector = connect(
@@ -79,7 +78,7 @@ class EditInvoiceContainer extends Component {
           location: input.contractorlocation,
           rate: fromUSDCentsToUSDUnits(input.contractorrate),
           address: input.paymentaddress,
-          datasheet: convertLineItemsToGrid(input.lineitems, false),
+          lineitems: input.lineitems,
           files: this.props.otherFiles
         }
       });

--- a/src/hocs/newInvoice.js
+++ b/src/hocs/newInvoice.js
@@ -5,10 +5,7 @@ import * as act from "../actions";
 import compose from "lodash/fp/compose";
 import { or } from "../lib/fp";
 import { validate } from "../validators/invoice";
-import {
-  createNewRow,
-  createTableHeaders
-} from "../components/InvoiceDatasheet/helpers";
+import { generateBlankLineItem } from "../components/InvoiceDatasheet/helpers";
 import { getCurrentYear, getCurrentMonth } from "../helpers";
 
 // XXX: connector needs to be moved in its own file
@@ -40,7 +37,7 @@ class NewInvoiceContainer extends Component {
       initialValues: {
         month: getCurrentMonth() - 1,
         year: getCurrentYear(),
-        datasheet: [createTableHeaders(), createNewRow(1)]
+        lineitems: [generateBlankLineItem()]
       },
       validationError: ""
     };


### PR DESCRIPTION
This PR adds a dropdown select for 'type' and 'domain' columns in the datasheet component.
It also tweaks a few things such as:
- add a total row at the end of the datasheet
- wrap the conversion of values (lineItems <-> grid) all inside the datasheet component. Now it will always receive 'lineItems' and return 'lineItems', all the underlying conversion happens inside the component.

![Screen Shot 2019-05-06 at 21 05 46](https://user-images.githubusercontent.com/14864439/57248451-a9c62b80-7042-11e9-8f38-767ed9785fc6.png)

closes #1154 