### PR TITLE
Remove the huge container for the 'go back' link

### DIFF
--- a/src/containers/Proposal/Detail/Detail.jsx
+++ b/src/containers/Proposal/Detail/Detail.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useCallback } from "react";
-import { Link, PageDetails } from "pi-ui";
+import { Link } from "pi-ui";
 import { withRouter } from "react-router-dom";
 import Proposal from "src/componentsv2/Proposal";
 import styles from "./Detail.module.css";

--- a/src/containers/Proposal/Detail/Detail.jsx
+++ b/src/containers/Proposal/Detail/Detail.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useCallback } from "react";
-import { Link } from "pi-ui";
+import { Link, PageDetails } from "pi-ui";
 import { withRouter } from "react-router-dom";
 import Proposal from "src/componentsv2/Proposal";
 import styles from "./Detail.module.css";
@@ -19,7 +19,7 @@ import {
 import { useProposalVote } from "../hooks";
 import { useRouter } from "src/componentsv2/Router";
 
-const ProposalDetail = ({ TopBanner, PageDetails, Main, match }) => {
+const ProposalDetail = ({ TopBanner, Main, match }) => {
   const { proposal, loading, threadParentID } = useProposal({ match });
   const proposalToken =
     proposal && proposal.censorshiprecord && proposal.censorshiprecord.token;
@@ -59,26 +59,22 @@ const ProposalDetail = ({ TopBanner, PageDetails, Main, match }) => {
     if (!message) return null;
 
     return (
-      <Link
-        gray
-        className={styles.returnLink}
-        onClick={returnToPreviousLocation}
-      >
-        &#8592; {message}
-      </Link>
+      <div className={styles.returnLinkContainer}>
+        <Link
+          gray
+          className={styles.returnLink}
+          onClick={returnToPreviousLocation}
+        >
+          &#8592; {message}
+        </Link>
+      </div>
     );
   }, [previousLocation, returnToPreviousLocation]);
 
   return (
     <>
-      <TopBanner>
-        <PageDetails
-          titleAndSubtitleWrapperClassName={styles.customTitleAndSubtitleWrapper}
-          headerClassName={styles.customHeader}
-          subtitle={goBackLinkFromPreviousLocation}
-        />
-      </TopBanner>
       <Main className={styles.customMain} fillScreen>
+        {goBackLinkFromPreviousLocation}
         <UnvettedActionsProvider>
           <PublicActionsProvider>
             {loading || !proposal ? (

--- a/src/containers/Proposal/Detail/Detail.module.css
+++ b/src/containers/Proposal/Detail/Detail.module.css
@@ -14,4 +14,16 @@
 
 .returnLink {
     cursor: pointer;
+    font-size: var(--font-size-small);
+}
+
+.returnLinkContainer {
+    margin-bottom: 1rem;
+}
+
+/* EXTRA SMALL */
+@media screen and (max-width: 560px) {
+   .returnLinkContainer {
+       padding-left: var(--container-padding-left);
+   }
 }

--- a/src/pages/Proposals/Detail.jsx
+++ b/src/pages/Proposals/Detail.jsx
@@ -4,7 +4,7 @@ import ProposalDetail from "src/containers/Proposal/Detail";
 
 const PublicList = () => {
   return (
-    <MultipleContentPage topBannerHeight={82}>
+    <MultipleContentPage topBannerHeight={0}>
       {props => {
         return <ProposalDetail {...props} />;
       }}


### PR DESCRIPTION
If you access a proposal directly without being authenticated, there won't be a  "go back" link, neither a "new proposal" button. Resulting in a huge white container on top of the page:
![Screen Shot 2019-10-09 at 16 31 34](https://user-images.githubusercontent.com/14864439/66490937-3ffaf380-eab2-11e9-8857-aabc7ba39e6b.png)

The  "New Proposal" button isn't really needed at this page, so I simplified it all by removing the white container at the top of the page and keeping only the  "go back" link when the user is coming from the proposals list:

![Screen Shot 2019-10-09 at 16 22 11](https://user-images.githubusercontent.com/14864439/66491072-79336380-eab2-11e9-9ef6-6b8ae9a5e7ec.png)
