### PR TITLE
Add csp meta to head

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -9,10 +9,10 @@ const cspConfigPolicy = {
   "script-src": ["'self'"],
   "style-src": ["'self'"],
   "connect-src":
-    "'self' 'faucet.decred.org' 'explorer.dcrdata.org' 'testnet.dcrdata.org' 'testnet.decred.org' 'mainnet.decred.org'",
+    "'self' faucet.decred.org explorer.dcrdata.org testnet.dcrdata.org testnet.decred.org mainnet.decred.org",
   "manifest-src": "'self'",
   "img-src:": "'self' data:",
-  "font-src": "'self"
+  "font-src": "'self'"
 };
 
 module.exports = function override(config) {

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,4 +1,14 @@
 const path = require("path");
+const { override, addWebpackAlias } = require("customize-cra");
+const cspHtmlWebpackPlugin = require("csp-html-webpack-plugin");
+
+const cspConfigPolicy = {
+  "default-src": "'none'",
+  "base-uri": "'self'",
+  "object-src": "'none'",
+  "script-src": ["'self'"],
+  "style-src": ["'self'"]
+};
 
 module.exports = function override(config) {
   config.resolve = {
@@ -7,4 +17,21 @@ module.exports = function override(config) {
   };
 
   return config;
+};
+
+function addCspHtmlWebpackPlugin(config) {
+  if (process.env.NODE_ENV === "production") {
+    config.plugins.push(new cspHtmlWebpackPlugin(cspConfigPolicy));
+  }
+
+  return config;
+}
+
+module.exports = {
+  webpack: override(
+    addCspHtmlWebpackPlugin,
+    addWebpackAlias({
+      src: path.resolve(__dirname, "src")
+    })
+  )
 };

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -7,12 +7,15 @@ const cspConfigPolicy = {
   "base-uri": "'self'",
   "object-src": "'none'",
   "script-src": ["'self'"],
-  "style-src": ["'self'"],
+  "style-src": [
+    "'self'",
+    "'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='"
+  ],
   "connect-src":
     "'self' faucet.decred.org explorer.dcrdata.org testnet.dcrdata.org testnet.decred.org mainnet.decred.org",
   "manifest-src": "'self'",
   "img-src": "'self' data:",
-  "font-src": "'self'"
+  "font-src": "'self' data:"
 };
 
 module.exports = function override(config) {

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -7,7 +7,12 @@ const cspConfigPolicy = {
   "base-uri": "'self'",
   "object-src": "'none'",
   "script-src": ["'self'"],
-  "style-src": ["'self'"]
+  "style-src": ["'self'"],
+  "connect-src":
+    "'self' 'faucet.decred.org' 'explorer.dcrdata.org' 'testnet.dcrdata.org' 'testnet.decred.org' 'mainnet.decred.org'",
+  "manifest-src": "'self'",
+  "img-src:": "'self' data:",
+  "font-src": "'self"
 };
 
 module.exports = function override(config) {

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -11,7 +11,7 @@ const cspConfigPolicy = {
   "connect-src":
     "'self' faucet.decred.org explorer.dcrdata.org testnet.dcrdata.org testnet.decred.org mainnet.decred.org",
   "manifest-src": "'self'",
-  "img-src:": "'self' data:",
+  "img-src": "'self' data:",
   "font-src": "'self'"
 };
 

--- a/package.json
+++ b/package.json
@@ -92,6 +92,8 @@
     "connect": "^3.7.0",
     "connect-api-mocker": "^1.7.0",
     "cross-env": "^5.0.5",
+    "csp-html-webpack-plugin": "^3.0.3",
+    "customize-cra": "^0.8.0",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
     "enzyme-to-json": "^3.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3790,6 +3790,15 @@ crypto-js@^3.1.9-1:
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.9-1.tgz#fda19e761fc077e01ffbfdc6e9fdfc59e8806cd8"
   integrity sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=
 
+csp-html-webpack-plugin@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/csp-html-webpack-plugin/-/csp-html-webpack-plugin-3.0.3.tgz#b2215664ebebbc3ceb84aadff0521f170ce0be65"
+  integrity sha512-E7IYkTYbh7lY2VpPa8snMrH0muoVCIdPb5dAW9dOX5CFRqeZNsBqqIBejlHJ2cn6rFrrQZ/s/vIh0ZTooBP+xQ==
+  dependencies:
+    cheerio "^1.0.0-rc.2"
+    lodash "^4.17.15"
+    memory-fs "^0.4.1"
+
 css-blank-pseudo@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/css-blank-pseudo/-/css-blank-pseudo-0.1.4.tgz#dfdefd3254bf8a82027993674ccf35483bfcb3c5"
@@ -4016,6 +4025,13 @@ currently-unhandled@^0.4.1:
   integrity sha1-mI3zP+qxke95mmE2nddsF635V+o=
   dependencies:
     array-find-index "^1.0.1"
+
+customize-cra@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/customize-cra/-/customize-cra-0.8.0.tgz#011e65fde9e443733668551740b76e3eefe95822"
+  integrity sha512-fIiuM4sJfDmTc+0ctNV0BCnSTsfq76bpAOHvUCrCzWaG1dHpHw2Yfec+liH4EdicG5TuwhYLFt2yY2ocJ8HoxA==
+  dependencies:
+    lodash.flow "^3.5.0"
 
 cyclist@^1.0.1:
   version "1.0.1"
@@ -7920,6 +7936,11 @@ lodash.flattendeep@^4.2.0, lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
+
+lodash.flow@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.flow/-/lodash.flow-3.5.0.tgz#87bf40292b8cf83e4e8ce1a3ae4209e20071675a"
+  integrity sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o=
 
 lodash.isarguments@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
This PR adds a rule to add a CSP meta tag to the index.html containing the CSP rules and the hashes for the inline scripts and styles.