### PR TITLE
Show updated username only for current user

### DIFF
--- a/src/containers/User/Detail/Detail.jsx
+++ b/src/containers/User/Detail/Detail.jsx
@@ -134,7 +134,9 @@ const UserDetail = ({
         <PageDetails
           title={
             <div className={styles.titleWrapper}>
-              <Title>{username || user.username}</Title>
+              <Title>
+                {isUserPageOwner ? username || user.username : user.username}
+              </Title>
               {isUserPageOwner && (
                 <Link
                   href="#"


### PR DESCRIPTION
When the username was updated, the new username was appearing for every other user detail page. This PR corrects this behavior.