### PR TITLE
Fixes missing horizontal scroll

### DIFF
--- a/src/style/index.css
+++ b/src/style/index.css
@@ -1254,7 +1254,8 @@ li p.header-3 {
 .appWrapper {
   background: #f3f5f6;
   min-height: 100%;
-  overflow-x: scroll;
+  height: 100%;
+  overflow-x: auto;
 }
 
 .available-credits {


### PR DESCRIPTION
Horizontal scroll bar was appearing at the bottom of the page's content because `appWrapper` div was with the whole content's height.

Also, the overflow scroll bar was appearing every time, and the `auto` prop should fix that to only appear when the browser's width is shrunk.