### PR TITLE
[redesign] Fix edit proposal name `double click` issue

### DIFF
--- a/src/Appv2/Loader/Loader.js
+++ b/src/Appv2/Loader/Loader.js
@@ -72,7 +72,7 @@ const Loader = ({ children }) => {
     if (enableCredits && hasUser) {
       onUserProposalCredits();
     }
-  }, [hasUser, onUserProposalCredits]);
+  }, [hasUser, onUserProposalCredits, enableCredits]);
 
   return (
     <LoaderContext.Provider

--- a/src/componentsv2/ProposalForm/ProposalForm.jsx
+++ b/src/componentsv2/ProposalForm/ProposalForm.jsx
@@ -17,18 +17,15 @@ import useBooleanState from "src/hooks/utils/useBooleanState";
 const ProposalForm = React.memo(function ProposalForm({
   values,
   handleChange,
-  handleBlur,
   handleSubmit,
   isSubmitting,
-  touched,
   setFieldValue,
   errors,
   isValid,
   submitSuccess,
   disableSubmit,
   openMDGuideModal,
-  openFullImageModal,
-  initialValues
+  openFullImageModal
 }) {
   const mobile = useMediaQuery("(max-width: 560px)");
 
@@ -98,11 +95,9 @@ const ProposalForm = React.memo(function ProposalForm({
       <BoxTextInput
         placeholder="Proposal name"
         name="name"
-        tabIndex={1}
         value={values.name}
         onChange={handleChange}
-        onBlur={handleBlur}
-        error={touched.name && errors.name}
+        error={errors.name}
       />
       <MarkdownEditor
         name="description"
@@ -110,9 +105,8 @@ const ProposalForm = React.memo(function ProposalForm({
         value={values.description}
         textAreaProps={textAreaProps}
         onChange={handleDescriptionChange}
-        onBlur={handleBlur}
         placeholder={"Write your proposal"}
-        error={touched.description && errors.description}
+        error={errors.description}
         filesInput={filesInput}
       />
       <ThumbnailGrid
@@ -128,16 +122,16 @@ const ProposalForm = React.memo(function ProposalForm({
           <SubmitButton />
         </Row>
       ) : (
-        <>
-          <Row topMarginSize="s" justify="right">
-            <DraftSaver submitSuccess={submitSuccess} />
-            <SubmitButton />
-          </Row>
-          <Row topMarginSize="s" justify="right">
-            <FormatHelpButton />
-          </Row>
-        </>
-      )}
+          <>
+            <Row topMarginSize="s" justify="right">
+              <DraftSaver submitSuccess={submitSuccess} />
+              <SubmitButton />
+            </Row>
+            <Row topMarginSize="s" justify="right">
+              <FormatHelpButton />
+            </Row>
+          </>
+        )}
 
     </form>
   );
@@ -188,7 +182,6 @@ const ProposalFormWrapper = ({
         }
         loading={!proposalFormValidation}
         validate={proposalFormValidation}
-        validateOnChange={true}
         onSubmit={handleSubmit}
       >
         {props => (

--- a/src/componentsv2/ProposalForm/ProposalForm.jsx
+++ b/src/componentsv2/ProposalForm/ProposalForm.jsx
@@ -95,6 +95,7 @@ const ProposalForm = React.memo(function ProposalForm({
       <BoxTextInput
         placeholder="Proposal name"
         name="name"
+        tabIndex={1}
         value={values.name}
         onChange={handleChange}
         error={errors.name}

--- a/src/componentsv2/ProposalForm/validation.js
+++ b/src/componentsv2/ProposalForm/validation.js
@@ -18,7 +18,6 @@ export const proposalValidation = ({
   maxmdsize
 }) => values => {
   const errors = {};
-
   if (!values) {
     values = {
       name: "",

--- a/src/pages/Proposals/Edit.jsx
+++ b/src/pages/Proposals/Edit.jsx
@@ -8,11 +8,11 @@ const PageProposalEdit = ({ history, match }) => {
   const mobile = useMediaQuery("(max-width: 560px)");
 
   const CancelButton = () => (
-    <Button 
+    <Button
       type="button"
       kind="secondary"
       size={mobile ? "sm" : "md"}
-      onClick={() => 
+      onClick={() =>
         history.push(`/proposal/${match.params.token}`)
       }
     >
@@ -25,7 +25,7 @@ const PageProposalEdit = ({ history, match }) => {
       {({ TopBanner, PageDetails, Main }) => (
         <>
           <TopBanner>
-            <PageDetails 
+            <PageDetails
               title="Edit Proposal"
               actionsContent={<CancelButton />}
             />


### PR DESCRIPTION
This PR closes the issue mentioned in #1504.

The onBlur handler was blocking the submit action if name text field was active(focused) - click on submit was calling the input's onBlur handler instead of submit button (e.g user was still able to submit by pressing the enter key).

 