### PR TITLE
[redesign] Fixes use of paywall hook for isPaid verification

### DIFF
--- a/src/componentsv2/NewProposalButton/NewProposalButton.jsx
+++ b/src/componentsv2/NewProposalButton/NewProposalButton.jsx
@@ -1,7 +1,6 @@
 import { Button } from "pi-ui";
 import React from "react";
 import { withRouter } from "react-router-dom";
-import { PAYWALL_STATUS_PAID } from "src/constants";
 import usePaywall from "src/hooks/api/usePaywall";
 import LoggedInContent from "../LoggedInContent";
 import styles from "./NewProposalButton.module.css";
@@ -9,8 +8,7 @@ import styles from "./NewProposalButton.module.css";
 const NewProposalButton = ({ history, location }) => {
   const newProposalPath = "/proposals/new";
   const isNewProposalRoute = location.pathname === newProposalPath;
-  const { userPaywallStatus } = usePaywall();
-  const isPaid = userPaywallStatus === PAYWALL_STATUS_PAID;
+  const { isPaid } = usePaywall();
   return (
     !isNewProposalRoute && (
       <LoggedInContent>

--- a/src/componentsv2/PaymentComponent/PaymentComponent.jsx
+++ b/src/componentsv2/PaymentComponent/PaymentComponent.jsx
@@ -2,11 +2,13 @@ import { classNames, CopyableText, H4, Text } from "pi-ui";
 import PropTypes from "prop-types";
 import React from "react";
 import PaymentFaucet from "../PaymentFaucet";
+import usePaywall from "src/hooks/api/usePaywall";
 import PaymentStatusTag from "../PaymentStatusTag";
 import QRCode from "../QRCode";
 import styles from "./PaymentComponent.module.css";
 
-const PaymentComponent = ({ address, amount, extraSmall, isPaid, status }) => {
+const PaymentComponent = ({ address, amount, extraSmall, status }) => {
+  const { isPaid } = usePaywall();
   return (
     <>
       <div className={classNames(styles.paywallInfo, "margin-top-l")}>
@@ -36,7 +38,6 @@ PaymentComponent.propTypes = {
   address: PropTypes.string,
   amount: PropTypes.number,
   extraSmall: PropTypes.bool,
-  isPaid: PropTypes.bool,
   status: PropTypes.number,
   mapStatusTag: PropTypes.object
 };

--- a/src/containers/User/Detail/Credits/Credits.jsx
+++ b/src/containers/User/Detail/Credits/Credits.jsx
@@ -6,14 +6,15 @@ import ModalConfirmWithReason from "src/componentsv2/ModalConfirmWithReason";
 import ModalPayPaywall from "src/componentsv2/ModalPayPaywall";
 import { MANAGE_USER_CLEAR_USER_PAYWALL } from "src/constants";
 import useBooleanState from "src/hooks/utils/useBooleanState";
-import { hasUserPaid } from "../helpers";
 import { useManageUser } from "../hooks.js";
+import usePaywall from "src/hooks/api/usePaywall";
 import styles from "./Credits.module.css";
 import { getCsvData, getProposalCreditsPaymentStatus, getTableContentFromPurchases, tableHeaders } from "./helpers.js";
 import { useCredits, useRescanUserCredits } from "./hooks.js";
 
 const Credits = () => {
   const { user, onManageUser, isApiRequestingMarkAsPaid } = useManageUser();
+  const { isPaid } = usePaywall();
   const {
     proposalCreditPrice,
     isAdmin,
@@ -95,11 +96,6 @@ const Credits = () => {
 
   const isUserPageOwner = user && loggedInAsUserId === user.id;
 
-  const paywallIsPaid = hasUserPaid(
-    user.newuserpaywalltx,
-    user.newuserpaywallamount
-  );
-
   const markAsPaid = reason =>
     onManageUser(user.id, MANAGE_USER_CLEAR_USER_PAYWALL, reason);
 
@@ -135,9 +131,9 @@ const Credits = () => {
                   "margin-top-xs margin-bottom-xs"
                 )}
               >
-                {paywallIsPaid ? "Paid" : "Not paid"}
+                {isPaid ? "Paid" : "Not paid"}
               </Text>
-              {!paywallIsPaid && isUserPageOwner && (
+              {!isPaid && isUserPageOwner && (
                 <Button
                   className="margin-top-s"
                   size="sm"
@@ -146,7 +142,7 @@ const Credits = () => {
                   Pay registration fee
                 </Button>
               )}
-              {!paywallIsPaid && isAdmin && (
+              {!isPaid && isAdmin && (
                 <Button
                   className="margin-top-s"
                   loading={isApiRequestingMarkAsPaid}
@@ -186,7 +182,7 @@ const Credits = () => {
             </div>
           </div>
           <div className={styles.buttonsWrapper}>
-            {isUserPageOwner && paywallIsPaid && (
+            {isUserPageOwner && isPaid && (
               <Button
                 className="margin-top-s"
                 size="sm"


### PR DESCRIPTION
Since we are near our deploy, this is a quick fix for the issue. The preferred solution here would be to normalize the paywall state, as part of #1490. Currently it is quite confusing where the data comes from the state branch; it is scattered through `api.me/api.login`, and `app`, with some redundant selectors checking for the same thing on different places, etc. 

closes #1511