### PR TITLE
Fix fetching of proposal details based on current user access level

### DIFF
--- a/src/containers/Proposal/Detail/hooks.js
+++ b/src/containers/Proposal/Detail/hooks.js
@@ -137,7 +137,7 @@ export function useProposal(ownProps) {
         setProposal(prop);
       }
     },
-    [getProposalFromCache, proposal]
+    [getProposalFromCache, proposal, getProposal]
   );
 
   if (error) {

--- a/src/containers/Proposal/Detail/hooks.js
+++ b/src/containers/Proposal/Detail/hooks.js
@@ -6,6 +6,8 @@ import { arg, or } from "src/lib/fp";
 import * as sel from "src/selectors";
 import * as act from "src/actions";
 import { useRedux } from "src/redux";
+import { useLoaderContext } from "src/Appv2/Loader";
+import { isUnreviewedProposal, isCensoredProposal } from "../helpers";
 
 const mapStateToProps = {
   token: compose(
@@ -25,7 +27,6 @@ const mapStateToProps = {
 };
 
 const mapDispatchToProps = {
-  onFetchUser: act.onFetchUser,
   onFetchProposal: act.onFetchProposal,
   onFetchProposalsVoteSummary: act.onFetchProposalsBatchVoteSummary
 };
@@ -57,6 +58,10 @@ export function useProposal(ownProps) {
     onFetchProposalsVoteSummary,
     commentID: threadParentID
   } = useRedux(ownProps, mapStateToProps, mapDispatchToProps);
+
+  const { currentUser } = useLoaderContext();
+  const currentUserIsAdmin = currentUser && currentUser.isadmin;
+  const currentUserId = currentUser && currentUser.userid;
 
   const getProposalFromCache = useCallback(() => {
     // try to use the edited proposal from cache first to get the
@@ -97,9 +102,22 @@ export function useProposal(ownProps) {
     unvettedProposals
   ]);
 
-  const [proposal, setProposal] = useState(
-    proposalWithFilesOrNothing(getProposalFromCache())
-  );
+  const getProposal = useCallback(() => {
+    const proposal = getProposalFromCache();
+    const proposalAuthorID = proposal && proposal.userid;
+    const userCannotViewFullProposal =
+      !currentUserIsAdmin || currentUserId !== proposalAuthorID;
+    if (
+      !!proposal &&
+      (isCensoredProposal(proposal) || isUnreviewedProposal(proposal)) &&
+      userCannotViewFullProposal
+    ) {
+      return proposal;
+    }
+    return proposalWithFilesOrNothing(proposal);
+  }, [getProposalFromCache, currentUserId, currentUserIsAdmin]);
+
+  const [proposal, setProposal] = useState(getProposal());
 
   useEffect(
     function fetchProposal() {
@@ -114,7 +132,7 @@ export function useProposal(ownProps) {
 
   useEffect(
     function handleProposalChanged() {
-      const prop = proposalWithFilesOrNothing(getProposalFromCache());
+      const prop = getProposal();
       if (!!prop && !isEqual(prop, proposal)) {
         setProposal(prop);
       }

--- a/src/containers/Proposal/helpers.js
+++ b/src/containers/Proposal/helpers.js
@@ -8,7 +8,8 @@ import {
   PROPOSAL_STATUS_ABANDONED,
   PROPOSAL_VOTING_FINISHED,
   PROPOSAL_STATUS_UNREVIEWED,
-  PROPOSAL_STATUS_UNREVIEWED_CHANGES
+  PROPOSAL_STATUS_UNREVIEWED_CHANGES,
+  PROPOSAL_STATUS_CENSORED
 } from "../../constants";
 import { getTextFromIndexMd } from "src/helpers";
 
@@ -54,6 +55,15 @@ export const isUnreviewedProposal = proposal => {
     proposal.status === PROPOSAL_STATUS_UNREVIEWED ||
     proposal.status === PROPOSAL_STATUS_UNREVIEWED_CHANGES
   );
+};
+
+/**
+ * Returns true if the given proposal is censored
+ * @param {Object} proposal
+ * @returns {Boolean} isCensored
+ */
+export const isCensoredProposal = proposal => {
+  return proposal.status === PROPOSAL_STATUS_CENSORED;
 };
 
 /**


### PR DESCRIPTION
This PR solves an issue where the proposal detail was loading indefinitely when the prop fetched from the API didn't have files. It can happen when a user without the appropriate access level tries to access an unreviewed or censored proposal.