### PR TITLE
User config values to trigger user paywall requests

### DIFF
--- a/src/Appv2/Loader/Loader.js
+++ b/src/Appv2/Loader/Loader.js
@@ -2,11 +2,13 @@ import React, { createContext, useContext, useEffect, useState } from "react";
 import { useLoader } from "./hooks";
 import LoaderScreen from "./LoaderScreen";
 import useLocalStorage from "src/hooks/utils/useLocalStorage";
+import { useConfig } from "src/Config";
 
 export const LoaderContext = createContext();
 export const useLoaderContext = () => useContext(LoaderContext);
 
 const Loader = ({ children }) => {
+  const { enablePaywall, enableCredits } = useConfig();
   const [initDone, setInitDone] = useState(false);
   const [error, setError] = useState(null);
   const [apiInfo, setApiInfo] = useState(null);
@@ -14,13 +16,16 @@ const Loader = ({ children }) => {
     onRequestApiInfo,
     onRequestCurrentUser,
     user,
-    localLogout
+    localLogout,
+    onPollUserPayment,
+    onUserProposalCredits
   } = useLoader();
   const [
     userActiveOnLocalStorage,
     setUserActiveOnLocalStorage
   ] = useLocalStorage("userActive", false);
 
+  // fetch api info and current user if any
   useEffect(() => {
     async function onInit() {
       try {
@@ -39,17 +44,35 @@ const Loader = ({ children }) => {
 
   const hasUser = !!user;
 
+  // mark user as active on login
   useEffect(() => {
     if (initDone) {
       setUserActiveOnLocalStorage(hasUser);
     }
   }, [hasUser, initDone, setUserActiveOnLocalStorage]);
 
+  // trigger logout if user isn't marked as active on local storage
+  // this is usefull for reflecting logout across different tabs
   useEffect(() => {
     if (!userActiveOnLocalStorage) {
       localLogout();
     }
   }, [userActiveOnLocalStorage, localLogout]);
+
+  // poll user paywall if applicable
+  useEffect(() => {
+    const userPaywallNotPaid = !!user && !!user.paywalladdress;
+    if (enablePaywall && userPaywallNotPaid) {
+      onPollUserPayment();
+    }
+  }, [user, enablePaywall, onPollUserPayment]);
+
+  // fetch user credits if applicable
+  useEffect(() => {
+    if (enableCredits && hasUser) {
+      onUserProposalCredits();
+    }
+  }, [hasUser, onUserProposalCredits]);
 
   return (
     <LoaderContext.Provider

--- a/src/Appv2/Loader/hooks.js
+++ b/src/Appv2/Loader/hooks.js
@@ -26,6 +26,8 @@ const mapDispatchToProps = {
   confirmWithModal: act.confirmWithModal,
   setOnboardAsViewed: act.setOnboardAsViewed,
   onLoadDraftProposals: act.onLoadDraftProposals,
+  onPollUserPayment: act.onPollUserPayment,
+  onUserProposalCredits: act.onUserProposalCredits,
   localLogout: act.handleLogout
 };
 

--- a/src/Config/Config.js
+++ b/src/Config/Config.js
@@ -17,6 +17,7 @@ const loadConfig = () => {
     recordType: defaultRecordType,
     enableAdminInvite: defaultEnableAdminInvite,
     enableCommentVote: defaultEnableCommentVote,
+    enableCredits: defaultEnableCredits,
     enablePaywall: defaultEnablePaywall,
     privacyPolicyContent: defaultprivacyPolicyContent,
     aboutContent: defaultAboutContent,
@@ -46,6 +47,7 @@ const loadConfig = () => {
       getConf("ENABLE_ADMIN_INVITE") || defaultEnableAdminInvite,
     enableCommentVote:
       getConf("ENABLE_COMMENT_VOTE") || defaultEnableCommentVote,
+    enableCredits: getConf("ENABLE_CREDITS") || defaultEnableCredits,
     enablePaywall: getConf("ENABLE_PAYWALL") || defaultEnablePaywall,
     privacyPolicyContent:
       getConf("PRIVACY_POLICY_CONTENT") || defaultprivacyPolicyContent,

--- a/src/Config/presets.js
+++ b/src/Config/presets.js
@@ -15,6 +15,7 @@ export const POLITEIA = {
   recordType: constants.RECORD_TYPE_PROPOSAL,
   enableAdminInvite: false,
   enableCommentVote: true,
+  enableCredits: true,
   enablePaywall: true,
   privacyPolicyContent: "privacy-policy",
   testnetGitRepository:
@@ -29,6 +30,7 @@ export const CMS = {
   recordType: constants.RECORD_TYPE_INVOICE,
   enableAdminInvite: true,
   enableCommentVote: false,
+  enableCredits: false,
   enablePaywall: false,
   privacyPolicyContent: "privacy-policy-cms",
   testnetGitRepository: "",

--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -52,23 +52,12 @@ export const requestApiInfo = (fetchUser = true) => dispatch => {
     });
 };
 
-export const onRequestMe = () => (dispatch, getState) => {
-  const state = getState();
+export const onRequestMe = () => dispatch => {
   dispatch(act.REQUEST_ME());
   return api
     .me()
     .then(response => {
       dispatch(act.RECEIVE_ME(response));
-      if (sel.usePaywall(state)) {
-        dispatch(onUserProposalCredits());
-
-        // Start polling for the user paywall tx, if applicable.
-        const paywallAddress = sel.paywallAddress(state);
-        if (paywallAddress) {
-          dispatch(onPollUserPayment());
-        }
-        return response;
-      }
     })
     .catch(error => {
       dispatch(act.RECEIVE_ME(null, error));
@@ -243,16 +232,12 @@ export const onSearchUser = query => dispatch => {
 };
 
 export const onLogin = ({ email, password }) =>
-  withCsrf((dispatch, getState, csrf) => {
+  withCsrf((dispatch, _, csrf) => {
     dispatch(act.REQUEST_LOGIN({ email }));
     return api
       .login(csrf, email, password)
       .then(response => {
         dispatch(act.RECEIVE_LOGIN(response));
-        if (sel.usePaywall(getState())) {
-          dispatch(onUserProposalCredits());
-        }
-        dispatch(closeModal());
         return response;
       })
       .then(() => dispatch(onRequestMe()))


### PR DESCRIPTION
This PR moves the trigger for: 
- Fetch user credits
- Poll user paywall

to the Loader component so it can check on the config values for `enablePaywall` and `enableCredits` before triggering these procedures.