### PR TITLE
Improve UX for Invoice Multiline Editor

### DIFF
--- a/src/components/InvoiceDatasheet/MultiLineEditor.js
+++ b/src/components/InvoiceDatasheet/MultiLineEditor.js
@@ -7,7 +7,19 @@ class MultiLineEditor extends React.Component {
   }
 
   componentDidMount() {
-    this._input.focus();
+    this.resizeText();
+  }
+
+  componentDidUpdate() {
+    this.resizeText();
+  }
+
+  //Sets height and maxheight of textarea to scrollheight
+  resizeText() {
+    if (this.textAreaRef) {
+      this.textAreaRef.style.height = this.textAreaRef.scrollHeight + "px";
+      this.textAreaRef.style.maxHeight = this.textAreaRef.scrollHeight + "px";
+    }
   }
 
   handleInputChange(event) {
@@ -18,13 +30,12 @@ class MultiLineEditor extends React.Component {
     const { value, onKeyDown } = this.props;
     return (
       <textarea
+        autoFocus
         className="multiline-cell-editor"
-        ref={input => {
-          this._input = input;
-        }}
         value={value}
-        onChange={this.handleInputChange}
         onKeyDown={onKeyDown}
+        onChange={this.handleInputChange}
+        ref={textAreaRef => (this.textAreaRef = textAreaRef)}
       />
     );
   }

--- a/src/components/InvoiceDatasheet/MultiLineEditor.js
+++ b/src/components/InvoiceDatasheet/MultiLineEditor.js
@@ -4,6 +4,7 @@ class MultiLineEditor extends React.Component {
   constructor(props) {
     super(props);
     this.handleInputChange = this.handleInputChange.bind(this);
+    this.handleOnKeyDownCapture = this.handleOnKeyDownCapture.bind(this);
   }
 
   componentDidMount() {
@@ -14,16 +15,23 @@ class MultiLineEditor extends React.Component {
     this.resizeText();
   }
 
+  handleInputChange(event) {
+    this.props.onChange(event.target.value);
+  }
+
+  // Prevents default onKeyDown if shift + enter are pressed
+  handleOnKeyDownCapture(event) {
+    if (event.keyCode === 13 && event.shiftKey) {
+      event.stopPropagation();
+    }
+  }
+
   //Sets height and maxheight of textarea to scrollheight
   resizeText() {
     if (this.textAreaRef) {
       this.textAreaRef.style.height = this.textAreaRef.scrollHeight + "px";
       this.textAreaRef.style.maxHeight = this.textAreaRef.scrollHeight + "px";
     }
-  }
-
-  handleInputChange(event) {
-    this.props.onChange(event.target.value);
   }
 
   render() {
@@ -33,8 +41,9 @@ class MultiLineEditor extends React.Component {
         autoFocus
         className="multiline-cell-editor"
         value={value}
-        onKeyDown={onKeyDown}
         onChange={this.handleInputChange}
+        onKeyDownCapture={this.handleOnKeyDownCapture}
+        onKeyDown={onKeyDown}
         ref={textAreaRef => (this.textAreaRef = textAreaRef)}
       />
     );

--- a/src/components/InvoiceDatasheet/styles.css
+++ b/src/components/InvoiceDatasheet/styles.css
@@ -102,8 +102,10 @@ pre {
 
 .multiline-cell-value {
 	word-break: break-word;
+	white-space: pre-line !important;
 }
 
 .multiline-cell-editor {
 	resize: vertical;
+	height: 25px;
 }


### PR DESCRIPTION
Closes #1258 

This commit adds a few UX improvements to the multiline editor for the Invoice datasheet. Users can now:
* Navigate the editor with the arrow keys
* Add a line break by pressing `shift + enter`

In addition, the text editor now resizes as the text content grows.