### PR TITLE
Fix layout styles causing lazy loading to fail

### DIFF
--- a/src/components/VoteStats.js
+++ b/src/components/VoteStats.js
@@ -295,7 +295,7 @@ class VoteStats extends React.Component {
       border: "1px solid #bbb",
       marginTop: "10px",
       borderRadius: "8px",
-      width: "500px",
+      maxWidth: "600px",
       cursor: "default"
     };
 

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -1254,7 +1254,10 @@ li p.header-3 {
 .appWrapper {
   background: #f3f5f6;
   min-height: 100%;
-  height: 100%;
+  overflow-x: auto;
+}
+
+.appWrapper > .content {
   overflow-x: auto;
 }
 
@@ -1895,4 +1898,12 @@ form div.usertext-body.may-blank-within.md-container {
 
 .thing  {
   list-style-type: none;
+}
+
+/* On screens that are 768px or less, apply the following styles */
+@media screen and (max-width: 768px) {
+  /* hide side bar */
+  .side {
+    display: none;
+  }
 }

--- a/src/style/theme/index.css
+++ b/src/style/theme/index.css
@@ -507,6 +507,7 @@ button.disabled {
 }
 
 .commentarea .usertext-edit {
+    width: 100% !important;
     max-width: 500px;
 }
 


### PR DESCRIPTION
This PR fixes the bug introduced on #1185. Since we had many back and forths with the horizontal scroll I decided to make the layout of the proposal squeeze and hide the side menu after a width breakpoint of 768px.

![May-13-2019 19-30-33](https://user-images.githubusercontent.com/14864439/57641797-2bbfd280-75b6-11e9-90bf-817435e197c1.gif)
