### PR TITLE
Unregister service worker

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,8 @@
 import React, { lazy, Suspense } from "react";
 import ReactDOM from "react-dom";
+import { unregister } from "./registerServiceWorker";
+
+unregister();
 
 // lazy load the v2 so it doesn't affect the app bundle size
 // and the styles from old version doesn't affect v2


### PR DESCRIPTION
Closes #1535 

Create-react-app provides a service worker and this caches the various files on the client-side. We stopped using it a while ago but I'm suspecting that some of our users still have those files cached. This PR unregisters the service worker. We already have cache busting for the html files in our nginx config:

```
location ~ \.html$ {
        add_header Cache-Control "private, no-cache, no-store, must-revalidate";
        add_header Expires "Sat, 01 Jan 2000 00:00:00 GMT";
        add_header Pragma no-cache;
    }
```