### PR TITLE
Fixes form crash when contractor rate isn't a number

### DIFF
--- a/src/components/snew/SubmitPage/SubmitPageInvoice.js
+++ b/src/components/snew/SubmitPage/SubmitPageInvoice.js
@@ -78,7 +78,9 @@ const InvoiceSubmit = props => {
   };
 
   const handleContractorRateChange = e =>
-    setContractorRate(e.target.valueAsNumber);
+    !isNaN(e.target.valueAsNumber)
+      ? setContractorRate(e.target.valueAsNumber)
+      : setContractorRate(0);
 
   return (
     <div className="content" role="main">

--- a/src/validators/invoice.js
+++ b/src/validators/invoice.js
@@ -32,7 +32,8 @@ const invoiceValidationSchema = ({
     rate: Yup.number()
       .required("required")
       .min(5)
-      .max(500),
+      .max(500)
+      .typeError("rate must be a number"),
     address: Yup.string().required("required"),
     lineitems: Yup.array()
       .of(


### PR DESCRIPTION
Fixes crash when contractor rate wasn't a number, and cast resulted in NaN.