### PR TITLE
Prevent redirect on invoice/edit route

### DIFF
--- a/src/hocs/editInvoice.js
+++ b/src/hocs/editInvoice.js
@@ -60,6 +60,7 @@ class EditInvoiceContainer extends Component {
       this.props.onResetInvoice();
       return this.props.history.push("/invoices/" + editedInvoiceToken);
     }
+    const isUserIDFetched = this.props.userid !== null ? true : false;
     const isInvoiceFetched =
       invoice &&
       invoice.censorshiprecord &&
@@ -85,7 +86,7 @@ class EditInvoiceContainer extends Component {
         }
       });
     }
-    if (isInvoiceFetched && !invoiceBelongsToTheUser) {
+    if (isInvoiceFetched && isUserIDFetched && !invoiceBelongsToTheUser) {
       this.props.history.push("/");
     }
   }


### PR DESCRIPTION
Closes #1259 

This commit ensures that the necessary props (userID) are loaded before running the redirect code on the /invoice/edit route.