### PR TITLE
[redesign] Add proposal form loader and fixes initial form values on edit

### DIFF
--- a/src/componentsv2/ProposalForm/ProposalFormLoader.jsx
+++ b/src/componentsv2/ProposalForm/ProposalFormLoader.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+import ContentLoader from "react-content-loader";
+
+const ProposalFormLoader = () => (
+  <ContentLoader
+    height={420}
+    width={800}
+    speed={2}
+    primaryColor="#f3f3f3"
+    secondaryColor="#ecebeb"
+  >
+    <rect x="0" y="10" width="800" height="40" />
+
+    <rect x="0" y="75" width="800" height="1" />
+
+    <rect x="0" y="100" width="800" height="150" />
+
+    <rect x="0" y="280" width="800" height="1" />
+    <rect x="0" y="310" width="130" height="14" />
+    <rect x="150" y="310" width="130" height="14" />
+    <rect x="500" y="360" width="140" height="40" />
+    <rect x="650" y="360" width="140" height="40" />
+  </ContentLoader>
+);
+
+export default ProposalFormLoader;

--- a/src/containers/Proposal/Edit/Edit.jsx
+++ b/src/containers/Proposal/Edit/Edit.jsx
@@ -9,6 +9,7 @@ import useIdentity from "src/hooks/useIdentity";
 import Or from "src/componentsv2/Or";
 import { IdentityMessageError } from "src/componentsv2/IdentityErrorIndicators";
 import ProposalForm from "src/componentsv2/ProposalForm";
+import ProposalFormLoader from "src/componentsv2/ProposalForm/ProposalFormLoader";
 
 const EditProposal = ({ match }) => {
   const { proposal, loading } = useProposal({ match });
@@ -23,10 +24,10 @@ const EditProposal = ({ match }) => {
         description: getMarkdownContent(proposal.files),
         files: proposal.files.filter(p => p.name !== "index.md")
       }
-    : {};
+    : null;
 
-  return !!proposal && !loading ? (
-    <Card className="container">
+  return (
+    <Card className={"container"}>
       <Or>
         {!isPaid && (
           <Message kind="error">
@@ -35,9 +36,13 @@ const EditProposal = ({ match }) => {
         )}
         {!!identityError && <IdentityMessageError />}
       </Or>
-      <ProposalForm initialValues={initialValues} onSubmit={onEditProposal} />
+      { !loading && !!proposal ?
+        <ProposalForm initialValues={initialValues} onSubmit={onEditProposal} />
+        :
+        <ProposalFormLoader />
+      }
     </Card>
-  ) : null;
-};
+  );
+}
 
 export default withRouter(EditProposal);


### PR DESCRIPTION
This PR fixes #1344. 

When the proposal wasn't fetched from the server yet, initial values on edit were set to an empty object, leading to errors on our form. This also adds a loader to give visual feedback until the proposal is fetched. Talking to @fernandoabolafio, we agreed that the difference from the production bundle and our local dev env was the difference in response time; since locally it happens pretty fast, the form didn't crash.