### PR TITLE
Only show "pay with faucet" on testnet

### DIFF
--- a/src/componentsv2/ModalBuyProposalCredits/ModalBuyProposalCredits.jsx
+++ b/src/componentsv2/ModalBuyProposalCredits/ModalBuyProposalCredits.jsx
@@ -11,7 +11,6 @@ const ModalBuyProposalCredits = ({
   price,
   initialStep = 0,
   address,
-  isPaid,
   status,
   isPollingCreditsPayment,
   startPollingPayment
@@ -33,7 +32,7 @@ const ModalBuyProposalCredits = ({
   }, [isPollingCreditsPayment, startPollingPayment, modalType]);
 
   const setValue = e => {
-    if(e.target.value === "") {
+    if (e.target.value === "") {
       setDisableNext(true);
       setNumber(e.target.value);
       return;
@@ -54,39 +53,41 @@ const ModalBuyProposalCredits = ({
         address={address}
         amount={(number * price).toFixed(1)}
         extraSmall={extraSmall}
-        isPaid={isPaid}
         status={status}
       />
     </Modal>
   ) : (
-      <Modal
-        show={show}
-        onClose={customOnClose}
-        title="Purchase Proposal Credits"
-        contentStyle={{ width: "100%" }}
-      >
-        <div>
-          <Text>How many credits do you want to buy? </Text>
-          <input
-            value={number}
-            onChange={setValue}
-            type="number"
-            className={styles.inputNumber}
-          />
-        </div>
-        <div className="margin-top-s">
-          <Text color="gray">Each proposal credit costs 0.1 DCR</Text>
-        </div>
-        <div className={classNames("margin-top-l", styles.actionButtons)}>
-          <Button onClick={customOnClose} kind="secondary">
-            Back
+    <Modal
+      show={show}
+      onClose={customOnClose}
+      title="Purchase Proposal Credits"
+      contentStyle={{ width: "100%" }}
+    >
+      <div>
+        <Text>How many credits do you want to buy? </Text>
+        <input
+          value={number}
+          onChange={setValue}
+          type="number"
+          className={styles.inputNumber}
+        />
+      </div>
+      <div className="margin-top-s">
+        <Text color="gray">Each proposal credit costs 0.1 DCR</Text>
+      </div>
+      <div className={classNames("margin-top-l", styles.actionButtons)}>
+        <Button onClick={customOnClose} kind="secondary">
+          Back
         </Button>
-          <Button kind={(disableNext && "disabled") || "primary"} onClick={handleGoToPaymentDetails}>
-            Next
-          </Button>
-        </div>
-      </Modal>
-    );
+        <Button
+          kind={(disableNext && "disabled") || "primary"}
+          onClick={handleGoToPaymentDetails}
+        >
+          Next
+        </Button>
+      </div>
+    </Modal>
+  );
 };
 
 ModalBuyProposalCredits.propTypes = {

--- a/src/componentsv2/ModalPayPaywall/ModalPayPaywall.jsx
+++ b/src/componentsv2/ModalPayPaywall/ModalPayPaywall.jsx
@@ -1,6 +1,5 @@
 import { Modal, P, Text, useMediaQuery } from "pi-ui";
 import React from "react";
-import { PAYWALL_STATUS_PAID } from "src/constants";
 import usePaywall from "src/hooks/api/usePaywall";
 import PaymentComponent from "../PaymentComponent";
 import PaymentStatusTag from "../PaymentStatusTag";
@@ -8,7 +7,6 @@ import styles from "./ModalPayPaywall.module.css";
 
 const ModalPayPaywall = ({ show, title, onClose }) => {
   const { userPaywallStatus, paywallAmount, paywallAddress } = usePaywall();
-  const isPaid = userPaywallStatus === PAYWALL_STATUS_PAID;
   const extraSmall = useMediaQuery("(max-width: 560px)");
   return (
     <Modal show={show} title={title} onClose={onClose}>
@@ -23,7 +21,6 @@ const ModalPayPaywall = ({ show, title, onClose }) => {
         address={paywallAddress}
         amount={paywallAmount}
         extraSmall={extraSmall}
-        isPaid={isPaid}
         status={userPaywallStatus}
       />
     </Modal>

--- a/src/componentsv2/PaymentComponent/PaymentComponent.jsx
+++ b/src/componentsv2/PaymentComponent/PaymentComponent.jsx
@@ -2,13 +2,11 @@ import { classNames, CopyableText, H4, Text } from "pi-ui";
 import PropTypes from "prop-types";
 import React from "react";
 import PaymentFaucet from "../PaymentFaucet";
-import usePaywall from "src/hooks/api/usePaywall";
 import PaymentStatusTag from "../PaymentStatusTag";
 import QRCode from "../QRCode";
 import styles from "./PaymentComponent.module.css";
 
 const PaymentComponent = ({ address, amount, extraSmall, status }) => {
-  const { isPaid } = usePaywall();
   return (
     <>
       <div className={classNames(styles.paywallInfo, "margin-top-l")}>
@@ -33,7 +31,7 @@ const PaymentComponent = ({ address, amount, extraSmall, status }) => {
           {!extraSmall && <PaymentStatusTag status={status} />}
         </div>
       </div>
-      <PaymentFaucet address={address} amount={amount} isPaid={isPaid} />
+      <PaymentFaucet address={address} amount={amount} />
     </>
   );
 };

--- a/src/componentsv2/PaymentFaucet/PaymentFaucet.jsx
+++ b/src/componentsv2/PaymentFaucet/PaymentFaucet.jsx
@@ -6,7 +6,7 @@ import styles from "./PaymentFaucet.module.css";
 const FAUCET_BASE_URL = "https://testnet.dcrdata.org/explorer/tx";
 const getFaucetUrl = txid => `${FAUCET_BASE_URL}/${txid}`;
 
-const PaymentFaucet = ({ address, amount, isPaid }) => {
+const PaymentFaucet = ({ address, amount }) => {
   const {
     payWithFaucetError,
     payWithFaucet,
@@ -14,42 +14,46 @@ const PaymentFaucet = ({ address, amount, isPaid }) => {
     isApiRequestingPayWithFaucet,
     isTestnet
   } = useFaucet();
-  return !isTestnet && !isPaid ? null : (
-    <div className="paywall-faucet">
-      <P className="margin-top-m">
-        This Politeia instance is running on Testnet, which means you can pay
-        with the Decred faucet:
-      </P>
-      {payWithFaucetTxId ? null : (
-        <Button
-          className="margin-top-s"
-          loading={isApiRequestingPayWithFaucet}
-          onClick={() => payWithFaucet(address, amount)}
-        >
-          Pay with Faucet
-        </Button>
-      )}
-      {payWithFaucetError ? (
-        <Message type="error" header="Faucet error" body={payWithFaucetError} />
-      ) : null}
-      {payWithFaucetTxId ? (
-        <Message kind="info" className={styles.transactionIdMessage}>
-          <span style={{ marginRight: "5px" }}>
-            Sent transaction:{" "}
-          </span>
-          <Link
-            href={getFaucetUrl(payWithFaucetTxId)}
-            target="_blank"
-            id="transactionLink"
-            truncate
-            rel="noopener noreferrer"
-            className={styles.transactionIdLink}
+  return (
+    isTestnet && (
+      <div className="paywall-faucet">
+        <P className="margin-top-m">
+          This Politeia instance is running on Testnet, which means you can pay
+          with the Decred faucet:
+        </P>
+        {payWithFaucetTxId ? null : (
+          <Button
+            className="margin-top-s"
+            loading={isApiRequestingPayWithFaucet}
+            onClick={() => payWithFaucet(address, amount)}
           >
-            {payWithFaucetTxId}
-          </Link>
-        </Message>
-      ) : null}
-    </div>
+            Pay with Faucet
+          </Button>
+        )}
+        {payWithFaucetError ? (
+          <Message
+            type="error"
+            header="Faucet error"
+            body={payWithFaucetError}
+          />
+        ) : null}
+        {payWithFaucetTxId ? (
+          <Message kind="info" className={styles.transactionIdMessage}>
+            <span style={{ marginRight: "5px" }}>Sent transaction: </span>
+            <Link
+              href={getFaucetUrl(payWithFaucetTxId)}
+              target="_blank"
+              id="transactionLink"
+              truncate
+              rel="noopener noreferrer"
+              className={styles.transactionIdLink}
+            >
+              {payWithFaucetTxId}
+            </Link>
+          </Message>
+        ) : null}
+      </div>
+    )
   );
 };
 


### PR DESCRIPTION
This PR fixes an issue of the "Pay with faucet" button appearing on mainnet for users trying to purchase proposal credits.