### PR TITLE
Improve Politeia mode verification

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -96,10 +96,12 @@ class Loader extends Component {
 
   render() {
     return (
-      <div className="appWrapper">
-        <ModalStack />
-        {this.props.children}
-      </div>
+      this.props.isModeFetched && (
+        <div className="appWrapper">
+          <ModalStack />
+          {this.props.children}
+        </div>
+      )
     );
   }
 }

--- a/src/components/RecordDetail/RecordDetail.js
+++ b/src/components/RecordDetail/RecordDetail.js
@@ -58,7 +58,7 @@ class RecordDetail extends React.Component {
   };
   componentDidUpdate(prevProps) {
     this.resolveTabTitle(prevProps);
-    this.resolveFetchLikedComments(prevProps);
+    !this.props.isCMS && this.resolveFetchLikedComments(prevProps);
     this.resolveFetchProposalVoteStatus(prevProps);
     this.handleUpdateOfComments(prevProps, this.props);
   }

--- a/src/components/UserDetail/index.js
+++ b/src/components/UserDetail/index.js
@@ -55,7 +55,7 @@ class UserDetail extends Component {
 
   componentDidMount() {
     this.props.onFetchData(this.props.userId);
-    this.props.onFetchUserProposals(this.props.userId);
+    !this.props.isCMS && this.props.onFetchUserProposals(this.props.userId);
   }
 
   onTabChange(tabId) {

--- a/src/connectors/loader.js
+++ b/src/connectors/loader.js
@@ -14,7 +14,8 @@ export default connect(
     lastLoginTime: sel.lastLoginTimeFromLoginResponse,
     onboardViewed: sel.onboardViewed,
     identityImportSuccess: sel.identityImportSuccess,
-    isCMS: sel.isCMS
+    isCMS: sel.isCMS,
+    isModeFetched: sel.isModeFetched
   }),
   dispatch =>
     bindActionCreators(

--- a/src/selectors/api.js
+++ b/src/selectors/api.js
@@ -691,6 +691,14 @@ const mode = compose(
   apiInitResponse
 );
 
+export const isModeFetched = state => {
+  if (mode(state) === undefined) {
+    return false;
+  } else {
+    return true;
+  }
+};
+
 export const isCMS = state => mode(state) === CMSWWWMODE;
 
 export const invoiceToken = compose(


### PR DESCRIPTION
Closes #1210 and #1217 

This commit adds a new API selector, `isModeFetched`. This selector is used in the App component to prevent rendering of the app until the mode is fetched from the backend.

This commit also adds `isCMS` checks to the `userDetail` and `recordDetail` components to prevent non-CMS requests from firing.