### PR TITLE
[redesign] Fix loading errors from account page

### DIFF
--- a/src/containers/User/Detail/Credits/Credits.jsx
+++ b/src/containers/User/Detail/Credits/Credits.jsx
@@ -19,6 +19,7 @@ const Credits = () => {
     user,
     userMe,
     isApiRequestingUserProposalCredits,
+    shouldFetchProposalCredits,
     proposalCreditPurchases,
     loggedInAsUserId,
     proposalPaywallAddress,
@@ -106,7 +107,7 @@ const Credits = () => {
     <Message kind="error">
       Only admins or the user himself can access this route.
     </Message>
-  ) : isApiRequestingUserProposalCredits || !proposalCreditPurchases.length ? (
+  ) : isApiRequestingUserProposalCredits || shouldFetchProposalCredits ? (
     <div className={styles.spinnerWrapper}>
       <Spinner invert />
     </div>

--- a/src/containers/User/Detail/Credits/hooks.js
+++ b/src/containers/User/Detail/Credits/hooks.js
@@ -98,7 +98,7 @@ export function useCredits(ownProps) {
     proposalPaywallPaymentTxid
   ]);
 
-  return fromRedux;
+  return { ...fromRedux, shouldFetchProposalCredits };
 }
 
 export function usePollProposalCreditsPayment(ownProps) {

--- a/src/containers/User/Detail/Identity/Identity.jsx
+++ b/src/containers/User/Detail/Identity/Identity.jsx
@@ -67,9 +67,9 @@ const Identity = ({ history, loadingKey, pubkey, id: userID, identities }) => {
       setKeyData(keyData);
     });
   }, [loggedInAsEmail]);
-
+  
   const isUserPageOwner = user && loggedInAsUserId === user.id;
-  return loadingKey === PUB_KEY_STATUS_LOADING || keyMismatch || !keyData ? (
+  return loadingKey === PUB_KEY_STATUS_LOADING ? (
     <div className={styles.spinnerWrapper}>
       <Spinner invert />
     </div>


### PR DESCRIPTION
This PR fixes some issues on the account page regarding loading data with the spinner, where it would render indefinitely. It also fixes the flickering on credits tab, when switched from the identity tab.

closes #1461 