### PR TITLE
Improve proposal details page efficiency

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -1079,7 +1079,12 @@ export const onFetchProposalVoteStatus = token => dispatch => {
     })
     .catch(error => {
       dispatch(act.RECEIVE_PROPOSAL_VOTE_STATUS(null, error));
-      throw error;
+      // Discard error when proposal is not public
+      if (error.errorCode === 28) {
+        return;
+      } else {
+        throw error;
+      }
     });
 };
 

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -227,10 +227,10 @@ export const onSaveChangePassword = ({ existingPassword, newPassword }) => (
     sel.newProposalToken(getState())
   );
 
-export const onFetchProposalApp = token => dispatch =>
-  dispatch(onFetchProposalApi(token)).then(() =>
-    dispatch(onFetchProposalComments(token))
-  );
+export const onFetchProposalApp = token => dispatch => {
+  dispatch(onFetchProposalApi(token));
+  dispatch(onFetchProposalComments(token));
+};
 
 export const onFetchInvoiceApp = (token, version = null) => dispatch =>
   dispatch(onFetchInvoiceApi(token, version)).then(() =>

--- a/src/components/RecordDetail/RecordDetail.js
+++ b/src/components/RecordDetail/RecordDetail.js
@@ -4,7 +4,7 @@ import { withRouter } from "react-router-dom";
 import { Content } from "../snew";
 import { commentsToT1, proposalToT3, invoiceToT3 } from "../../lib/snew";
 import { getTextFromIndexMd } from "../../helpers";
-import { DEFAULT_TAB_TITLE, PROPOSAL_STATUS_PUBLIC } from "../../constants";
+import { DEFAULT_TAB_TITLE } from "../../constants";
 import Message from "../Message";
 import {
   updateSortedComments,
@@ -45,27 +45,17 @@ class RecordDetail extends React.Component {
       this.props.onFetchLikedComments(this.props.token);
     }
   };
-  resolveFetchProposalVoteStatus = prevProps => {
-    const { isCMS, record, onFetchProposalVoteStatus, token } = this.props;
-    const proposal = !isCMS && record;
-    const proposalIsPublic = proposal.status === PROPOSAL_STATUS_PUBLIC;
-    const proposalJustFetched =
-      proposal &&
-      (!prevProps.record || Object.keys(prevProps.record).length === 0);
-    if (proposalJustFetched && proposalIsPublic) {
-      onFetchProposalVoteStatus(token);
-    }
-  };
   componentDidUpdate(prevProps) {
     this.resolveTabTitle(prevProps);
     !this.props.isCMS && this.resolveFetchLikedComments(prevProps);
-    this.resolveFetchProposalVoteStatus(prevProps);
     this.handleUpdateOfComments(prevProps, this.props);
   }
   componentDidMount() {
     !this.props.isCMS &&
       this.props.loggedInAsEmail &&
       this.props.onFetchLikedComments(this.props.token);
+
+    this.resolveFetchProposalVoteStatus();
   }
 
   componentWillUnmount() {

--- a/src/connectors/reply.js
+++ b/src/connectors/reply.js
@@ -58,7 +58,11 @@ class Wrapper extends React.PureComponent {
   }
 
   componentDidMount() {
-    this.props.policy || this.props.onFetchData();
+    // Only request policy for the CommentForm component
+    if (this.props.Component.name === "CommentForm") {
+      this.props.policy || this.props.onFetchData();
+    }
+
     // this.props.initialize(getNewCommentData());
   }
 


### PR DESCRIPTION
Resolves #1230

This commit updates the the policy, vote status, and comments requests so that they fire concurrently on the proposal details page.

This commit also fixes the bug where duplicate policy requests were being called.