### PR TITLE
[redesign] Do not collapse comments by default

### DIFF
--- a/src/containers/Comments/Comment/Comment.jsx
+++ b/src/containers/Comments/Comment/Comment.jsx
@@ -122,7 +122,6 @@ const Comment = ({
 Comment.propTypes = {
   className: PropTypes.string,
   permalink: PropTypes.string,
-  topLevelComment: PropTypes.bool,
   author: PropTypes.string,
   authorID: PropTypes.string,
   createdAt: PropTypes.number,

--- a/src/containers/Comments/Comment/CommentWrapper.jsx
+++ b/src/containers/Comments/Comment/CommentWrapper.jsx
@@ -38,7 +38,6 @@ const CommentWrapper = ({ comment, children, numOfReplies, ...props }) => {
   } = comment;
 
   const isRecordAuthor = recordAuthorID === userid;
-  const isThreadParent = +parentid === 0 || +commentid === +threadParentID;
   const censorable = isAdmin && !readOnly;
 
   const [showReplyForm, setShowReplyForm] = useState(false);
@@ -129,7 +128,6 @@ const CommentWrapper = ({ comment, children, numOfReplies, ...props }) => {
       <Comment
         permalink={`/${recordType}/${recordToken}/comments/${commentid}`}
         censorable={censorable}
-        topLevelComment={isThreadParent}
         author={username}
         authorID={userid}
         createdAt={timestamp}

--- a/src/containers/Comments/Comment/CommentWrapper.jsx
+++ b/src/containers/Comments/Comment/CommentWrapper.jsx
@@ -42,7 +42,7 @@ const CommentWrapper = ({ comment, children, numOfReplies, ...props }) => {
   const censorable = isAdmin && !readOnly;
 
   const [showReplyForm, setShowReplyForm] = useState(false);
-  const [showReplies, setShowReplies] = useState(isThreadParent);
+  const [showReplies, setShowReplies] = useState(true);
 
   const handleToggleReplyForm = useCallback(() => {
     setShowReplyForm(!showReplyForm);


### PR DESCRIPTION
Should we keep the `isThreadParent` / `topLevelComment` props for some reason?

closes #1426 