### PR TITLE
Fix Loading Icon for Username / Password Change

### DIFF
--- a/src/components/PasswordChange/Form.js
+++ b/src/components/PasswordChange/Form.js
@@ -1,8 +1,8 @@
 import React from "react";
 import { reduxForm, Field } from "redux-form";
 import Message from "../Message";
-import { PageLoadingIcon } from "../snew";
 import { getPasswordFieldLabel } from "../../helpers";
+import ButtonWithLoadingIcon from "../snew/ButtonWithLoadingIcon";
 
 const ChangePasswordForm = ({
   error,
@@ -10,69 +10,66 @@ const ChangePasswordForm = ({
   policy,
   onChangePassword,
   handleSubmit
-}) =>
-  isApiRequestingChangePassword ? (
-    <PageLoadingIcon />
-  ) : (
-    <form
-      className="change-password-form"
-      onSubmit={handleSubmit(onChangePassword)}
-    >
-      {error && (
-        <Message type="error" header="Cannot change password" body={error} />
-      )}
-      <div className="c-form-group">
-        <label className="screenreader-only" htmlFor="existingPassword">
-          Current Password:
-        </label>
-        <Field
-          className="c-form-control"
-          id="existingPassword"
-          name="existingPassword"
-          component="input"
-          type="password"
-          placeholder="Current Password"
-          tabIndex={3}
-        />
-      </div>
-      <div className="c-form-group">
-        <label className="screenreader-only" htmlFor="newPassword">
-          New Password:
-        </label>
-        <Field
-          className="c-form-control"
-          id="newPassword"
-          name="newPassword"
-          component="input"
-          type="password"
-          placeholder={getPasswordFieldLabel(policy, "New Password")}
-          tabIndex={3}
-        />
-      </div>
-      <div className="c-form-group">
-        <label className="screenreader-only" htmlFor="newPasswordVerify">
-          Verify Password:
-        </label>
-        <Field
-          className="c-form-control"
-          id="newPasswordVerify"
-          name="newPasswordVerify"
-          component="input"
-          type="password"
-          placeholder="Verify Password"
-          tabIndex={3}
-        />
-      </div>
-      <div className="c-clearfix c-submit-group">
-        <button
-          className="c-btn c-btn-primary c-pull-left"
-          tabIndex={3}
-          type="submit"
-        >
-          Change Password
-        </button>
-      </div>
-    </form>
-  );
+}) => (
+  <form
+    className="change-password-form"
+    onSubmit={handleSubmit(onChangePassword)}
+  >
+    {error && (
+      <Message type="error" header="Cannot change password" body={error} />
+    )}
+    <div className="c-form-group">
+      <label className="screenreader-only" htmlFor="existingPassword">
+        Current Password:
+      </label>
+      <Field
+        className="c-form-control"
+        id="existingPassword"
+        name="existingPassword"
+        component="input"
+        type="password"
+        placeholder="Current Password"
+        tabIndex={3}
+      />
+    </div>
+    <div className="c-form-group">
+      <label className="screenreader-only" htmlFor="newPassword">
+        New Password:
+      </label>
+      <Field
+        className="c-form-control"
+        id="newPassword"
+        name="newPassword"
+        component="input"
+        type="password"
+        placeholder={getPasswordFieldLabel(policy, "New Password")}
+        tabIndex={3}
+      />
+    </div>
+    <div className="c-form-group">
+      <label className="screenreader-only" htmlFor="newPasswordVerify">
+        Verify Password:
+      </label>
+      <Field
+        className="c-form-control"
+        id="newPasswordVerify"
+        name="newPasswordVerify"
+        component="input"
+        type="password"
+        placeholder="Verify Password"
+        tabIndex={3}
+      />
+    </div>
+    <div className="c-clearfix c-submit-group">
+      <ButtonWithLoadingIcon
+        className="c-btn c-btn-primary c-pull-left"
+        tabIndex={3}
+        type="submit"
+        text="Change Password"
+        isLoading={isApiRequestingChangePassword}
+      />
+    </div>
+  </form>
+);
 
 export default reduxForm({ form: "form/change-password" })(ChangePasswordForm);

