### PR TITLE
[WIP] Replace yup with @hapi/joi for form validations

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "politeiagui",
   "version": "0.1.1",
   "dependencies": {
+    "@hapi/joi": "^16.1.7",
     "ajv": "^6.10.2",
     "concurrently": "^4.1.2",
     "core-decorators": "^0.20.0",

--- a/src/componentsv2/CommentForm/CommentForm.jsx
+++ b/src/componentsv2/CommentForm/CommentForm.jsx
@@ -15,15 +15,15 @@ const CommentForm = ({
   className
 }) => {
 
-  function validateForm(values) {
+  const validateForm = (values) => {
     const { error } = validationSchema.validate(values);
     return error;
-  }
+  };
 
-  async function handleSubmit(
+  const handleSubmit = async (
     values,
     { resetForm, setSubmitting, setFieldError }
-  ) {
+  ) => {
     try {
       await onSubmit(values.comment);
       setSubmitting(false);
@@ -33,7 +33,8 @@ const CommentForm = ({
       setSubmitting(false);
       setFieldError("global", e);
     }
-  }
+  };
+
   return (
     <Formik
       initialValues={{

--- a/src/componentsv2/CommentForm/CommentForm.jsx
+++ b/src/componentsv2/CommentForm/CommentForm.jsx
@@ -14,6 +14,12 @@ const CommentForm = ({
   persistKey,
   className
 }) => {
+
+  function validateForm(values) {
+    const { error } = validationSchema.validate(values);
+    return error;
+  }
+
   async function handleSubmit(
     values,
     { resetForm, setSubmitting, setFieldError }
@@ -34,7 +40,7 @@ const CommentForm = ({
         comment: ""
       }}
       loading={!validationSchema}
-      validationSchema={validationSchema}
+      validate={validateForm}
       onSubmit={handleSubmit}
     >
       {formikProps => {

--- a/src/componentsv2/CommentForm/validation.js
+++ b/src/componentsv2/CommentForm/validation.js
@@ -1,7 +1,7 @@
-import * as Yup from "yup";
+import * as Joi from "@hapi/joi";
 
-const commentValidationSchema = Yup.object().shape({
-  comment: Yup.string().required("Required")
+const commentValidationSchema = Joi.object({
+  comment: Joi.string().required()
 });
 
 export default commentValidationSchema;

--- a/src/componentsv2/ModalConfirmWithReason.jsx
+++ b/src/componentsv2/ModalConfirmWithReason.jsx
@@ -10,7 +10,7 @@ import {
 } from "pi-ui";
 import PropTypes from "prop-types";
 import FormWrapper from "src/componentsv2/FormWrapper";
-import * as Yup from "yup";
+import * as Joi from "@hapi/joi";
 
 const ModalConfirmWithReason = ({
   show,
@@ -24,6 +24,19 @@ const ModalConfirmWithReason = ({
 }) => {
   const [success, setSuccess] = useState(false);
   const [isSubmitting, setSubmitting] = useState(false);
+
+  const reasonValidationSchema = Joi.object({
+    reason: Joi.string().required()
+  });
+
+  const validateReasonForm = (values) => {
+    const errors = {};
+    const { error } = reasonValidationSchema.validate(values);
+    if (error) {
+      errors.reason = "Required";
+    }
+    return errors;
+  };
 
   const onSubmitReason = async (values, { resetForm, setFieldError }) => {
     setSubmitting(true);
@@ -77,9 +90,7 @@ const ModalConfirmWithReason = ({
           initialValues={{
             reason: ""
           }}
-          validationSchema={Yup.object().shape({
-            reason: Yup.string().required("Required")
-          })}
+          validate={validateReasonForm}
           onSubmit={onSubmitReason}
         >
           {({

--- a/src/containers/Comments/Comments.jsx
+++ b/src/containers/Comments/Comments.jsx
@@ -270,7 +270,7 @@ const Comments = ({
           )}
         </div>
         <ModalConfirmWithReason
-          title={`Censor comment`}
+          title="Censor comment"
           reasonLabel="Censor reason"
           subject="censorComment"
           successTitle="Comment censored"

--- a/src/containers/User/Search/Search.jsx
+++ b/src/containers/User/Search/Search.jsx
@@ -2,9 +2,9 @@ import { Formik } from "formik";
 import { BoxTextInput, Button, Card, classNames, Link, Message, RadioButtonGroup, Table } from "pi-ui";
 import React, { useEffect, useState } from "react";
 import HelpMessage from "src/componentsv2/HelpMessage";
-import * as Yup from "yup";
 import { useSearchUser } from "./hooks";
 import styles from "./Search.module.css";
+import * as Joi from "@hapi/joi";
 
 const getFormattedSearchResults = (users = []) =>
   users.map(u => ({
@@ -38,6 +38,18 @@ const UserSearch = ({ TopBanner, PageDetails, Main, Title }) => {
     },
     [usersResult]
   );
+
+  const formSchema = Joi.object({
+    searchTerm: Joi.string()
+      .required(),
+    searchBy: Joi.string()
+  });
+
+  const validate = (values) => {
+    const { error } = formSchema.validate(values);
+    return error;
+  };
+
   return (
     <>
       <TopBanner>
@@ -51,9 +63,7 @@ const UserSearch = ({ TopBanner, PageDetails, Main, Title }) => {
               searchBy: "email"
             }}
             onSubmit={onSubmit}
-            validationSchema={Yup.object().shape({
-              searchTerm: Yup.string().required("Required")
-            })}
+            validate={validate}
           >
             {({
               values,

--- a/yarn.lock
+++ b/yarn.lock
@@ -978,7 +978,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.8.2.tgz#576ff7fb1230185b619a75d258cbc98f0867a8dc"
   integrity sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw==
 
-"@hapi/address@2.x.x":
+"@hapi/address@2.x.x", "@hapi/address@^2.1.2":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.2.tgz#1c794cd6dbf2354d1eb1ef10e0303f573e1c7222"
   integrity sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q==
@@ -988,10 +988,20 @@
   resolved "https://registry.yarnpkg.com/@hapi/bourne/-/bourne-1.3.2.tgz#0a7095adea067243ce3283e1b56b8a8f453b242a"
   integrity sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==
 
+"@hapi/formula@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@hapi/formula/-/formula-1.2.0.tgz#994649c7fea1a90b91a0a1e6d983523f680e10cd"
+  integrity sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA==
+
 "@hapi/hoek@8.x.x":
   version "8.2.4"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-8.2.4.tgz#684a14f4ca35d46f44abc87dfc696e5e4fe8a020"
   integrity sha512-Ze5SDNt325yZvNO7s5C4fXDscjJ6dcqLFXJQ/M7dZRQCewuDj2iDUuBi6jLQt+APbW9RjjVEvLr35FXuOEqjow==
+
+"@hapi/hoek@^8.2.4", "@hapi/hoek@^8.3.0":
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-8.3.1.tgz#227d29efdb158e4a64590224add90c820f94d20e"
+  integrity sha512-75ocgnI7HG/I01iGA3/rs0y6PXydUA/kxhFZM0HoT8NLSTnt/J8Gq03iKl4a4B/2A3iMG0ctXtxr5Hg9SGr1gw==
 
 "@hapi/joi@^15.0.0":
   version "15.1.1"
@@ -1003,12 +1013,35 @@
     "@hapi/hoek" "8.x.x"
     "@hapi/topo" "3.x.x"
 
+"@hapi/joi@^16.1.7":
+  version "16.1.7"
+  resolved "https://registry.yarnpkg.com/@hapi/joi/-/joi-16.1.7.tgz#360857223a87bb1f5f67691537964c1b4908ed93"
+  integrity sha512-anaIgnZhNooG3LJLrTFzgGALTiO97zRA1UkvQHm9KxxoSiIzCozB3RCNCpDnfhTJD72QlrHA8nwGmNgpFFCIeg==
+  dependencies:
+    "@hapi/address" "^2.1.2"
+    "@hapi/formula" "^1.2.0"
+    "@hapi/hoek" "^8.2.4"
+    "@hapi/pinpoint" "^1.0.2"
+    "@hapi/topo" "^3.1.3"
+
+"@hapi/pinpoint@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@hapi/pinpoint/-/pinpoint-1.0.2.tgz#025b7a36dbbf4d35bf1acd071c26b20ef41e0d13"
+  integrity sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ==
+
 "@hapi/topo@3.x.x":
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-3.1.4.tgz#42e2fe36f593d90ad258a08b582be128c141c45d"
   integrity sha512-aVWQTOI9wBD6zawmOr6f+tdEIxQC8JXfQVLTjgGe8YEStAWGn/GNNVTobKJhbWKveQj2RyYF3oYbO9SC8/eOCA==
   dependencies:
     "@hapi/hoek" "8.x.x"
+
+"@hapi/topo@^3.1.3":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-3.1.6.tgz#68d935fa3eae7fdd5ab0d7f953f3205d8b2bfc29"
+  integrity sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==
+  dependencies:
+    "@hapi/hoek" "^8.3.0"
 
 "@jest/console@^24.7.1", "@jest/console@^24.9.0":
   version "24.9.0"
@@ -10620,7 +10653,7 @@ react-is@^16.7.0, react-is@^16.8.6:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
-react-is@^16.8.1:
+react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
   version "16.10.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.10.2.tgz#984120fd4d16800e9a738208ab1fba422d23b5ab"
   integrity sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA==


### PR DESCRIPTION
In order to track the progress properly and to get a good overview of the migration from `yup` to `@hapi/joi` as our forms validation library, we decided to create draft pr which lists all forms included in our app as checklist.

Checklist:

- [x] User search form
- [x] Comment form
- [x] Reason confirmation modal
- [ ] Search votes
- [ ] Start vote
- [ ] User's change password/username form(s)
- [ ] Login
- [ ] Reset password
- [ ] Signup
- [ ] Verify Email 
- [ ] Invoice
- [ ] Delete yup dep

closes #1494 