### PR TITLE
[redesign] Improve UX for "go back" buttons on proposal details

### DIFF
--- a/src/Appv2/Appv2.js
+++ b/src/Appv2/Appv2.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { BrowserRouter as Router } from "react-router-dom";
+import { Router } from "src/componentsv2/Router";
 import Config from "src/Config";
 import { defaultLightTheme, useTheme } from "pi-ui";
 import { ReduxProvider } from "src/redux";

--- a/src/componentsv2/Router/Router.jsx
+++ b/src/componentsv2/Router/Router.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { BrowserRouter as ReactRouter } from "react-router-dom";
+import RouterProvider from "./RouterProvider";
+
+const Router = ({ children }) => (
+  <ReactRouter>
+    <RouterProvider>{children}</RouterProvider>
+  </ReactRouter>
+);
+
+export default Router;

--- a/src/componentsv2/Router/RouterProvider.jsx
+++ b/src/componentsv2/Router/RouterProvider.jsx
@@ -1,0 +1,26 @@
+import React, { createContext, useContext, useState, useEffect } from "react";
+import { withRouter } from "react-router-dom";
+
+const routerCtx = createContext();
+
+export const useRouter = () => useContext(routerCtx);
+
+const RouterProvider = ({ location, history, children, ...rest }) => {
+  const [pastLocations, setPastLocations] = useState([]);
+  const [previousLocation, setPreviousLocation] = useState(null);
+
+  useEffect(() => {
+    setPreviousLocation(pastLocations[0]);
+    setPastLocations([location].concat(pastLocations));
+  }, [location]);
+
+  return (
+    <routerCtx.Provider
+      value={{ ...rest, location, history, pastLocations, previousLocation }}
+    >
+      {children}
+    </routerCtx.Provider>
+  );
+};
+
+export default withRouter(RouterProvider);

--- a/src/componentsv2/Router/RouterProvider.jsx
+++ b/src/componentsv2/Router/RouterProvider.jsx
@@ -1,4 +1,11 @@
-import React, { createContext, useContext, useState, useEffect } from "react";
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useMemo
+} from "react";
+import isEqual from "lodash/isEqual";
 import { withRouter } from "react-router-dom";
 
 const routerCtx = createContext();
@@ -7,20 +14,19 @@ export const useRouter = () => useContext(routerCtx);
 
 const RouterProvider = ({ location, history, children, ...rest }) => {
   const [pastLocations, setPastLocations] = useState([]);
-  const [previousLocation, setPreviousLocation] = useState(null);
 
   useEffect(() => {
-    setPreviousLocation(pastLocations[0]);
-    setPastLocations([location].concat(pastLocations));
-  }, [location]);
+    if (!isEqual(pastLocations[0], location)) {
+      setPastLocations([location].concat(pastLocations));
+    }
+  }, [location, pastLocations]);
 
-  return (
-    <routerCtx.Provider
-      value={{ ...rest, location, history, pastLocations, previousLocation }}
-    >
-      {children}
-    </routerCtx.Provider>
+  const ctxValue = useMemo(
+    () => ({ ...rest, location, history, pastLocations }),
+    [rest, location, history, pastLocations]
   );
+
+  return <routerCtx.Provider value={ctxValue}>{children}</routerCtx.Provider>;
 };
 
 export default withRouter(RouterProvider);

--- a/src/componentsv2/Router/RouterProvider.jsx
+++ b/src/componentsv2/Router/RouterProvider.jsx
@@ -12,7 +12,7 @@ const routerCtx = createContext();
 
 export const useRouter = () => useContext(routerCtx);
 
-const RouterProvider = ({ location, history, children, ...rest }) => {
+const RouterProvider = ({ location, children, ...rest }) => {
   const [pastLocations, setPastLocations] = useState([]);
 
   useEffect(() => {
@@ -21,10 +21,11 @@ const RouterProvider = ({ location, history, children, ...rest }) => {
     }
   }, [location, pastLocations]);
 
-  const ctxValue = useMemo(
-    () => ({ ...rest, location, history, pastLocations }),
-    [rest, location, history, pastLocations]
-  );
+  const ctxValue = useMemo(() => ({ ...rest, location, pastLocations }), [
+    rest,
+    location,
+    pastLocations
+  ]);
 
   return <routerCtx.Provider value={ctxValue}>{children}</routerCtx.Provider>;
 };

--- a/src/componentsv2/Router/index.js
+++ b/src/componentsv2/Router/index.js
@@ -1,0 +1,2 @@
+export { default as Router } from "./Router";
+export * from "./RouterProvider";

--- a/src/containers/Proposal/Detail/Detail.jsx
+++ b/src/containers/Proposal/Detail/Detail.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo, useCallback } from "react";
 import { withRouter } from "react-router-dom";
 import Proposal from "src/componentsv2/Proposal";
 import styles from "./Detail.module.css";
