### PR TITLE
Diff Improvements

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -27,9 +27,10 @@ class Modal extends React.Component {
           disabled={disableCloseOnClick}
         />
         <div className="modal">
-          <div className="modal-overlay" />
-          <div className="modal-container" style={style}>
-            {children}
+          <div className="modal-overlay">
+            <div className="modal-container" style={style}>
+              {children}
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/Modal/ModalContentWrapper.js
+++ b/src/components/Modal/ModalContentWrapper.js
@@ -31,7 +31,7 @@ class ModalContentWrapper extends React.Component {
       style
     } = this.props;
     return (
-      <div className="modal-content" style={{ minWidth: "700px", ...style }}>
+      <div className="modal-content" style={{ minWidth: "803px", ...style }}>
         <div className="modal-content-header">
           <h2 style={{ fontSize: "18px", textTransform: "uppercase" }}>
             {title}

--- a/src/components/snew/Markdown/Diff.js
+++ b/src/components/snew/Markdown/Diff.js
@@ -57,10 +57,18 @@ const DiffBody = ({
 }) => (
   <div>
     <div className="diff-text-preview-toggle" onClick={onToggleTextDiffPreview}>
-      <div className={!preview ? "diff-active-toggle" : ""}>
+      <div
+        className={!preview ? "diff-active-toggle" : ""}
+        onClick={!preview ? onToggleTextDiffPreview : null}
+      >
         View version {version}
       </div>
-      <div className={preview ? "diff-active-toggle" : ""}>Text changes</div>
+      <div
+        className={preview ? "diff-active-toggle" : ""}
+        onClick={preview ? onToggleTextDiffPreview : null}
+      >
+        Text changes
+      </div>
     </div>
     <div style={{ padding: "16px" }}>
       {preview ? (

--- a/src/components/snew/Markdown/Diff.js
+++ b/src/components/snew/Markdown/Diff.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { insertDiffHTML } from "./helpers";
 import Message from "../../Message";
 import ProposalImages from "../../ProposalImages";
+import MarkdownRenderer from "./Markdown";
 
 const DiffHeader = ({
   userName,
@@ -34,7 +35,7 @@ const DiffHeader = ({
               onClick={onToggleFilesDiff}
               href=""
             >
-              {filesDiff ? "Text Diff" : "Files Diff"}
+              {filesDiff ? "Text Changes" : "Attachments changes"}
               {isNewFile && <span className="new-file-indicator" />}
             </span>
           ) : null}
@@ -47,9 +48,27 @@ const DiffHeader = ({
   </div>
 );
 
-const DiffBody = ({ body }) => (
-  <div className="md" style={{ padding: "16px" }}>
-    {body}
+const DiffBody = ({
+  body,
+  proposal,
+  onToggleTextDiffPreview,
+  preview,
+  version
+}) => (
+  <div>
+    <div className="diff-text-preview-toggle" onClick={onToggleTextDiffPreview}>
+      <div className={!preview ? "diff-active-toggle" : ""}>
+        View version {version}
+      </div>
+      <div className={preview ? "diff-active-toggle" : ""}>Text changes</div>
+    </div>
+    <div style={{ padding: "16px" }}>
+      {preview ? (
+        <div className="md">{body}</div>
+      ) : (
+        <MarkdownRenderer body={proposal} />
+      )}
+    </div>
   </div>
 );
 
@@ -73,15 +92,23 @@ const hasFilesChanged = filesDiff =>
   filesDiff.filter(file => file.added || file.removed).length > 0;
 
 const withDiffStyle = {
-  zIndex: 9999
+  zIndex: 9999,
+  minWidth: "800px",
+  margin: "0px 1px"
 };
 
 class Diff extends React.Component {
-  state = { filesDiff: false };
+  state = { filesDiff: false, textDiffPreview: false };
   handleToggleFilesDiff = e => {
     e.preventDefault();
     this.setState(state => ({
       filesDiff: !state.filesDiff
+    }));
+  };
+  handleToggleTextDiffPreview = e => {
+    e.preventDefault();
+    this.setState(state => ({
+      textDiffPreview: !state.textDiffPreview
     }));
   };
   render() {
@@ -98,16 +125,13 @@ class Diff extends React.Component {
       loading,
       error
     } = this.props;
-    const { filesDiff } = this.state;
+    const { filesDiff, textDiffPreview } = this.state;
     const filesDiffArray = getFilesDiff(newFiles, oldFiles, filesDiffFunc);
     const hasFileChanged = hasFilesChanged(filesDiffArray);
     return (
       // It is not necessary to use another Modal component here, since we already call the openModal function on
       // the parent component
-      <div
-        className="modal-content"
-        style={{ minWidth: "700px", ...withDiffStyle }}
-      >
+      <div className="modal-content" style={withDiffStyle}>
         <div className="diff-wrapper">
           <DiffHeader
             title={title}
@@ -126,7 +150,13 @@ class Diff extends React.Component {
           ) : filesDiff ? (
             <ProposalImages files={filesDiffArray} readOnly={true} />
           ) : (
-            <DiffBody body={insertDiffHTML(oldProposal, newProposal)} />
+            <DiffBody
+              body={insertDiffHTML(oldProposal, newProposal)}
+              proposal={newProposal}
+              onToggleTextDiffPreview={this.handleToggleTextDiffPreview}
+              preview={textDiffPreview}
+              version={version}
+            />
           )}
         </div>
       </div>

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -1859,6 +1859,7 @@ form div.usertext-body.may-blank-within.md-container {
 }
 .diff-active-toggle{
   background-color: white;
+  cursor: default;
 }
 
 .diff-table {

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -1872,11 +1872,13 @@ form div.usertext-body.may-blank-within.md-container {
   border: none;
   word-wrap: break-word;
   overflow-wrap: break-word;
+  padding: 3px 4px;
 }
 
 .diff-line-index {
   width: 2em;
-  padding: 4px 1px
+  padding: 4px 1px;
+  text-align: center;
 }
 .diff-line-icon {
   font-weight: bold;

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -425,6 +425,7 @@ a:hover, a:focus {
 .attached-image {
   display: block;
   position: relative;
+  max-width: 100%;
 }
 .attached-image-title {
   height: 24px;
@@ -553,12 +554,23 @@ table.md {
 
 .md a {
   color: #2971ff;
+  word-break: break-all;
+  white-space: normal;
 }
 .md a:visited {
   color: #7D5D8A;
 }
 .md pre {
   padding: 8px;
+}
+
+.md code, .md pre code {
+  display: block;
+  width: 100%;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+  line-height: 1.5em !important;
 }
 .md blockquote {
   border-left: 2px solid #edf1f3;
@@ -1167,11 +1179,19 @@ li p.header-3 {
   z-index: 1;
 }
 
+@media (max-width: 800px) {
+  .modal-container {
+      align-items: normal !important;
+  }
+}
+
 .modal-container {
-  overflow-y: auto;
+  overflow: auto;
   box-sizing: border-box;
   padding-top: 80px;
+  padding-bottom: 80px;
   width: 100%;
+  height: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -1181,7 +1201,6 @@ li p.header-3 {
   background: white;
   box-shadow: 0 9px 46px 8px rgba(0,0,0,.14),0 11px 15px -7px rgba(0,0,0,.12),0 24px 38px 3px rgba(0,0,0,.2);
   z-index: 2;
-  margin-bottom: 40px;
 }
 
 .modal-content-header {
@@ -1253,10 +1272,7 @@ li p.header-3 {
 .appWrapper {
   background: #f3f5f6;
   min-height: 100%;
-  overflow-x: auto;
-}
-
-.appWrapper > .content {
+  height: 100%;
   overflow-x: auto;
 }
 
@@ -1829,32 +1845,57 @@ form div.usertext-body.may-blank-within.md-container {
   font-family: monospace;
 }
 
-.diff-line-in {
+.diff-text-preview-toggle {
+  width: 100%;
+  display: inline-block;
+  background-color: #dcdcdc;
+  line-height: 2em;
+  cursor: pointer;
+}
+.diff-text-preview-toggle div {
+  width: 50%;
+  float: left;
+  text-align: center
+}
+.diff-active-toggle{
+  background-color: white;
+}
+
+.diff-table {
+  border: none;
+  table-layout: fixed;
+  width: 100%;
+  font-family: "menlo",monospace;
+}
+.diff-table td {
+  font-size: 0.8em;
+  border: none;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
+.diff-line-index {
+  width: 2em;
+  padding: 4px 1px
+}
+.diff-line-icon {
+  font-weight: bold;
+  width: 1em
+}
+.diff-line-content {
+  width: 500px;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+.diff-line-added {
   list-style-type: none;
   background-color: #e6ffed;
   color: #164623;
 }
 
-.diff-in {
-  list-style-type: none;
-  background-color: #bfffd1;
-  color: #164623;
-  display:inline-block;
-  margin-left: 0.16em;
-}
-
-.diff-out {
-  list-style-type: none;
-  background-color: #f8bac1;
-  color: #cb2431;
-  display:inline-block;
-  margin-left: 0.16em;
-}
-
-.diff-line-out {
+.diff-line-removed {
   background-color: #ffdce0;
   list-style-type: none;
-  color: #cb2431;
   position: relative;
 }
 


### PR DESCRIPTION
Fixes #1012, #1149 and #1212

### Proposal version viewer - diff component
This commit improves the Diff component, now showing the diffs on raw text instead of rendered markdown.

The purpose of doing this is to mitigate future errors due to markdown limitations to show diffs.

By analyzing the way that other applications deal with diffs on markdown files, such as GitHub, it is possible to conclude that the smartest way to deal with it is to separate the diff from the rendered content.

Besides that, this version now allows us to see the changes that are not rendered by the `MarkdownRenderer` such as blank lines addition. Formerly, if you added one or more blank lines, a new version was created, but the diff modal showed a new version without any changes.

### Proposal version viewer - scrolling issue
By the diffs added on this PR, the scrolling issue reported on #1012 should get fixed.

### Overflowed images on CMS
This also resizes overflowed images, as reported on #1212.
> In some cases, images with a wide width end up getting very shrunken. To solve this, we can implement an image viewer that displays the image with its full resolution. However, I will not use this space to add that feature, since that's not the purpose of this PR.