--- a/src/components/UsernameChange/Form.js
+++ b/src/components/UsernameChange/Form.js
@@ -1,8 +1,8 @@
 import React from "react";
 import { reduxForm, Field } from "redux-form";
 import Message from "../Message";
-import { PageLoadingIcon } from "../snew";
 import { getUsernameFieldLabel } from "../../helpers";
+import ButtonWithLoadingIcon from "../snew/ButtonWithLoadingIcon";
 
 const ChangeUsernameForm = ({
   error,
@@ -10,55 +10,52 @@ const ChangeUsernameForm = ({
   policy,
   onChangeUsername,
   handleSubmit
-}) =>
-  isApiRequestingChangeUsername ? (
-    <PageLoadingIcon />
-  ) : (
-    <form
-      className="change-username-form"
-      onSubmit={handleSubmit(onChangeUsername)}
-    >
-      {error && (
-        <Message type="error" header="Cannot change username" body={error} />
-      )}
-      <div className="c-form-group">
-        <label className="screenreader-only" htmlFor="username">
-          New Username:
-        </label>
-        <Field
-          className="c-form-control"
-          id="newUsername"
-          name="newUsername"
-          component="input"
-          type="username"
-          placeholder={getUsernameFieldLabel(policy, "New Username")}
-          tabIndex={3}
-        />
-      </div>
-      <div className="c-form-group">
-        <label className="screenreader-only" htmlFor="password">
-          Current Password:
-        </label>
-        <Field
-          className="c-form-control"
-          id="password"
-          name="password"
-          component="input"
-          type="password"
-          placeholder="Current Password"
-          tabIndex={3}
-        />
-      </div>
-      <div className="c-clearfix c-submit-group">
-        <button
-          className="c-btn c-btn-primary c-pull-left"
-          tabIndex={3}
-          type="submit"
-        >
-          Change Username
-        </button>
-      </div>
-    </form>
-  );
+}) => (
+  <form
+    className="change-username-form"
+    onSubmit={handleSubmit(onChangeUsername)}
+  >
+    {error && (
+      <Message type="error" header="Cannot change username" body={error} />
+    )}
+    <div className="c-form-group">
+      <label className="screenreader-only" htmlFor="username">
+        New Username:
+      </label>
+      <Field
+        className="c-form-control"
+        id="newUsername"
+        name="newUsername"
+        component="input"
+        type="username"
+        placeholder={getUsernameFieldLabel(policy, "New Username")}
+        tabIndex={3}
+      />
+    </div>
+    <div className="c-form-group">
+      <label className="screenreader-only" htmlFor="password">
+        Current Password:
+      </label>
+      <Field
+        className="c-form-control"
+        id="password"
+        name="password"
+        component="input"
+        type="password"
+        placeholder="Current Password"
+        tabIndex={3}
+      />
+    </div>
+    <div className="c-clearfix c-submit-group">
+      <ButtonWithLoadingIcon
+        className="c-btn c-btn-primary c-pull-left"
+        tabIndex={3}
+        type="submit"
+        text="Change Username"
+        isLoading={isApiRequestingChangeUsername}
+      />
+    </div>
+  </form>
+);
 
 export default reduxForm({ form: "form/change-username" })(ChangeUsernameForm);

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -1889,6 +1889,7 @@ form div.usertext-body.may-blank-within.md-container {
 
 .btn.loading {
   cursor: not-allowed;
+  overflow: hidden;
 }
 
 .thing  {


### PR DESCRIPTION
Closes #1180 and #1027 

This commit removes the loading spinner from the username and password change modals. Instead,  this commit uses the `ButtonWithLoadingIcon` component, which is more in line with how our other buttons load.

Also fixes the styling issue where button text was not being properly hidden while loading.