@@ -17,6 +17,7 @@ import {
   PublicActionsProvider
 } from "src/containers/Proposal/Actions";
 import { useProposalVote } from "../hooks";
+import { useRouter } from "src/componentsv2/Router";
 
 const ProposalDetail = ({ TopBanner, PageDetails, Sidebar, Main, match }) => {
   const { proposal, loading, threadParentID } = useProposal({ match });
@@ -29,16 +30,45 @@ const ProposalDetail = ({ TopBanner, PageDetails, Sidebar, Main, match }) => {
   const canReceiveComments =
     isPublicProposal(proposal) && !isVotingFinishedProposal(voteStatus);
 
+  const { previousLocation, history } = useRouter();
+
+  const returnToPreviousLocation = useCallback(() => history.goBack(), [
+    history
+  ]);
+
+  const goBackLinkFromPreviousLocation = useMemo(() => {
+    if (!previousLocation) return null;
+    let message = "";
+
+    switch (previousLocation.pathname) {
+      case "/":
+        message = "Go back to public proposals";
+        break;
+      case "/proposals/unvetted":
+        message = "Go back to unvetted proposals";
+        break;
+      default:
+        if (previousLocation.pathname.match("/user/*")) {
+          message = "Go back to user account";
+        }
+        break;
+    }
+
+    if (!message) return null;
+
+    return (
+      <Link gray to="/" onClick={returnToPreviousLocation}>
+        &#8592; {message}
+      </Link>
+    );
+  }, [previousLocation, returnToPreviousLocation]);
+
   return (
     <>
       <TopBanner>
         <PageDetails
           title={"Proposal Details"}
-          subtitle={
-            <Link gray to="/">
-              &#8592; Go back to all proposals
-            </Link>
-          }
+          subtitle={goBackLinkFromPreviousLocation}
         />
       </TopBanner>
       <Sidebar />

--- a/src/containers/Proposal/Detail/Detail.jsx
+++ b/src/containers/Proposal/Detail/Detail.jsx
@@ -1,10 +1,10 @@
 import React, { useMemo, useCallback } from "react";
+import { Link } from "pi-ui";
 import { withRouter } from "react-router-dom";
 import Proposal from "src/componentsv2/Proposal";
 import styles from "./Detail.module.css";
 import { useProposal } from "./hooks";
 import Comments from "src/containers/Comments";
-import Link from "src/componentsv2/Link";
 import ProposalLoader from "src/componentsv2/Proposal/ProposalLoader";
 import { getCommentBlockedReason } from "./helpers";
 import {
@@ -30,7 +30,9 @@ const ProposalDetail = ({ TopBanner, PageDetails, Sidebar, Main, match }) => {
   const canReceiveComments =
     isPublicProposal(proposal) && !isVotingFinishedProposal(voteStatus);
 
-  const { previousLocation, history } = useRouter();
+  const { pastLocations, history } = useRouter();
+
+  const previousLocation = pastLocations[1];
 
   const returnToPreviousLocation = useCallback(() => history.goBack(), [
     history
@@ -57,7 +59,11 @@ const ProposalDetail = ({ TopBanner, PageDetails, Sidebar, Main, match }) => {
     if (!message) return null;
 
     return (
-      <Link gray to="/" onClick={returnToPreviousLocation}>
+      <Link
+        gray
+        className={styles.returnLink}
+        onClick={returnToPreviousLocation}
+      >
         &#8592; {message}
       </Link>
     );

--- a/src/containers/Proposal/Detail/Detail.module.css
+++ b/src/containers/Proposal/Detail/Detail.module.css
@@ -2,3 +2,7 @@
     background: none !important;
     overflow: hidden;
 }
+
+.returnLink {
+    cursor: pointer;
+}

--- a/src/containers/User/Search/Search.jsx
+++ b/src/containers/User/Search/Search.jsx
@@ -8,7 +8,6 @@ import {
   Message
 } from "pi-ui";
 import { Formik } from "formik";
-import Link from "src/componentsv2/Link";
 import styles from "./Search.module.css";
 import * as Yup from "yup";
 import { useSearchUser } from "./hooks";
@@ -48,11 +47,6 @@ const UserSearch = ({ TopBanner, PageDetails, Sidebar, Main, Title }) => {
         <PageDetails
           actionsContent={null}
           title={<Title className="margin-right-m">Search</Title>}
-          subtitle={
-            <Link gray to="/proposals/unvetted">
-              &#8592; Go back to unvetted proposals
-            </Link>
-          }
         >
           <Formik
             initialValues={{


### PR DESCRIPTION
This PR tweaks the Proposal detail route to show the "go back.. " link under the title only when:
 1. The user accessed the proposal from the public list
 2. The user accessed the proposal from the unvetted list
 3. The user accessed the proposal from the account -> proposals list

The message show will be updated accordingly. For example, in case 1 presented above, the message shown would be "Go back to public proposals".
I also removed the "Go back to unvetted" from Search Users page.
closes #1383 