### PR TITLE
Improve fallback UI for proposals

### DIFF
--- a/src/components/ListPageFallbackUI/ListPageFallbackUI.js
+++ b/src/components/ListPageFallbackUI/ListPageFallbackUI.js
@@ -1,8 +1,21 @@
 import React from "react";
+import { Tabs, Tab } from "../Tabs";
+import LoadingIcon from "../snew/LoadingIcon";
 
 const ListPageFallbackUI = () => (
-  <div className="fallback-list-page-content">
-    <h1 className="fallback-list-page-content-title">Loading...</h1>
+  <div className="content">
+    <h1 className="content-title">Public Proposals</h1>
+    <Tabs>
+      <Tab title="In Discusssion" count={""} />
+      <Tab title="Voting" count={""} />
+      <Tab title="Approved" count={""} />
+      <Tab title="Rejected" count={""} />
+      <Tab title="Abandoned" count={""} />
+    </Tabs>
+    <LoadingIcon
+      width={200}
+      style={{ paddingTop: "100px", margin: "0 auto" }}
+    />
   </div>
 );
 

--- a/src/components/PublicProposalsPage/PublicProposals.js
+++ b/src/components/PublicProposalsPage/PublicProposals.js
@@ -13,7 +13,6 @@ import {
 } from "./helpers";
 import { proposalToT3 } from "../../lib/snew";
 import proposalsConnector from "../../connectors/publicProposals";
-import LoadingIcon from "../snew/LoadingIcon";
 
 const DEFAULT_PAGE_SIZE = 4;
 
@@ -123,11 +122,6 @@ const PublicProposals = ({
           onTabChange={() => handleTabChange(tabValues.ABANDONED)}
         />
       </Tabs>
-      <LoadingIcon
-        width={200}
-        hidden={!isLoading}
-        style={{ paddingTop: "100px", margin: "0 auto" }}
-      />
       {proposalsTokens && !isLoading && (
         <LazyList
           items={filteredProposals}

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -13,7 +13,9 @@ export const Tab = ({ title, count, tabId, selected, onTabChange }) => {
   if (typeof count !== "undefined") {
     countIcon = <div className="tab-count">{count}</div>;
   }
-
+  if (count === "") {
+    countIcon = null;
+  }
   return (
     <span
       className={"tab" + (selected ? " tab-selected" : "")}


### PR DESCRIPTION
Resolves #1179 

This commit changes the loading screen for proposals. It uses "Public Proposals" + the proposal tabs as the fallback UI until the count and proposals have loaded.