### PR TITLE
Disable 'Remove Row' Button when there is one lineitem row

### DIFF
--- a/src/components/InvoiceDatasheet/InvoiceDatasheet.js
+++ b/src/components/InvoiceDatasheet/InvoiceDatasheet.js
@@ -43,13 +43,12 @@ const InvoiceDatasheet = ({ value, onChange, readOnly, userRate }) => {
 
   const handleRemoveLastRow = e => {
     e.preventDefault();
-    if (grid.length > 2) {
+    if (grid.length > 3) {
       onChange(dropRight(value, 1));
     }
   };
 
-  const removeRowsIsDisabled = grid && grid.length <= 2;
-
+  const removeRowsIsDisabled = grid && grid.length <= 3;
   return (
     <div className="sheet-container">
       <ReactDataSheet

--- a/src/validators/invoice.js
+++ b/src/validators/invoice.js
@@ -90,7 +90,7 @@ export function yupToFormErrors(yupError) {
           lineitems: getErrorForLineItem(errors, err.path, err.message)
         };
       } else {
-        errors = { ...errors, [err.path]: err.message };
+        errors = { ...errors, [err.path]: [err.message] };
       }
     }
   }

--- a/src/validators/invoice.js
+++ b/src/validators/invoice.js
@@ -90,7 +90,7 @@ export function yupToFormErrors(yupError) {
           lineitems: getErrorForLineItem(errors, err.path, err.message)
         };
       } else {
-        errors = { ...errors, [err.path]: [err.message] };
+        errors = { ...errors, [err.path]: err.message };
       }
     }
   }


### PR DESCRIPTION
Closes #1250 

This commit wraps error messages from our invoice validation schema in an array. This solves the problem where the error dropdown for line items was trying to map over a string as opposed to an array, which caused a soft UX crash.