### PR TITLE
[redesign] Rewording some proposal status

### DIFF
--- a/src/componentsv2/Proposal/helpers.js
+++ b/src/componentsv2/Proposal/helpers.js
@@ -30,9 +30,15 @@ export const getProposalStatusTagProps = (proposal, voteSummary) => {
   if (isPublicProposal(proposal) && !!voteSummary) {
     switch (voteSummary.status) {
       case PROPOSAL_VOTING_NOT_AUTHORIZED:
-        return { type: "blackTime", text: "Hasn't authorized yet" };
+        return {
+          type: "blackTime",
+          text: "Waiting for author to authorize voting"
+        };
       case PROPOSAL_VOTING_AUTHORIZED:
-        return { type: "yellowTime", text: "Waiting for approval" };
+        return {
+          type: "yellowTime",
+          text: "Waiting for admin to start voting"
+        };
       case PROPOSAL_VOTING_ACTIVE:
         return { type: "bluePending", text: "Active" };
       case PROPOSAL_VOTING_FINISHED:


### PR DESCRIPTION
Hey guys @RichardRed0x @MariaPleshkova , wanted to get your final word on this one. So this PR changes the following status:

`Hasn't authorized yet` -> `Waiting for author authorization`
`Waiting for approval` -> `Waiting for admin authorization`

We also have `Active` for ongoing proposal voting, `Finished` for finished proposal voting, and `Abandoned`.

Is there any status you think needs some change? imo I like how succinct they are after a proposal is active, and each one seems clear to me after the changes you proposed, but of course, my opinion might be biased.

closes #1413