### PR TITLE
Filter duplicate comments

### DIFF
--- a/src/containers/Comments/Comments.jsx
+++ b/src/containers/Comments/Comments.jsx
@@ -176,6 +176,10 @@ const Comments = ({
     [userEmail, recordToken, commentIDCensorTarget, onCensorComment]
   );
 
+  const numOfDuplicatedComments = numOfComments - state.comments.length;
+  const hasDuplicatedComments =
+    !!state.comments.length && numOfDuplicatedComments > 0;
+
   return (
     <>
       <Card
@@ -214,12 +218,18 @@ const Comments = ({
           </LoggedInContent>
           <div className={styles.commentsHeader}>
             {!isSingleThread && (
-              <H2 className={styles.commentsTitle}>
-                Comments{" "}
-                <span className={styles.commentsCount}>
-                  {state.comments.length || numOfComments}
-                </span>
-              </H2>
+              <div className={styles.titleWrapper}>
+                <H2 className={styles.commentsTitle}>
+                  Comments{" "}
+                  <span className={styles.commentsCount}>{numOfComments}</span>
+                </H2>
+                {hasDuplicatedComments && (
+                  <Text
+                    color="gray"
+                    size="small"
+                  >{`(${numOfDuplicatedComments} duplicate comments omitted)`}</Text>
+                )}
+              </div>
             )}
             <div className={styles.sortContainer}>
               {!!comments && !!comments.length && (

--- a/src/reducers/models/comments.js
+++ b/src/reducers/models/comments.js
@@ -1,5 +1,7 @@
 import * as act from "src/actions/types";
 import cloneDeep from "lodash/cloneDeep";
+import uniqBy from "lodash/uniqBy";
+import reverse from "lodash/reverse";
 import unionBy from "lodash/unionBy";
 import compose from "lodash/fp/compose";
 import set from "lodash/fp/set";
@@ -16,8 +18,11 @@ const comments = (state = DEFAULT_STATE, action) =>
     : ({
         [act.RECEIVE_PROPOSAL_COMMENTS]: () => {
           const { token, comments, accesstime } = action.payload;
+          // Filter duplicated comments by signature. The latest copy found
+          // will be kept.
+          const filteredComments = uniqBy(reverse(comments), "signature");
           return compose(
-            set(["comments", "byToken", token], comments),
+            set(["comments", "byToken", token], filteredComments),
             set(["comments", "accessTimeByToken", token], accesstime)
           )(state);
         },


### PR DESCRIPTION
This PR filter duplicate comments by signature. The last copy found (latest duplicated comment) will be kept. 

To make the number of comments consistent across different screens, the real number of comments (e.g non-filtered) will be shown and a message in the proposal page will show how many comments were omitted:

![Screen Shot 2019-10-31 at 19 19 10](https://user-images.githubusercontent.com/14864439/67975352-3299da80-fc14-11e9-8d87-7f3e38bd0fef.png)


closes #1533 