### PR TITLE
Fetch API policy during app init

### DIFF
--- a/src/Appv2/Loader/Loader.js
+++ b/src/Appv2/Loader/Loader.js
@@ -18,7 +18,8 @@ const Loader = ({ children }) => {
     user,
     localLogout,
     onPollUserPayment,
-    onUserProposalCredits
+    onUserProposalCredits,
+    onGetPolicy
   } = useLoader();
   const [
     userActiveOnLocalStorage,
@@ -28,19 +29,17 @@ const Loader = ({ children }) => {
   // fetch api info and current user if any
   useEffect(() => {
     async function onInit() {
-      try {
-        const apiInfo = await onRequestApiInfo(false);
-        setApiInfo(apiInfo);
-        if (apiInfo.activeusersession) {
-          await onRequestCurrentUser();
-        }
-        setInitDone(true);
-      } catch (e) {
-        setError(e);
+      const apiInfo = await onRequestApiInfo(false);
+      setApiInfo(apiInfo);
+      if (apiInfo.activeusersession) {
+        await onRequestCurrentUser();
       }
     }
-    onInit();
-  }, [onRequestApiInfo, onRequestCurrentUser]);
+
+    Promise.all([onInit(), onGetPolicy()])
+      .then(() => setInitDone(true))
+      .catch(e => setError(e));
+  }, [onRequestApiInfo, onRequestCurrentUser, onGetPolicy]);
 
   const hasUser = !!user;
 

--- a/src/Appv2/Loader/hooks.js
+++ b/src/Appv2/Loader/hooks.js
@@ -28,6 +28,7 @@ const mapDispatchToProps = {
   onLoadDraftProposals: act.onLoadDraftProposals,
   onPollUserPayment: act.onPollUserPayment,
   onUserProposalCredits: act.onUserProposalCredits,
+  onGetPolicy: act.onGetPolicy,
   localLogout: act.handleLogout
 };
 


### PR DESCRIPTION
This PR adds a fetching for the API policy during the APP initialization. This is a pretty fast call so we can take the opportunity to request it while we're fetching the other app initial data which is the API info and current user (if applicable).