### PR TITLE
Dockerfile - disable inline JS in production build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY ./ /root/
 
 RUN yarn install
 
-RUN yarn build
+RUN INLINE_RUNTIME_CHUNK=false yarn build
 
 # Serve image (stable nginx version)
 FROM nginx:1.14.2 


### PR DESCRIPTION
sets INLINE_RUNTIME_CHUNK to false.This removes some inline JS from being added to the code and adds it as a separate js file. 

See INLINE_RUNTIME_CHUNK in https://facebook.github.io/create-react-app/docs/advanced-configuration