### PR TITLE
Fix access to draft prposals

### DIFF
--- a/src/components/snew/ThingLink/ThingLinkProposal.js
+++ b/src/components/snew/ThingLink/ThingLinkProposal.js
@@ -176,6 +176,7 @@ class ThingLinkComp extends React.Component {
     const loadingCensor = status && status === PROPOSAL_STATUS_CENSORED;
     const loadingApprove = status && status === PROPOSAL_STATUS_PUBLIC;
     const loadingAbandoned = status && status === PROPOSAL_STATUS_ABANDONED;
+    const isDraft = !!draftId;
 
     const censoredorAbandoned = () => {
       if (review_status === PROPOSAL_STATUS_CENSORED) {
@@ -226,7 +227,7 @@ class ThingLinkComp extends React.Component {
             className="title"
             style={{ display: "flex", overflow: "visible", cursor: "pointer" }}
           >
-            <Link to={`/proposals/${id}`} className="right-margin-5">
+            <Link to={url} className="right-margin-5">
               {title}{" "}
               {review_status === PROPOSAL_STATUS_UNREVIEWED_CHANGES ? (
                 <span className="font-12 warning-color">edited</span>
@@ -603,15 +604,17 @@ class ThingLinkComp extends React.Component {
                 </Link>
               </li>
             ) : null}
-            <li>
-              <Link
-                className="bylink comments may-blank proposal-permalink"
-                data-event-action="permalink"
-                to={permalink}
-              >
-                permalink
-              </Link>
-            </li>
+            {!isDraft && (
+              <li>
+                <Link
+                  className="bylink comments may-blank proposal-permalink"
+                  data-event-action="permalink"
+                  to={permalink}
+                >
+                  permalink
+                </Link>
+              </li>
+            )}
             {isVotingActiveOrFinished && (
               <li>
                 <Link

--- a/src/lib/snew.js
+++ b/src/lib/snew.js
@@ -37,8 +37,7 @@ export const proposalToT3 = (
     publishedat,
     censoredat,
     abandonedat,
-    permalink: `/proposals/${censorshiprecord.token ||
-      (draftId ? `new?draftid=${draftId}` : "")}`,
+    permalink: `/proposals/${censorshiprecord.token}`,
     url: `/proposals/${censorshiprecord.token ||
       (draftId ? `new?draftid=${draftId}` : "")}`,
     is_self: true,


### PR DESCRIPTION
This PR fixes access to draft proposals. It also removes the "permalink" for draft proposals since all it does is to take the user to the new proposal's route.
closes #1244 