### PR TITLE
Improve quorum tooltip

### DIFF
--- a/src/components/VoteStats/StatsDisplay.js
+++ b/src/components/VoteStats/StatsDisplay.js
@@ -245,9 +245,9 @@ class Stats extends React.Component {
               Quorum:
               <Tooltip
                 tipStyle={{
-                  left: "110px",
-                  bottom: "-5px",
-                  padding: "6px",
+                  left: "105px",
+                  top: "-2px",
+                  padding: "3px",
                   textAlign: "center",
                   minWidth: "300px"
                 }}

--- a/src/components/VoteStats/StatsDisplay.js
+++ b/src/components/VoteStats/StatsDisplay.js
@@ -203,10 +203,7 @@ class Stats extends React.Component {
     const isPreVoting =
       status === PROPOSAL_VOTING_NOT_AUTHORIZED ||
       status === PROPOSAL_VOTING_AUTHORIZED;
-    const currentQuorumPercentage = getPercentage(
-      totalVotes,
-      numOfEligibleVotes
-    );
+
     const quorumInVotes = Math.trunc(
       (numOfEligibleVotes * quorumPercentage) / 100
     );
@@ -248,12 +245,13 @@ class Stats extends React.Component {
               Quorum:
               <Tooltip
                 tipStyle={{
-                  left: "80px",
-                  maxWidth: "100px",
+                  left: "110px",
+                  bottom: "-5px",
                   padding: "6px",
-                  textAlign: "center"
+                  textAlign: "center",
+                  minWidth: "300px"
                 }}
-                text={`${currentQuorumPercentage}/${quorumPercentage} %`}
+                text={`Quorum minimum is ${quorumPercentage}% of ${numOfEligibleVotes} elegible votes`}
                 position="right"
               >
                 <span


### PR DESCRIPTION
closes #1225 
This PR simplifies the tooltip message and yet make it more informative. Here is the output of it:
![Screen Shot 2019-06-10 at 16 55 18](https://user-images.githubusercontent.com/14864439/59204329-b1787300-8ba0-11e9-8007-900fe5f7863f.png)
