### PR TITLE
[cms/pigui] Page error when user has no identities

### DIFF
--- a/src/components/UserDetail/GeneralTab.js
+++ b/src/components/UserDetail/GeneralTab.js
@@ -261,9 +261,12 @@ class GeneralTab extends React.Component {
             ) : (
               <div className="monospace no-text-overflow">
                 {pubkeyStatus !== PUB_KEY_STATUS_LOADED ||
-                user.identities[user.identities.length - 1].pubkey !== pubkey
-                  ? user.identities[user.identities.length - 1].pubkey
-                  : "Loading public key..."}
+                user.identities.length > 1
+                  ? user.identities[user.identities.length - 1].pubkey !==
+                    pubkey
+                    ? user.identities[user.identities.length - 1].pubkey
+                    : "Loading public key..."
+                  : "No Idenities available"}
               </div>
             )}
           </Field>


### PR DESCRIPTION
I'm not sure if it's possible to not have an identity in pigui (since one is set on registration/verification), but in CMS user's that have been invited but not registered will be caught in this state.

So when an admin goes to a user's page in this state, it would error due to user.identities being undefined.  This simply checks to make sure there are identities to check.