### PR TITLE
Set 'Politeia' placeholder for document title

### DIFF
--- a/src/components/RecordDetail/RecordDetail.js
+++ b/src/components/RecordDetail/RecordDetail.js
@@ -29,7 +29,7 @@ class RecordDetail extends React.Component {
         prevProps.record.name !== proposal.name) ||
       (proposal && proposal.name !== document.title);
     if (proposalNameHasBeenUpdated) {
-      document.title = proposal.name;
+      document.title = proposal.name || DEFAULT_TAB_TITLE;
     }
   };
   resolveFetchProposalVoteStatus = () => {


### PR DESCRIPTION
Closes #1239 

This commit adds "Politeia" as a placeholder until the proposal name is resolved. Previously, the document title would revert to undefined until the proposal name was resolved.