### PR TITLE
Fix `how to contribute` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Relevant libraries/modules used for testing are:
 
 ## Contributing 
 
-We encourage you to contribute to Politeiagui. Please check [How to contribute to Politeiagui](../CONTRIBUTING.md) for guidelines about how to proceed.
+We encourage you to contribute to Politeiagui. Please check [How to contribute to Politeiagui](../master/CONTRIBUTING.md) for guidelines about how to proceed.
 
 ## Docker
 


### PR DESCRIPTION
* closes #1336 