### PR TITLE
[cms] Improve invoice validation 

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "tweetnacl": "^1.0.1",
     "tweetnacl-util": "^0.15.0",
     "typescript": "^3.4.3",
-    "xss-filters": "^1.2.7"
+    "xss-filters": "^1.2.7",
+    "yup": "^0.27.0"
   },
   "scripts": {
     "mockapi": "node mockapi.js",

--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -542,7 +542,6 @@ export const onSubmitInvoice = (
         resetNewProposalData();
       })
       .catch(error => {
-        console.log("error", error);
         dispatch(act.RECEIVE_NEW_INVOICE(null, error));
         resetNewProposalData();
         throw error;

--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -542,6 +542,7 @@ export const onSubmitInvoice = (
         resetNewProposalData();
       })
       .catch(error => {
+        console.log("error", error);
         dispatch(act.RECEIVE_NEW_INVOICE(null, error));
         resetNewProposalData();
         throw error;

--- a/src/components/Form/Fields/FilesField.js
+++ b/src/components/Form/Fields/FilesField.js
@@ -109,7 +109,7 @@ FilesField.propTypes = {
   touched: PropTypes.bool,
   error: PropTypes.bool,
   disabled: PropTypes.bool,
-  policy: PropTypes.object.isRequired
+  policy: PropTypes.object
 };
 
 export const normalizer = (value, previousValue) => {

--- a/src/components/Form/Fields/InvoiceDatasheetField.js
+++ b/src/components/Form/Fields/InvoiceDatasheetField.js
@@ -1,14 +1,58 @@
-import React from "react";
+import React, { useState } from "react";
 import InvoiceDatasheet from "../../InvoiceDatasheet";
+
+const CollapsableErrors = ({ errors }) => {
+  const [showErrors, setShowErrors] = useState(false);
+  const handleToggleErrorsVisibility = () => {
+    setShowErrors(!showErrors);
+  };
+  const angleStyle = {
+    marginLeft: "5px",
+    position: "relative"
+  };
+  return (
+    !!errors.length && (
+      <div style={{ paddingLeft: "5px" }}>
+        <div
+          style={{
+            cursor: "pointer",
+            color: "#bf4153",
+            fontWeight: "bold",
+            display: "flex"
+          }}
+          onClick={handleToggleErrorsVisibility}
+        >
+          <span>{`${showErrors ? "Hide" : "Display"} ${
+            errors.length
+          } validation errors`}</span>
+          <span style={angleStyle}>&#9662;</span>
+        </div>
+        {showErrors && (
+          <ul style={{ color: "#bf4153" }}>
+            {errors.map((e, idx) => (
+              <li key={`lineitem-error$-${idx}`}>{e}</li>
+            ))}
+          </ul>
+        )}
+      </div>
+    )
+  );
+};
 
 const InvoiceDatasheetField = ({
   input: { onChange, value = [] },
+  meta: { error = [], touched },
   ...props
 }) => {
   if (typeof value == "string") {
     value = [];
   }
-  return <InvoiceDatasheet onChange={onChange} value={value} {...props} />;
+  return (
+    <>
+      <InvoiceDatasheet onChange={onChange} value={value} {...props} />
+      {touched && <CollapsableErrors errors={error} />}
+    </>
+  );
 };
 
 export default InvoiceDatasheetField;

--- a/src/components/InvoiceDatasheet/InvoiceDatasheet.js
+++ b/src/components/InvoiceDatasheet/InvoiceDatasheet.js
@@ -5,32 +5,19 @@ import dropRight from "lodash/dropRight";
 import "react-datasheet/lib/react-datasheet.css";
 import "./styles.css";
 import {
-  errorsMessage,
   processCellsChange,
   convertLineItemsToGrid,
   convertGridToLineItems,
   generateBlankLineItem
 } from "./helpers";
 
-const InvoiceDatasheet = ({
-  policy,
-  value,
-  onChange,
-  errors,
-  onChangeErrors: setErrors,
-  readOnly
-}) => {
+const InvoiceDatasheet = ({ value, onChange, readOnly }) => {
   const [grid, setGrid] = useState([]);
 
   const handleCellsChange = changes => {
-    const { grid: newGrid, errors: newErrors } = processCellsChange(
-      policy,
-      grid,
-      changes
-    );
+    const { grid: newGrid } = processCellsChange(grid, changes);
     const lineItems = convertGridToLineItems(newGrid);
     onChange(lineItems);
-    setErrors([...newErrors]);
   };
 
   const handleAddNewRow = e => {
@@ -55,7 +42,6 @@ const InvoiceDatasheet = ({
     }
   };
 
-  const anyError = !!errors && !!errors.length;
   const removeRowsIsDisabled = grid && grid.length <= 2;
 
   return (
@@ -81,13 +67,6 @@ const InvoiceDatasheet = ({
         onContextMenu={(e, cell) => (cell.readOnly ? e.preventDefault() : null)}
         onCellsChanged={handleCellsChange}
       />
-      {anyError && (
-        <ul className="error-list">
-          {errors.map((e, idx) => (
-            <li key={`error-${idx}`}>{errorsMessage[e]}</li>
-          ))}
-        </ul>
-      )}
     </div>
   );
 };
@@ -95,9 +74,7 @@ const InvoiceDatasheet = ({
 InvoiceDatasheet.propTypes = {
   value: PropTypes.array.isRequired,
   readOnly: PropTypes.bool.isRequired,
-  onChange: PropTypes.func,
-  errors: PropTypes.array,
-  onChangeErrors: PropTypes.func
+  onChange: PropTypes.func
 };
 
 InvoiceDatasheet.defaultProps = {

--- a/src/components/InvoiceDatasheet/helpers.js
+++ b/src/components/InvoiceDatasheet/helpers.js
@@ -57,7 +57,7 @@ export const selectWrapper = options => props => (
 );
 
 export const generateBlankLineItem = () => ({
-  type: "",
+  type: 1,
   domain: "",
   subdomain: "",
   description: "",

--- a/src/components/InvoiceDatasheet/helpers.js
+++ b/src/components/InvoiceDatasheet/helpers.js
@@ -17,7 +17,7 @@ export const columnTypes = {
   EXP_COL: 7
 };
 
-const { TYPE_COL, LABOR_COL, EXP_COL } = columnTypes;
+const { LABOR_COL, EXP_COL } = columnTypes;
 
 const getDropdownOptionsByColumnType = colType => {
   const domainOptions = [
@@ -177,57 +177,12 @@ export const createTableHeaders = () => [
   { value: "Expense (USD)", width: 60, readOnly: true }
 ];
 
-export const errors = {
-  InvalidType: 1,
-  InvalidDomainLen: 2,
-  InvalidSubdomainLen: 3,
-  InvalidDescriptionLen: 4,
-  InvalidPropTokenLen: 5,
-  InvalidLaborValue: 6,
-  InvalidLaborAmount: 7,
-  InvalidExpenseValue: 8,
-  InvalidExpenseAmount: 9
-};
-
-export const errorsMessage = {
-  [errors.InvalidType]:
-    "Type must be either Labor (1), Expense (2) or Misc (3)",
-  [errors.InvalidDomainLen]: "Domain must have between 3 and 200 chars",
-  [errors.InvalidSubdomainLen]: "Subomain must have between 3 and 200 chars",
-  [errors.InvalidDescriptionLen]:
-    "Description must have between 3 and 200 chars",
-  [errors.InvalidPropTokenLen]: "Proposals tokens must be 64 characters long",
-  [errors.InvalidLaborValue]: "Labor value must be a number",
-  [errors.InvalidLaborAmount]:
-    "If Type is 1, labor value must be greater than 0",
-  [errors.InvalidExpenseValue]: "Expense value must be a number",
-  [errors.InvalidExpenseAmount]:
-    "If Type is 2, expense value must be greater than 0"
-};
-
-const response = (error, newValue) => ({
-  error,
-  newValue
-});
-
 export const updateGridCell = (grid, row, col, values) => {
   grid[row][col] = { ...grid[row][col], ...values };
   return grid;
 };
 
 export const processTypeColChange = (grid, { row, col, value }) => {
-  const validTypeValues = [1, 2, 3];
-  const valueIsValid = validTypeValues.find(v => v === +value);
-  // validate if the value
-  if (!valueIsValid) {
-    return response(
-      errors.InvalidType,
-      updateGridCell(grid, row, col, {
-        value: ""
-      })
-    );
-  }
-
   // if value is 1, the expense column must be 0, so we set it to readOnly
   if (+value === 1) {
     grid = updateGridCell(grid, row, EXP_COL, { value: 0, readOnly: true });
@@ -244,195 +199,16 @@ export const processTypeColChange = (grid, { row, col, value }) => {
     grid = updateGridCell(grid, row, LABOR_COL, { readOnly: false });
   }
 
-  return response(null, updateGridCell(grid, row, col, { value }));
+  return updateGridCell(grid, row, col, { value });
 };
 
-const validateStringLength = (policy, value) => {
-  if (
-    value.length < policy.minlineitemcollength ||
-    value.length > policy.maxlineitemcollength
-  ) {
-    return false;
-  }
-  return true;
-};
-
-export const processStringColChange = (policy, grid, { row, col, value }) => {
-  if (!validateStringLength(policy, value)) {
-    return response(
-      errors.InvalidDomainLen,
-      updateGridCell(grid, row, col, {
-        value: ""
-      })
-    );
-  }
-
-  return response(null, updateGridCell(grid, row, col, { value }));
-};
-
-export const processDomainColChange = (policy, grid, { row, col, value }) => {
-  if (!validateStringLength(policy, value)) {
-    return response(
-      errors.InvalidDomainLen,
-      updateGridCell(grid, row, col, {
-        value: value
-      })
-    );
-  }
-
-  return response(null, updateGridCell(grid, row, col, { value }));
-};
-
-export const processSubdomainColChange = (
-  policy,
-  grid,
-  { row, col, value }
-) => {
-  if (!validateStringLength(policy, value)) {
-    return response(
-      errors.InvalidSubdomainLen,
-      updateGridCell(grid, row, col, {
-        value: value
-      })
-    );
-  }
-
-  return response(null, updateGridCell(grid, row, col, { value }));
-};
-
-export const processDescriptionColChange = (
-  policy,
-  grid,
-  { row, col, value }
-) => {
-  if (!validateStringLength(policy, value)) {
-    return response(
-      errors.InvalidDescriptionLen,
-      updateGridCell(grid, row, col, {
-        value: value
-      })
-    );
-  }
-
-  return response(null, updateGridCell(grid, row, col, { value }));
-};
-
-export const processPropTokenColChange = (grid, { row, col, value }) => {
-  const updatedGrid = updateGridCell(grid, row, col, {
-    value: value
-  });
-  // proposal token can be either blank or have a valid token
-  if (!value) {
-    return response(null, updatedGrid);
-  }
-
-  // for now only validate the token length
-  if (value.length < 64) {
-    return response(errors.InvalidPropTokenLen, updatedGrid);
-  }
-
-  return updatedGrid;
-};
-
-export const processLaborColChange = (grid, { row, col, value }) => {
-  const floatValue = parseFloat(value, 10).toFixed(2);
-
-  // make sure the value can be converted to a valid number
-  const invalidNumber = !floatValue || isNaN(floatValue);
-  if (invalidNumber) {
-    return response(
-      errors.InvalidLaborValue,
-      updateGridCell(grid, row, col, {
-        value: ""
-      })
-    );
-  }
-
-  // make sure labor is different than 0 if type is equal 1
-  const typeColValue = grid[row][TYPE_COL].value;
-  const isTypeOne = parseInt(typeColValue, 10) === 1;
-  if (isTypeOne && +floatValue <= 0) {
-    return response(
-      errors.InvalidLaborAmount,
-      updateGridCell(grid, row, col, {
-        value: 1
-      })
-    );
-  }
-
-  return response(
-    null,
-    updateGridCell(grid, row, col, {
-      value: floatValue
-    })
-  );
-};
-
-export const processExpenseColChange = (grid, { row, col, value }) => {
-  const floatValue = parseFloat(value, 10).toFixed(2);
-
-  const invalidNumber = !floatValue || isNaN(floatValue);
-
-  if (invalidNumber) {
-    return response(
-      errors.InvalidExpenseValue,
-      updateGridCell(grid, row, col, {
-        value: ""
-      })
-    );
-  }
-
-  // make sure expense is different than 0 if type is equal 2
-  const typeColValue = grid[row][TYPE_COL].value;
-  const isTypeTwo = parseInt(typeColValue, 10) === 2;
-  if (isTypeTwo && +floatValue <= 0) {
-    return response(
-      errors.InvalidExpenseAmount,
-      updateGridCell(grid, row, col, {
-        value: 1
-      })
-    );
-  }
-
-  return response(
-    null,
-    updateGridCell(grid, row, col, {
-      value: floatValue
-    })
-  );
-};
-
-export const processCellsChange = (policy, currentGrid, changes) => {
-  let result = null;
-  const getGridAndErrorsFromResult = (acc, result) => ({
-    grid: result.newValue,
-    errors: result.error ? acc.errors.add(result.error) : acc.errors
-  });
-
+export const processCellsChange = (currentGrid, changes) => {
   return changes.reduce(
     (acc, change) => {
       switch (change.col) {
         case columnTypes.TYPE_COL:
-          result = processTypeColChange(acc.grid, change);
-          return getGridAndErrorsFromResult(acc, result);
-        case columnTypes.DOMAIN_COL:
-          result = processDomainColChange(policy, acc.grid, change);
-          return getGridAndErrorsFromResult(acc, result);
-        case columnTypes.SUBDOMAIN_COL:
-          result = processSubdomainColChange(policy, acc.grid, change);
-          return getGridAndErrorsFromResult(acc, result);
-        case columnTypes.DESC_COL:
-          result = processDescriptionColChange(policy, acc.grid, change);
-          return getGridAndErrorsFromResult(acc, result);
-        case columnTypes.PROP_TOKEN_COL:
-          result = processPropTokenColChange(acc.grid, change);
-          return getGridAndErrorsFromResult(acc, result);
-        case columnTypes.LABOR_COL:
-          result = processLaborColChange(acc.grid, change);
-          return getGridAndErrorsFromResult(acc, result);
-        case columnTypes.EXP_COL:
-          result = processExpenseColChange(acc.grid, change);
-          return getGridAndErrorsFromResult(acc, result);
+          acc.grid = processTypeColChange(acc.grid, change);
+          return acc;
         default:
           acc.grid = updateGridCell(acc.grid, change.row, change.col, {
             value: change.value
@@ -440,6 +216,6 @@ export const processCellsChange = (policy, currentGrid, changes) => {
           return acc;
       }
     },
-    { grid: currentGrid, errors: new Set() }
+    { grid: currentGrid }
   );
 };

--- a/src/components/InvoiceDatasheet/styles.css
+++ b/src/components/InvoiceDatasheet/styles.css
@@ -94,11 +94,6 @@ pre {
     background: #f17d86;
 }
 
-
-.error-list {
-    color: red;
-}
-
 .total-label {
   color: black;
   font-size: 12px;

--- a/src/components/snew/SubmitPage/SubmitPageInvoice.js
+++ b/src/components/snew/SubmitPage/SubmitPageInvoice.js
@@ -15,58 +15,10 @@ import {
   getCurrentYear,
   getCurrentMonth
 } from "../../../helpers";
+import { invoiceInstructions } from "./helpers";
 
 const YEAR_OPTIONS = [2018, 2019];
 const MONTH_OPTIONS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-
-const concatSupportedChars = supportedChars =>
-  supportedChars.reduce((str, v) => str + v, "");
-
-const invoiceInstructions = ({
-  cmscontactsupportedchars,
-  cmsnamelocationsupportedchars,
-  maxlocationlength,
-  minlocationlength,
-  mincontactlength,
-  maxcontactlength,
-  minnamelength,
-  maxnamelength,
-  minlineitemcollength,
-  maxlineitemcollength,
-  invoicefieldsupportedchars
-}) => `
-***Contractor Name:*** This is whatever name you identify yourself with the DHG, typically something beyond a mere handle or nick. 
- - Allowed chars: ${concatSupportedChars(cmsnamelocationsupportedchars)}
- - Min length: ${minnamelength}
- - Max length: ${maxnamelength}
-
-***Contractor Location:*** This is the country you are currently located, or primarily residing.
-- Allowed chars: ${concatSupportedChars(cmsnamelocationsupportedchars)}
-- Min length: ${minlocationlength}
-- Max length: ${maxlocationlength}
-
-***Contractor Contact:*** Contact information in case an administrator would need to reach out to discuss something, typically an email address or chat nick.
-- Allowed chars: ${concatSupportedChars(cmscontactsupportedchars)}
-- Min length: ${mincontactlength}
-- Max length: ${maxcontactlength}
-
-***Contractor Rate:*** This is the previously agreed upon rate you will be performing work.
-
-***Payment Address:*** This is the DCR address where you would like to receive payment.  
-
-***Line Items:***
-  * Type: Currently can be 1 (Labor), 2 (Expense), or 3 (Misc)
-  * Domain: The broad category of work performed/expenses spent (for example, Development, Marketing, Community etc).
-  * Subdomain: The specific project or program of which the work or expenses are related (for example, Decrediton, dcrd, NYC Event).
-  * Description: A thorough description of the work or expenses.
-  * Labor: The number of hours of work performed.
-  * Expenses: The cost of the line item (in USD).
-  
-Line items policy for domain, subdomain and description:
-- Allowed chars: ${concatSupportedChars(invoicefieldsupportedchars)}
-- Min length: ${minlineitemcollength}
-- Max length: ${maxlineitemcollength}
-`;
 
 const InvoiceSubmit = props => {
   const {

--- a/src/components/snew/SubmitPage/SubmitPageInvoice.js
+++ b/src/components/snew/SubmitPage/SubmitPageInvoice.js
@@ -219,7 +219,6 @@ const InvoiceSubmit = props => {
                     <Field
                       name="lineitems"
                       onChangeErrors={setDatasheetErrors}
-                      errors={datasheetErrors}
                       component={InvoiceDatasheetField}
                       policy={policy}
                     />

--- a/src/components/snew/SubmitPage/SubmitPageInvoice.js
+++ b/src/components/snew/SubmitPage/SubmitPageInvoice.js
@@ -61,7 +61,6 @@ const InvoiceSubmit = props => {
     pristine
   } = props;
 
-  const [datasheetErrors, setDatasheetErrors] = useState([]);
   const [monthOptions, setMonthOptions] = useState(MONTH_OPTIONS);
 
   useEffect(() => {
@@ -80,7 +79,6 @@ const InvoiceSubmit = props => {
     !submitting &&
     valid &&
     !pristine &&
-    datasheetErrors.length === 0 &&
     !exchangeRateError &&
     !loadingExchangeRate;
 
@@ -218,7 +216,6 @@ const InvoiceSubmit = props => {
                   <div className="usertext">
                     <Field
                       name="lineitems"
-                      onChangeErrors={setDatasheetErrors}
                       component={InvoiceDatasheetField}
                       policy={policy}
                     />

--- a/src/components/snew/SubmitPage/SubmitPageInvoice.js
+++ b/src/components/snew/SubmitPage/SubmitPageInvoice.js
@@ -57,7 +57,8 @@ const InvoiceSubmit = props => {
     policy,
     userCanExecuteActions,
     loggedInAsEmail,
-    valid
+    valid,
+    pristine
   } = props;
 
   const [datasheetErrors, setDatasheetErrors] = useState([]);
@@ -78,6 +79,7 @@ const InvoiceSubmit = props => {
     loggedInAsEmail &&
     !submitting &&
     valid &&
+    !pristine &&
     datasheetErrors.length === 0 &&
     !exchangeRateError &&
     !loadingExchangeRate;

--- a/src/components/snew/SubmitPage/SubmitPageInvoice.js
+++ b/src/components/snew/SubmitPage/SubmitPageInvoice.js
@@ -19,12 +19,36 @@ import {
 const YEAR_OPTIONS = [2018, 2019];
 const MONTH_OPTIONS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
 
-const invoiceInstructions = `
-***Contractor Name:*** This is whatever name you identify yourself with the DHG, typically something beyond a mere handle or nick.
+const concatSupportedChars = supportedChars =>
+  supportedChars.reduce((str, v) => str + v, "");
+
+const invoiceInstructions = ({
+  cmscontactsupportedchars,
+  cmsnamelocationsupportedchars,
+  maxlocationlength,
+  minlocationlength,
+  mincontactlength,
+  maxcontactlength,
+  minnamelength,
+  maxnamelength,
+  minlineitemcollength,
+  maxlineitemcollength,
+  invoicefieldsupportedchars
+}) => `
+***Contractor Name:*** This is whatever name you identify yourself with the DHG, typically something beyond a mere handle or nick. 
+ - Allowed chars: ${concatSupportedChars(cmsnamelocationsupportedchars)}
+ - Min length: ${minnamelength}
+ - Max length: ${maxnamelength}
 
 ***Contractor Location:*** This is the country you are currently located, or primarily residing.
+- Allowed chars: ${concatSupportedChars(cmsnamelocationsupportedchars)}
+- Min length: ${minlocationlength}
+- Max length: ${maxlocationlength}
 
 ***Contractor Contact:*** Contact information in case an administrator would need to reach out to discuss something, typically an email address or chat nick.
+- Allowed chars: ${concatSupportedChars(cmscontactsupportedchars)}
+- Min length: ${mincontactlength}
+- Max length: ${maxcontactlength}
 
 ***Contractor Rate:*** This is the previously agreed upon rate you will be performing work.
 
@@ -36,7 +60,13 @@ const invoiceInstructions = `
   * Subdomain: The specific project or program of which the work or expenses are related (for example, Decrediton, dcrd, NYC Event).
   * Description: A thorough description of the work or expenses.
   * Labor: The number of hours of work performed.
-  * Expenses: The cost of the line item (in USD).`;
+  * Expenses: The cost of the line item (in USD).
+  
+Line items policy for domain, subdomain and description:
+- Allowed chars: ${concatSupportedChars(invoicefieldsupportedchars)}
+- Min length: ${minlineitemcollength}
+- Max length: ${maxlineitemcollength}
+`;
 
 const InvoiceSubmit = props => {
   const {
@@ -204,13 +234,15 @@ const InvoiceSubmit = props => {
                       />
                     </div>
                     <div>
-                      <Markdown
-                        body={invoiceInstructions}
-                        filterXss={false}
-                        confirmWithModal={null}
-                        displayExternalLikWarning={false}
-                        {...props}
-                      />
+                      {policy && (
+                        <Markdown
+                          body={invoiceInstructions(policy)}
+                          filterXss={false}
+                          confirmWithModal={null}
+                          displayExternalLikWarning={false}
+                          {...props}
+                        />
+                      )}
                     </div>
                   </div>
                   <div className="usertext">

--- a/src/components/snew/SubmitPage/helpers.js
+++ b/src/components/snew/SubmitPage/helpers.js
@@ -1,0 +1,48 @@
+const concatSupportedChars = supportedChars =>
+  supportedChars.reduce((str, v) => str + v, "");
+
+export const invoiceInstructions = ({
+  cmscontactsupportedchars,
+  cmsnamelocationsupportedchars,
+  maxlocationlength,
+  minlocationlength,
+  mincontactlength,
+  maxcontactlength,
+  minnamelength,
+  maxnamelength,
+  minlineitemcollength,
+  maxlineitemcollength,
+  invoicefieldsupportedchars
+}) => `
+  ***Contractor Name:*** This is whatever name you identify yourself with the DHG, typically something beyond a mere handle or nick. 
+   - Allowed chars: ${concatSupportedChars(cmsnamelocationsupportedchars)}
+   - Min length: ${minnamelength}
+   - Max length: ${maxnamelength}
+  
+  ***Contractor Location:*** This is the country you are currently located, or primarily residing.
+  - Allowed chars: ${concatSupportedChars(cmsnamelocationsupportedchars)}
+  - Min length: ${minlocationlength}
+  - Max length: ${maxlocationlength}
+  
+  ***Contractor Contact:*** Contact information in case an administrator would need to reach out to discuss something, typically an email address or chat nick.
+  - Allowed chars: ${concatSupportedChars(cmscontactsupportedchars)}
+  - Min length: ${mincontactlength}
+  - Max length: ${maxcontactlength}
+  
+  ***Contractor Rate:*** This is the previously agreed upon rate you will be performing work.
+  
+  ***Payment Address:*** This is the DCR address where you would like to receive payment.  
+  
+  ***Line Items:***
+    * Type: Currently can be 1 (Labor), 2 (Expense), or 3 (Misc)
+    * Domain: The broad category of work performed/expenses spent (for example, Development, Marketing, Community etc).
+    * Subdomain: The specific project or program of which the work or expenses are related (for example, Decrediton, dcrd, NYC Event).
+    * Description: A thorough description of the work or expenses.
+    * Labor: The number of hours of work performed.
+    * Expenses: The cost of the line item (in USD).
+    
+  Line items policy for domain, subdomain and description:
+  - Allowed chars: ${concatSupportedChars(invoicefieldsupportedchars)}
+  - Min length: ${minlineitemcollength}
+  - Max length: ${maxlineitemcollength}
+  `;

--- a/src/components/snew/SubmitPage/helpers.js
+++ b/src/components/snew/SubmitPage/helpers.js
@@ -14,34 +14,34 @@ export const invoiceInstructions = ({
   maxlineitemcollength,
   invoicefieldsupportedchars
 }) => `
-  ***Contractor Name:*** This is whatever name you identify yourself with the DHG, typically something beyond a mere handle or nick. 
+***Contractor Name:*** This is whatever name you identify yourself with the DHG, typically something beyond a mere handle or nick. 
    - Allowed chars: ${concatSupportedChars(cmsnamelocationsupportedchars)}
    - Min length: ${minnamelength}
    - Max length: ${maxnamelength}
   
-  ***Contractor Location:*** This is the country you are currently located, or primarily residing.
+***Contractor Location:*** This is the country you are currently located, or primarily residing.
   - Allowed chars: ${concatSupportedChars(cmsnamelocationsupportedchars)}
   - Min length: ${minlocationlength}
   - Max length: ${maxlocationlength}
   
-  ***Contractor Contact:*** Contact information in case an administrator would need to reach out to discuss something, typically an email address or chat nick.
+***Contractor Contact:*** Contact information in case an administrator would need to reach out to discuss something, typically an email address or chat nick.
   - Allowed chars: ${concatSupportedChars(cmscontactsupportedchars)}
   - Min length: ${mincontactlength}
   - Max length: ${maxcontactlength}
   
-  ***Contractor Rate:*** This is the previously agreed upon rate you will be performing work.
+***Contractor Rate:*** This is the previously agreed upon rate you will be performing work.
   
-  ***Payment Address:*** This is the DCR address where you would like to receive payment.  
+***Payment Address:*** This is the DCR address where you would like to receive payment.  
   
-  ***Line Items:***
-    * Type: Currently can be 1 (Labor), 2 (Expense), or 3 (Misc)
-    * Domain: The broad category of work performed/expenses spent (for example, Development, Marketing, Community etc).
-    * Subdomain: The specific project or program of which the work or expenses are related (for example, Decrediton, dcrd, NYC Event).
-    * Description: A thorough description of the work or expenses.
-    * Labor: The number of hours of work performed.
-    * Expenses: The cost of the line item (in USD).
+***Line Items:***
+  * Type: Currently can be 1 (Labor), 2 (Expense), or 3 (Misc)
+  * Domain: The broad category of work performed/expenses spent (for example, Development, Marketing, Community etc).
+  * Subdomain: The specific project or program of which the work or expenses are related (for example, Decrediton, dcrd, NYC Event).
+  * Description: A thorough description of the work or expenses.
+  * Labor: The number of hours of work performed.
+  * Expenses: The cost of the line item (in USD).
     
-  Line items policy for domain, subdomain and description:
+Line items policy for domain, subdomain and description:
   - Allowed chars: ${concatSupportedChars(invoicefieldsupportedchars)}
   - Min length: ${minlineitemcollength}
   - Max length: ${maxlineitemcollength}

--- a/src/hocs/editInvoice.js
+++ b/src/hocs/editInvoice.js
@@ -4,7 +4,6 @@ import * as sel from "../selectors";
 import * as act from "../actions";
 import compose from "lodash/fp/compose";
 import get from "lodash/fp/get";
-import { validate } from "../validators/invoice";
 import { arg, or } from "../lib/fp";
 import { fromUSDCentsToUSDUnits } from "../helpers";
 
@@ -44,9 +43,7 @@ const editInvoiceConnector = connect(
 class EditInvoiceContainer extends Component {
   constructor(props) {
     super(props);
-    this.state = {
-      validationError: ""
-    };
+    this.state = {};
   }
 
   componentDidMount() {
@@ -107,12 +104,7 @@ class EditInvoiceContainer extends Component {
   onSave = (...args) => {
     const { exchangeRate } = this.props;
     args[0].exchangerate = exchangeRate;
-    try {
-      validate(...args);
-      this.props.onSave(...args, this.props.token);
-    } catch (e) {
-      this.setState({ validationError: e.errors._error });
-    }
+    this.props.onSave(...args, this.props.token);
   };
 
   onCancel = () => this.props.history.push(`/invoices/${this.props.token}`);

--- a/src/hocs/newInvoice.js
+++ b/src/hocs/newInvoice.js
@@ -4,7 +4,6 @@ import * as sel from "../selectors";
 import * as act from "../actions";
 import compose from "lodash/fp/compose";
 import { or } from "../lib/fp";
-import { validate } from "../validators/invoice";
 import { generateBlankLineItem } from "../components/InvoiceDatasheet/helpers";
 import { getCurrentYear, getCurrentMonth } from "../helpers";
 
@@ -15,6 +14,7 @@ const newInvoiceConnector = connect(
     description: sel.newProposalDescription,
     error: sel.newInvoiceError,
     submitError: sel.newInvoiceError,
+    policy: sel.policy,
     token: sel.newInvoiceToken,
     month: sel.invoiceFormMonth,
     year: sel.invoiceFormYear,
@@ -38,8 +38,7 @@ class NewInvoiceContainer extends Component {
         month: getCurrentMonth() - 1,
         year: getCurrentYear(),
         lineitems: [generateBlankLineItem()]
-      },
-      validationError: ""
+      }
     };
   }
 
@@ -53,33 +52,21 @@ class NewInvoiceContainer extends Component {
 
   render() {
     const { Component } = this.props;
-    const { validationError } = this.state;
     return (
       <Component
         {...{
           ...this.props,
           onSave: this.onSaveInvoice.bind(this),
           initialValues: this.state.initialValues,
-          validationError: validationError,
           onChange: this.onChange
         }}
       />
     );
   }
 
-  onChange = () => {
-    this.setState({ validationError: "" });
-  };
-
   onSaveInvoice = (...args) => {
     const { exchangeRate } = this.props;
     args[0].exchangerate = exchangeRate;
-    try {
-      validate(...args);
-    } catch (e) {
-      this.setState({ validationError: e.errors._error });
-      return;
-    }
     return this.props.onSave(...args);
   };
 }

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -83,6 +83,7 @@ export const makeInvoice = (
     paymentaddress,
     lineItems
   });
+
   return {
     id: "",
     month,
@@ -129,16 +130,23 @@ export const makeCensoredComment = (token, reason, commentid) => ({
 });
 
 export const signRegister = (email, proposal) => {
-  return pki.myPubKeyHex(email).then(publickey => {
-    const digests = proposal.files
-      .map(x => Buffer.from(get("digest", x), "hex"))
-      .sort(Buffer.compare);
-    const tree = new MerkleTree(digests);
-    const root = tree.getRoot().toString("hex");
-    return pki
-      .signStringHex(email, root)
-      .then(signature => ({ ...proposal, publickey, signature }));
-  });
+  return pki
+    .myPubKeyHex(email)
+    .then(publickey => {
+      const digests = proposal.files
+        .map(x => Buffer.from(get("digest", x), "hex"))
+        .sort(Buffer.compare);
+      const tree = new MerkleTree(digests);
+      const root = tree.getRoot().toString("hex");
+      return pki
+        .signStringHex(email, root)
+        .then(signature => ({ ...proposal, publickey, signature }));
+    })
+    .catch(() => {
+      throw new Error(
+        "Failed to load user identity. You need tor restore it from a backup or generate a new one."
+      );
+    });
 };
 
 export const signComment = (email, comment) =>

--- a/src/validators/invoice.js
+++ b/src/validators/invoice.js
@@ -1,79 +1,87 @@
-import { SubmissionError } from "redux-form";
-import { isRequiredValidator } from "./util";
+import * as Yup from "yup";
 
-const emptyInvoiceField = values =>
-  !isRequiredValidator(values.month) ||
-  !isRequiredValidator(values.year) ||
-  !isRequiredValidator(values.name && values.name.trim()) ||
-  !isRequiredValidator(values.location && values.location.trim()) ||
-  !isRequiredValidator(values.contact && values.contact.trim()) ||
-  !isRequiredValidator(values.rate) ||
-  !isRequiredValidator(values.address && values.address.trim());
+const invoiceValidationSchema = ({
+  cmscontactsupportedchars,
+  cmsnamelocationsupportedchars,
+  maxlocationlength,
+  minlocationlength,
+  mincontactlength,
+  maxcontactlength,
+  minnamelength,
+  maxnamelength
+}) =>
+  Yup.object().shape({
+    name: Yup.string()
+      .required("required")
+      .min(minnamelength)
+      .max(maxnamelength)
+      .matches(...fieldMatcher("Name", cmsnamelocationsupportedchars)),
+    location: Yup.string()
+      .required("required")
+      .min(minlocationlength)
+      .max(maxlocationlength)
+      .matches(...fieldMatcher("Location", cmsnamelocationsupportedchars)),
+    contact: Yup.string()
+      .required("required")
+      .min(mincontactlength)
+      .max(maxcontactlength)
+      .matches(...fieldMatcher("Contact", cmscontactsupportedchars)),
+    rate: Yup.number()
+      .required("required")
+      .min(5)
+      .max(500),
+    address: Yup.string().required("required")
+  });
 
-const validate = (values, dispatch, props) => {
-  if (emptyInvoiceField(values)) {
-    throw new SubmissionError({
-      _error: "Your invoice must have a month, a year and an input."
-    });
+export function yupToFormErrors(yupError) {
+  let errors = {};
+  if (yupError.inner.length === 0) {
+    return { ...errors, [yupError.path]: yupError.message };
   }
-  if (props.keyMismatch) {
-    throw new SubmissionError({
-      _error:
-        "Your local key does not match the one on the server.  Please generate a new one under account settings."
-    });
+  for (const err of yupError.inner) {
+    if (!errors[err.path]) {
+      errors = { ...errors, [err.path]: err.message };
+    }
   }
-
-  return null;
-};
-
-const validateContractorName = name => {
-  if (!name) {
-    return "Name cannot be blank";
-  }
-  return null;
-};
-
-const validateContractorLocation = location => {
-  if (!location) {
-    return "Location cannot be blank";
-  }
-  return null;
-};
-
-const validateContractorContact = contact => {
-  if (!contact) {
-    return "Contact cannot be blank";
-  }
-  return null;
-};
-
-const validateContractorRate = rate => {
-  if (!rate) {
-    return "Rate cannot be blank";
-  }
-  if (+rate < 5 || +rate > 500) {
-    return "Rate must be within the range of 5 to 500";
-  }
-  return null;
-};
-
-const validateContractorPaymentAddress = address => {
-  if (!address) {
-    return "Payment address cannot be blank";
-  }
-  return null;
-};
-
-const synchronousValidation = ({ name, location, contact, rate, address }) => {
-  const errors = {
-    name: validateContractorName(name),
-    location: validateContractorLocation(location),
-    contact: validateContractorContact(contact),
-    rate: validateContractorRate(rate),
-    address: validateContractorPaymentAddress(address)
-  };
-
   return errors;
+}
+
+const buildRegexFromSupportedChars = supportedChars => {
+  const concatedChars = supportedChars.reduce((str, v) => str + `\\${v}`, "");
+  const regex = "^[" + concatedChars + "]*$";
+  return new RegExp(regex);
 };
 
-export { validate, synchronousValidation };
+const invalidMessage = (fieldName, supportedChars) =>
+  `${fieldName} is not valid. Valid chars are ${buildValidCharsStrFromSupportedChars(
+    supportedChars
+  )} `;
+
+const fieldMatcher = (fieldName, supportedChars) => {
+  return [
+    buildRegexFromSupportedChars(supportedChars),
+    {
+      excludeEmptyString: true,
+      message: invalidMessage(fieldName, supportedChars)
+    }
+  ];
+};
+
+const buildValidCharsStrFromSupportedChars = supportedChars =>
+  supportedChars.reduce((str, v) => str + v, "");
+
+const synchronousValidation = (values, { policy }) => {
+  if (!policy)
+    return {
+      waiting: "policy"
+    };
+  const validationSchema = invoiceValidationSchema(policy);
+  try {
+    validationSchema.validateSync(values, { abortEarly: false });
+    return {};
+  } catch (e) {
+    return yupToFormErrors(e);
+  }
+};
+
+export { synchronousValidation };

--- a/src/validators/invoice.js
+++ b/src/validators/invoice.js
@@ -8,7 +8,10 @@ const invoiceValidationSchema = ({
   mincontactlength,
   maxcontactlength,
   minnamelength,
-  maxnamelength
+  maxnamelength,
+  minlineitemcollength,
+  maxlineitemcollength,
+  invoicefieldsupportedchars
 }) =>
   Yup.object().shape({
     name: Yup.string()
@@ -30,8 +33,44 @@ const invoiceValidationSchema = ({
       .required("required")
       .min(5)
       .max(500),
-    address: Yup.string().required("required")
+    address: Yup.string().required("required"),
+    lineitems: Yup.array()
+      .of(
+        Yup.object().shape({
+          type: Yup.string()
+            .required("required")
+            .oneOf(["1", "2", "3"]),
+          domain: Yup.string()
+            .required("required")
+            .min(minlineitemcollength)
+            .max(maxlineitemcollength)
+            .matches(...fieldMatcher("Domain", invoicefieldsupportedchars)),
+          subdomain: Yup.string()
+            .required("required")
+            .min(minlineitemcollength)
+            .max(maxlineitemcollength)
+            .matches(...fieldMatcher("Sub domain", invoicefieldsupportedchars)),
+          description: Yup.string()
+            .min(minlineitemcollength)
+            .max(maxlineitemcollength)
+            .matches(...fieldMatcher("Description", invoicefieldsupportedchars))
+        })
+      )
+      .min(1)
   });
+
+/** Captures a value such as 'lineitems[0].description' */
+const lineItemPathRegex = /[A-z]*\[[0-9]*\]\.[A-z]*/gm;
+
+const getErrorForLineItem = (errors, errPath, errMessage) => {
+  const column = errPath.split(".")[1];
+  const position = +/\[([0-9])*\]/gm.exec(errPath)[1] + 1;
+  const message = `'${column}' of item ${position} ${errMessage.replace(
+    lineItemPathRegex,
+    ""
+  )}`;
+  return (errors.lineitems || []).concat([message]);
+};
 
 export function yupToFormErrors(yupError) {
   let errors = {};
@@ -40,7 +79,15 @@ export function yupToFormErrors(yupError) {
   }
   for (const err of yupError.inner) {
     if (!errors[err.path]) {
-      errors = { ...errors, [err.path]: err.message };
+      const isLineItemPath = lineItemPathRegex.test(err.path);
+      if (isLineItemPath) {
+        errors = {
+          ...errors,
+          lineitems: getErrorForLineItem(errors, err.path, err.message)
+        };
+      } else {
+        errors = { ...errors, [err.path]: err.message };
+      }
     }
   }
   return errors;

--- a/src/validators/invoice.js
+++ b/src/validators/invoice.js
@@ -53,7 +53,11 @@ const invoiceValidationSchema = ({
           description: Yup.string()
             .min(minlineitemcollength)
             .max(maxlineitemcollength)
-            .matches(...fieldMatcher("Description", invoicefieldsupportedchars))
+            .matches(
+              ...fieldMatcher("Description", invoicefieldsupportedchars)
+            ),
+          labour: Yup.number(),
+          expense: Yup.number()
         })
       )
       .min(1)
@@ -94,7 +98,11 @@ export function yupToFormErrors(yupError) {
 }
 
 const buildRegexFromSupportedChars = supportedChars => {
-  const concatedChars = supportedChars.reduce((str, v) => str + `\\${v}`, "");
+  const charNeedsEscaping = c => c === "/" || c === "." || c === "-";
+  const concatedChars = supportedChars.reduce(
+    (str, char) => (charNeedsEscaping(char) ? str + `\\${char}` : str + char),
+    ""
+  );
   const regex = "^[" + concatedChars + "]*$";
   return new RegExp(regex);
 };

--- a/src/validators/submit.js
+++ b/src/validators/submit.js
@@ -2,15 +2,10 @@ import {
   validate as proposalValidate,
   synchronousValidation as proposalSynchronousValidation
 } from "./proposal";
-import {
-  validate as invoiceValidate,
-  synchronousValidation as invoiceSynchronousValidation
-} from "./invoice";
+import { synchronousValidation as invoiceSynchronousValidation } from "./invoice";
 
 const validate = (values, dispatch, props) => {
-  return props.isCMS
-    ? invoiceValidate(values, dispatch, props)
-    : proposalValidate(values, dispatch, props);
+  return props.isCMS ? () => {} : proposalValidate(values, dispatch, props);
 };
 
 const synchronousValidation = (values, props) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -751,6 +751,13 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.0.0":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.5.tgz#582bb531f5f9dc67d2fcb682979894f75e253f12"
+  integrity sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/runtime@^7.1.2":
   version "7.1.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.1.5.tgz#4170907641cf1f61508f563ece3725150cc6fe39"
@@ -9896,6 +9903,11 @@ regenerator-runtime@^0.12.0:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
 
+regenerator-runtime@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
+  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
+
 regenerator-transform@^0.10.0:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.10.1.tgz#1e4996837231da8b7f3cf4114d71b5691a0680dd"
@@ -11056,6 +11068,11 @@ synchronous-promise@^2.0.5:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.6.tgz#de76e0ea2b3558c1e673942e47e714a930fa64aa"
   integrity sha512-TyOuWLwkmtPL49LHCX1caIwHjRzcVd62+GF6h8W/jHOeZUFHpnd2XJDVuUlaTaLPH1nuu2M69mfHr5XbQJnf/g==
+
+synchronous-promise@^2.0.6:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.8.tgz#01fd026fffdbf2d3d39ec06ee1a7c971578136f7"
+  integrity sha512-xYavZtFC1vKgJu0AOSYdrLeikNCsNwmUeZaV1XF9cMqEhBVVxLq6rEbYzOGrF1MV2MNPkhsJqqiXuQ4a76CEUg==
 
 table@^5.0.2:
   version "5.2.3"
@@ -12248,4 +12265,16 @@ yup@^0.26.10:
     lodash "^4.17.10"
     property-expr "^1.5.0"
     synchronous-promise "^2.0.5"
+    toposort "^2.0.2"
+
+yup@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-0.27.0.tgz#f8cb198c8e7dd2124beddc2457571329096b06e7"
+  integrity sha512-v1yFnE4+u9za42gG/b/081E7uNW9mUj3qtkmelLbW5YPROZzSH/KUUyJu9Wt8vxFJcT9otL/eZopS0YK1L5yPQ==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    fn-name "~2.0.1"
+    lodash "^4.17.11"
+    property-expr "^1.5.0"
+    synchronous-promise "^2.0.6"
     toposort "^2.0.2"


### PR DESCRIPTION
This PR improves the invoices validation by:
- Adding full policy validation for invoice fields
- Display better validation message (including allowed chars)

It also improves the validation code by introducing [Yup](https://github.com/jquense/yup). This lib has more 'declarative' approach for dealing with forms validation. This dep is going to be introduced in the redesign process so I figure would be nice to use it already for invoices validation. The datasheet component doesn't handle the line items validation anymore, all the validation, including line items, were lifted to the synchronous validation using redux form + yup.

