### PR TITLE
[cms] Disable comments for approved/paid/rejected

### DIFF
--- a/src/components/snew/CommentForm.js
+++ b/src/components/snew/CommentForm.js
@@ -30,14 +30,12 @@ const CommentForm = ({
   onClose,
   hide = false,
   invoice,
-  isAdmin,
   isCMS
 }) => {
   const isCommentInvoiceUnavailable = isCMS
-    ? (invoice.status === INVOICE_STATUS_APPROVED ||
-        invoice.status === INVOICE_STATUS_PAID ||
-        invoice.status === INVOICE_STATUS_REJECTED) &&
-      isAdmin
+    ? invoice.status === INVOICE_STATUS_APPROVED ||
+      invoice.status === INVOICE_STATUS_PAID ||
+      invoice.status === INVOICE_STATUS_REJECTED
     : false;
   const isVotingFinished =
     getVoteStatus(token) &&


### PR DESCRIPTION
Previously users were able to comment on approved invoices.

This now matches the rule set on the backend.