### PR TITLE
[redesign] Fix warning `React Hook useEffect has a missing dependency`

### DIFF
--- a/src/hooks/utils/useDocumentTitle.js
+++ b/src/hooks/utils/useDocumentTitle.js
@@ -7,5 +7,5 @@ export function useDocumentTitle(newTitle, originalTitle) {
   useEffect(() => {
     setHTMLTitle(newTitle);
     return () => setHTMLTitle(originalTitle);
-  }, [newTitle]);
+  }, [newTitle, originalTitle]);
 }


### PR DESCRIPTION
Build warning related to new `useDocumentTitle`