### PR TITLE
Improve general performance on Proposal Detail page

### DIFF
--- a/src/Appv2/Loader/hooks.js
+++ b/src/Appv2/Loader/hooks.js
@@ -1,38 +1,24 @@
 import * as sel from "src/selectors";
 import * as act from "src/actions";
-// import { or } from "src/lib/fp";
-import { useRedux } from "src/redux";
+import { useSelector, useAction } from "src/redux";
 
-const mapStateToProps = {
-  user: sel.currentUser,
-  userPubkey: sel.currentUserPublicKey,
-  currentUserEmail: sel.currentUserEmail,
-  currentUserID: sel.currentUserID,
-  lastLoginTime: sel.currentUserLastLoginTime,
-  keyMismatch: sel.getKeyMismatch,
-  apiError: sel.apiError,
-  userCanExecuteActions: sel.userCanExecuteActions,
-  onboardViewed: sel.onboardViewed,
-  identityImportSuccess: sel.identityImportSuccess,
-  isCMS: sel.isCMS,
-  apiInfo: sel.apiInitResponse
-};
-
-const mapDispatchToProps = {
-  onRequestApiInfo: act.requestApiInfo,
-  keyMismatchAction: act.keyMismatch,
-  openModal: act.openModal,
-  onRequestCurrentUser: act.onRequestMe,
-  confirmWithModal: act.confirmWithModal,
-  setOnboardAsViewed: act.setOnboardAsViewed,
-  onLoadDraftProposals: act.onLoadDraftProposals,
-  onPollUserPayment: act.onPollUserPayment,
-  onUserProposalCredits: act.onUserProposalCredits,
-  onGetPolicy: act.onGetPolicy,
-  localLogout: act.handleLogout
-};
-
-export function useLoader(ownProps) {
-  const fromRedux = useRedux(ownProps, mapStateToProps, mapDispatchToProps);
-  return fromRedux;
+export function useLoader() {
+  const user = useSelector(sel.currentUser);
+  const apiInfo = useSelector(sel.apiInitResponse);
+  const onRequestApiInfo = useAction(act.requestApiInfo);
+  const onRequestCurrentUser = useAction(act.onRequestMe);
+  const localLogout = useAction(act.handleLogout);
+  const onPollUserPayment = useAction(act.onPollUserPayment);
+  const onUserProposalCredits = useAction(act.onUserProposalCredits);
+  const onGetPolicy = useAction(act.onGetPolicy);
+  return {
+    user,
+    apiInfo,
+    onRequestApiInfo,
+    onRequestCurrentUser,
+    localLogout,
+    onPollUserPayment,
+    onUserProposalCredits,
+    onGetPolicy
+  };
 }

--- a/src/componentsv2/Likes/Likes.jsx
+++ b/src/componentsv2/Likes/Likes.jsx
@@ -13,15 +13,7 @@ import styles from "./Likes.module.css";
 export const isLiked = action => action === 1 || action === "1";
 export const isDisliked = action => action === -1 || action === "-1";
 
-const Likes = ({
-  upLikes,
-  downLikes,
-  onLike,
-  onDislike,
-  option,
-  disabled,
-  asyncLoading
-}) => {
+const Likes = ({ upLikes, downLikes, onLike, onDislike, option, disabled }) => {
   const theme = useTheme();
   const [loading, setLoading] = useState(false);
   const [likeRef, isLikeHovered] = useHover();
@@ -35,28 +27,6 @@ const Likes = ({
     (liked || isLikeHovered) && !isDisabled ? activeColor : defaultColor;
   const dislikeColor =
     (disliked || isDislikeHovered) && !isDisabled ? activeColor : defaultColor;
-
-  async function handleLike() {
-    if (disabled || loading) return;
-    try {
-      setLoading(true);
-      await onLike();
-      setLoading(false);
-    } catch (e) {
-      setLoading(false);
-    }
-  }
-
-  async function handleDislike() {
-    if (disabled || loading) return;
-    try {
-      setLoading(true);
-      await onDislike();
-      setLoading(false);
-    } catch (e) {
-      setLoading(false);
-    }
-  }
 
   const renderCount = useCallback(
     count => (
@@ -77,14 +47,9 @@ const Likes = ({
           disabled={loading || disabled}
           ref={likeRef}
           className={styles.likeBtn}
-          onClick={asyncLoading ? handleLike : onLike}
+          onClick={onLike}
         >
-          <Icon
-            onClick={onLike}
-            iconColor={likeColor}
-            backgroundColor={likeColor}
-            type="like"
-          />
+          <Icon iconColor={likeColor} backgroundColor={likeColor} type="like" />
         </button>
         {renderCount(upLikes)}
       </div>
@@ -93,10 +58,9 @@ const Likes = ({
           disabled={loading || disabled}
           ref={dislikeRef}
           className={styles.likeBtn}
-          onClick={asyncLoading ? handleDislike : onDislike}
+          onClick={onDislike}
         >
           <Icon
-            onClick={onDislike}
             iconColor={dislikeColor}
             backgroundColor={dislikeColor}
             type="dislike"

--- a/src/componentsv2/Likes/Likes.jsx
+++ b/src/componentsv2/Likes/Likes.jsx
@@ -13,7 +13,15 @@ import styles from "./Likes.module.css";
 export const isLiked = action => action === 1 || action === "1";
 export const isDisliked = action => action === -1 || action === "-1";
 
-const Likes = ({ upLikes, downLikes, onLike, onDislike, option, disabled }) => {
+const Likes = ({
+  upLikes,
+  downLikes,
+  onLike,
+  onDislike,
+  option,
+  disabled,
+  id
+}) => {
   const theme = useTheme();
   const [loading, setLoading] = useState(false);
   const [likeRef, isLikeHovered] = useHover();
@@ -27,6 +35,36 @@ const Likes = ({ upLikes, downLikes, onLike, onDislike, option, disabled }) => {
     (liked || isLikeHovered) && !isDisabled ? activeColor : defaultColor;
   const dislikeColor =
     (disliked || isDislikeHovered) && !isDisabled ? activeColor : defaultColor;
+
+  // console.log(id, loading);
+
+  const handleLike = useCallback(
+    async function handleLike() {
+      if (disabled || loading) return;
+      try {
+        setLoading(true);
+        await onLike();
+        setLoading(false);
+      } catch (e) {
+        setLoading(false);
+      }
+    },
+    [disabled, loading, setLoading, onLike]
+  );
+
+  const handleDislike = useCallback(
+    async function handleDislike() {
+      if (disabled || loading) return;
+      try {
+        setLoading(true);
+        await onDislike();
+        setLoading(false);
+      } catch (e) {
+        setLoading(false);
+      }
+    },
+    [disabled, loading, setLoading, onDislike]
+  );
 
   const renderCount = useCallback(
     count => (
@@ -47,7 +85,7 @@ const Likes = ({ upLikes, downLikes, onLike, onDislike, option, disabled }) => {
           disabled={loading || disabled}
           ref={likeRef}
           className={styles.likeBtn}
-          onClick={onLike}
+          onClick={handleLike}
         >
           <Icon iconColor={likeColor} backgroundColor={likeColor} type="like" />
         </button>
@@ -58,7 +96,7 @@ const Likes = ({ upLikes, downLikes, onLike, onDislike, option, disabled }) => {
           disabled={loading || disabled}
           ref={dislikeRef}
           className={styles.likeBtn}
-          onClick={onDislike}
+          onClick={handleDislike}
         >
           <Icon
             iconColor={dislikeColor}
@@ -82,7 +120,6 @@ Likes.propTypes = {
 
 Likes.defaultProps = {
   active: false,
-  asyncLoading: true,
   upLikes: 0,
   downLikes: 0
 };

--- a/src/componentsv2/Likes/Likes.jsx
+++ b/src/componentsv2/Likes/Likes.jsx
@@ -36,8 +36,6 @@ const Likes = ({
   const dislikeColor =
     (disliked || isDislikeHovered) && !isDisabled ? activeColor : defaultColor;
 
-  // console.log(id, loading);
-
   const handleLike = useCallback(
     async function handleLike() {
       if (disabled || loading) return;

--- a/src/componentsv2/Markdown/Markdown.jsx
+++ b/src/componentsv2/Markdown/Markdown.jsx
@@ -31,4 +31,4 @@ MarkdownRenderer.prototype = {
   escapeHtml: PropTypes.bool
 };
 
-export default MarkdownRenderer;
+export default React.memo(MarkdownRenderer);

--- a/src/componentsv2/ModalConfirm.jsx
+++ b/src/componentsv2/ModalConfirm.jsx
@@ -104,4 +104,4 @@ ModalConfirm.defaultProps = {
   message: "Are you sure?"
 };
 
-export default ModalConfirm;
+export default React.memo(ModalConfirm);

--- a/src/componentsv2/ModalConfirmWithReason.jsx
+++ b/src/componentsv2/ModalConfirmWithReason.jsx
@@ -144,4 +144,4 @@ ModalConfirmWithReason.defaultProps = {
   reasonLabel: "Reason"
 };
 
-export default ModalConfirmWithReason;
+export default React.memo(ModalConfirmWithReason);

--- a/src/componentsv2/PaywallMessage.jsx
+++ b/src/componentsv2/PaywallMessage.jsx
@@ -19,21 +19,22 @@ const PaywallMessage = ({ wrapper, ...props }) => {
   const WrapperComponent = wrapper;
 
   return (
-    <>
-      {showMessage ? (
+    showMessage && (
+      <>
         <WrapperComponent {...props}>
           <StaticMarkdown contentName={paywallContent} />
           <Button onClick={openPaywallModal} className="margin-top-m">
             Pay the registration fee
           </Button>
         </WrapperComponent>
-      ) : null}
-      <ModalPayPaywall
-        show={showModal}
-        title="Complete your registration"
-        onClose={closePaywallModal}
-      />
-    </>
+
+        <ModalPayPaywall
+          show={showModal}
+          title="Complete your registration"
+          onClose={closePaywallModal}
+        />
+      </>
+    )
   );
 };
 

--- a/src/componentsv2/Proposal/Proposal.jsx
+++ b/src/componentsv2/Proposal/Proposal.jsx
@@ -12,7 +12,8 @@ import {
   isPublicProposal,
   isEditableProposal,
   getQuorumInVotes,
-  isVotingFinishedProposal
+  isVotingFinishedProposal,
+  getProposalToken
 } from "src/containers/Proposal/helpers";
 import { useProposalVote } from "src/containers/Proposal/hooks";
 import { useLoaderContext } from "src/Appv2/Loader";
@@ -27,7 +28,24 @@ import ModalFullImage from "src/componentsv2/ModalFullImage";
 import VersionPicker from "src/componentsv2/VersionPicker";
 import { useRouter } from "src/componentsv2/Router";
 
-const Proposal = ({ proposal, extended, collapseBodyContent }) => {
+const ProposalWrapper = props => {
+  const voteProps = useProposalVote(getProposalToken(props.proposal));
+  const { currentUser } = useLoaderContext();
+  const { history } = useRouter();
+  return <Proposal {...{ ...props, ...voteProps, currentUser, history }} />;
+};
+
+const Proposal = React.memo(function Proposal({
+  proposal,
+  extended,
+  collapseBodyContent,
+  voteSummary,
+  voteActive: isVoteActive,
+  voteTimeInWords: voteTime,
+  voteBlocksLeft,
+  currentUser,
+  history
+}) {
   const {
     censorshiprecord,
     files,
@@ -40,14 +58,6 @@ const Proposal = ({ proposal, extended, collapseBodyContent }) => {
     username,
     version
   } = proposal;
-  const {
-    voteSummary,
-    voteActive: isVoteActive,
-    voteTimeInWords: voteTime,
-    voteBlocksLeft
-  } = useProposalVote(censorshiprecord.token);
-  const { currentUser } = useLoaderContext();
-  const { history } = useRouter();
   const {
     showFullImageModal,
     openFullImageModal,
@@ -280,6 +290,6 @@ const Proposal = ({ proposal, extended, collapseBodyContent }) => {
       )}
     </>
   );
-};
+});
 
-export default Proposal;
+export default ProposalWrapper;

--- a/src/componentsv2/RecordWrapper/RecordWrapper.jsx
+++ b/src/componentsv2/RecordWrapper/RecordWrapper.jsx
@@ -100,14 +100,14 @@ const MobileHeader = ({ title, status, edit }) => (
   </div>
 );
 
-export const Header = ({
+export const Header = React.memo(function Header({
   title,
   subtitle,
   status,
   edit,
   mobile,
   disableMobileView = false
-}) => {
+}) {
   return (
     <div className={styles.header}>
       {!mobile || disableMobileView ? (
@@ -124,7 +124,7 @@ export const Header = ({
       {subtitle}
     </div>
   );
-};
+});
 
 export const ChartsLink = ({ token }) => {
   const { apiInfo } = useLoader();
@@ -140,7 +140,11 @@ export const ChartsLink = ({ token }) => {
       placement="bottom"
       content="Voting Charts"
     >
-      <UILink ref={ref} target="_blank" href={`https://${hostName}.dcrdata.org/proposal/${token}`}>
+      <UILink
+        ref={ref}
+        target="_blank"
+        href={`https://${hostName}.dcrdata.org/proposal/${token}`}
+      >
         <Icon type="chart" iconColor={iconColor} />
       </UILink>
     </Tooltip>

--- a/src/containers/Comments/hooks.js
+++ b/src/containers/Comments/hooks.js
@@ -7,21 +7,12 @@ import {
 } from "react";
 import * as sel from "src/selectors";
 import * as act from "src/actions";
-import { useRedux } from "src/redux";
+import { useSelector, useAction } from "src/redux";
 import { useConfig } from "src/Config";
 import { useLoaderContext } from "src/Appv2/Loader";
 
 export const CommentContext = createContext();
 export const useComment = () => useContext(CommentContext);
-
-const mapDispatchToProps = {
-  onSubmitComment: act.onSaveNewCommentV2,
-  onFetchComments: act.onFetchProposalComments,
-  onFetchLikes: act.onFetchLikedComments,
-  onLikeComment: act.onLikeComment,
-  onResetComments: act.onResetComments,
-  onCensorComment: act.onCensorCommentv2
-};
 
 export function useComments(ownProps) {
   const recordToken = ownProps && ownProps.recordToken;
@@ -33,26 +24,19 @@ export function useComments(ownProps) {
     () => sel.makeGetProposalCommentsLikes(recordToken),
     [recordToken]
   );
-  const mapStateToProps = useMemo(
-    () => ({
-      comments: commentsSelector,
-      commentsLikes: commentsLikesSelector,
-      lastVisitTimestamp: sel.visitedProposal,
-      loading: sel.isApiRequestingComments,
-      loadingLikes: sel.isApiRequestingCommentsLikes
-    }),
-    [commentsSelector, commentsLikesSelector]
-  );
 
-  const {
-    comments,
-    onFetchComments,
-    onFetchLikes,
-    onCensorComment,
-    onLikeComment: onLikeCommentAction,
-    commentsLikes,
-    ...fromRedux
-  } = useRedux(ownProps, mapStateToProps, mapDispatchToProps);
+  const comments = useSelector(commentsSelector);
+  const commentsLikes = useSelector(commentsLikesSelector);
+  const lastVisitTimestamp = useSelector(sel.visitedProposal);
+  const loading = useSelector(sel.isApiRequestingComments);
+  const loadingLikes = useSelector(sel.isApiRequestingCommentsLikes);
+  const onSubmitComment = useAction(act.onSaveNewCommentV2);
+  const onFetchComments = useAction(act.onFetchProposalComments);
+  const onFetchLikes = useAction(act.onFetchLikedComments);
+  const onLikeCommentAction = useAction(act.onLikeComment);
+  const onResetComments = useAction(act.onResetComments);
+  const onCensorComment = useAction(act.onCensorCommentv2);
+
   const { enableCommentVote, recordType } = useConfig();
   const { currentUser } = useLoaderContext();
   const email = currentUser && currentUser.email;
@@ -116,6 +100,10 @@ export function useComments(ownProps) {
     userEmail: email,
     recordType,
     currentUser,
-    ...fromRedux
+    lastVisitTimestamp,
+    loading,
+    loadingLikes,
+    onSubmitComment,
+    onResetComments
   };
 }

--- a/src/containers/Proposal/Actions/hooks.js
+++ b/src/containers/Proposal/Actions/hooks.js
@@ -50,7 +50,7 @@ export function usePublicActions() {
   const onAuthorize = useAction(act.onAuthorizeVote);
   const onRevoke = useAction(act.onRevokeVote);
 
-  const currentUser = useSelector(sel.currentUser);
+  const currentUserEmail = useSelector(sel.currentUserEmail);
 
   const onAbandonProposal = useCallback(
     proposal => reason =>
@@ -65,33 +65,33 @@ export function usePublicActions() {
   const onAuthorizeVote = useCallback(
     proposal => () =>
       onAuthorize(
-        currentUser.email,
+        currentUserEmail,
         proposal.censorshiprecord.token,
         proposal.version
       ),
-    [onAuthorize, currentUser.email]
+    [onAuthorize, currentUserEmail]
   );
 
   const onRevokeVote = useCallback(
     proposal => () =>
       onRevoke(
-        currentUser.email,
+        currentUserEmail,
         proposal.censorshiprecord.token,
         proposal.version
       ),
-    [onRevoke, currentUser.email]
+    [onRevoke, currentUserEmail]
   );
 
   const onStartVote = useCallback(
     proposal => ({ duration, quorumPercentage, passPercentage }) =>
       onStart(
-        currentUser.email,
+        currentUserEmail,
         proposal.censorshiprecord.token,
         duration,
         quorumPercentage,
         passPercentage
       ),
-    [onStart, currentUser.email]
+    [onStart, currentUserEmail]
   );
 
   return {

--- a/src/containers/Proposal/Detail/Detail.jsx
+++ b/src/containers/Proposal/Detail/Detail.jsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useCallback } from "react";
+import get from "lodash/fp/get";
 import { Link } from "pi-ui";
 import { withRouter } from "react-router-dom";
 import Proposal from "src/componentsv2/Proposal";
@@ -10,7 +11,8 @@ import { getCommentBlockedReason } from "./helpers";
 import {
   isPublicProposal,
   isAbandonedProposal,
-  isVotingFinishedProposal
+  isVotingFinishedProposal,
+  getProposalToken
 } from "../helpers";
 import {
   UnvettedActionsProvider,
@@ -20,9 +22,12 @@ import { useProposalVote } from "../hooks";
 import { useRouter } from "src/componentsv2/Router";
 
 const ProposalDetail = ({ Main, match }) => {
-  const { proposal, loading, threadParentID } = useProposal({ match });
-  const proposalToken =
-    proposal && proposal.censorshiprecord && proposal.censorshiprecord.token;
+
+  const tokenFromUrl = get("params.token", match);
+  const threadParentCommentID = get("params.commentid", match);
+  const { proposal, loading, threadParentID } = useProposal(tokenFromUrl, threadParentCommentID);
+  const proposalToken = getProposalToken(proposal);
+
   const { voteSummary } = useProposalVote(proposalToken);
 
   const showCommentArea =
@@ -61,12 +66,12 @@ const ProposalDetail = ({ Main, match }) => {
             {loading || !proposal ? (
               <ProposalLoader extended />
             ) : (
-                <Proposal
-                  proposal={proposal}
-                  extended
-                  collapseBodyContent={!!threadParentID}
-                />
-              )}
+              <Proposal
+                proposal={proposal}
+                extended
+                collapseBodyContent={!!threadParentID}
+              />
+            )}
             {showCommentArea && (
               <Comments
                 recordAuthorID={proposal.userid}

--- a/src/containers/Proposal/Detail/hooks.js
+++ b/src/containers/Proposal/Detail/hooks.js
@@ -1,31 +1,10 @@
 import { useEffect, useState, useCallback, useMemo } from "react";
-import get from "lodash/fp/get";
-import compose from "lodash/fp/compose";
 import isEqual from "lodash/isEqual";
-import { arg, or } from "src/lib/fp";
+import { or } from "src/lib/fp";
 import * as sel from "src/selectors";
 import * as act from "src/actions";
-import { useRedux } from "src/redux";
-import { useLoaderContext } from "src/Appv2/Loader";
+import { useSelector, useAction } from "src/redux";
 import { isUnreviewedProposal, isCensoredProposal } from "../helpers";
-
-const mapStateToProps = {
-  token: compose(
-    get(["match", "params", "token"]),
-    arg(1)
-  ),
-  commentID: compose(
-    get(["match", "params", "commentid"]),
-    arg(1)
-  ),
-  error: sel.proposalError,
-  loading: or(sel.isApiRequestingProposalsVoteSummary, sel.proposalIsRequesting)
-};
-
-const mapDispatchToProps = {
-  onFetchProposal: act.onFetchProposal,
-  onFetchProposalsVoteSummary: act.onFetchProposalsBatchVoteSummary
-};
 
 const proposalWithFilesOrNothing = proposal => {
   return proposal && proposal.files && !!proposal.files.length
@@ -33,25 +12,23 @@ const proposalWithFilesOrNothing = proposal => {
     : null;
 };
 
-export function useProposal(ownProps) {
-  const {
-    error,
-    token,
-    loading,
-    onFetchProposal,
-    onFetchProposalsVoteSummary,
-    commentID: threadParentID
-  } = useRedux(ownProps, mapStateToProps, mapDispatchToProps);
-
+export function useProposal(token, threadParentID) {
+  const error = useSelector(sel.proposalError);
+  const loadingSelector = useMemo(
+    () => or(sel.isApiRequestingProposalsVoteSummary, sel.proposalIsRequesting),
+    []
+  );
+  const loading = useSelector(loadingSelector);
+  const onFetchProposal = useAction(act.onFetchProposal);
+  const onFetchProposalsVoteSummary = useAction(
+    act.onFetchProposalsBatchVoteSummary
+  );
   const proposalSelector = useMemo(() => sel.makeGetProposalByToken(token), [
     token
   ]);
-  const { proposalFromState } = useRedux(
-    {},
-    { proposalFromState: proposalSelector }
-  );
+  const proposalFromState = useSelector(proposalSelector);
+  const currentUser = useSelector(sel.currentUser);
 
-  const { currentUser } = useLoaderContext();
   const currentUserIsAdmin = currentUser && currentUser.isadmin;
   const currentUserId = currentUser && currentUser.userid;
 

--- a/src/containers/Proposal/Detail/hooks.js
+++ b/src/containers/Proposal/Detail/hooks.js
@@ -5,7 +5,6 @@ import * as sel from "src/selectors";
 import * as act from "src/actions";
 import { useSelector, useAction } from "src/redux";
 import { isUnreviewedProposal, isCensoredProposal } from "../helpers";
-import why from "src/hooks/utils/useWhyDidYouUpdate";
 
 const proposalWithFilesOrNothing = proposal => {
   return proposal && proposal.files && !!proposal.files.length
@@ -49,13 +48,6 @@ export function useProposal(token, threadParentID) {
   }, [proposalFromState, currentUserId, currentUserIsAdmin]);
 
   const [proposal, setProposal] = useState(getProposal());
-
-  why("detail", {
-    proposal,
-    token,
-    onFetchProposal,
-    onFetchProposalsVoteSummary
-  });
 
   useEffect(
     function fetchProposal() {

--- a/src/containers/Proposal/Detail/hooks.js
+++ b/src/containers/Proposal/Detail/hooks.js
@@ -5,6 +5,7 @@ import * as sel from "src/selectors";
 import * as act from "src/actions";
 import { useSelector, useAction } from "src/redux";
 import { isUnreviewedProposal, isCensoredProposal } from "../helpers";
+import why from "src/hooks/utils/useWhyDidYouUpdate";
 
 const proposalWithFilesOrNothing = proposal => {
   return proposal && proposal.files && !!proposal.files.length
@@ -48,6 +49,13 @@ export function useProposal(token, threadParentID) {
   }, [proposalFromState, currentUserId, currentUserIsAdmin]);
 
   const [proposal, setProposal] = useState(getProposal());
+
+  why("detail", {
+    proposal,
+    token,
+    onFetchProposal,
+    onFetchProposalsVoteSummary
+  });
 
   useEffect(
     function fetchProposal() {

--- a/src/containers/Proposal/Edit/Edit.jsx
+++ b/src/containers/Proposal/Edit/Edit.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import get from "lodash/fp/get";
 import { Card, Message } from "pi-ui";
 import { useProposal } from "../Detail/hooks";
 import { useEditProposal } from "./hooks";
@@ -12,7 +13,8 @@ import ProposalForm from "src/componentsv2/ProposalForm/ProposalFormLazy";
 import ProposalFormLoader from "src/componentsv2/ProposalForm/ProposalFormLoader";
 
 const EditProposal = ({ match }) => {
-  const { proposal, loading } = useProposal({ match });
+  const tokenFromUrl = get("params.token", match);
+  const { proposal, loading } = useProposal(tokenFromUrl);
   const { onEditProposal } = useEditProposal();
   const { isPaid } = usePaywall();
   const [, identityError] = useIdentity();

--- a/src/containers/Proposal/helpers.js
+++ b/src/containers/Proposal/helpers.js
@@ -200,3 +200,14 @@ export const getMarkdownContent = files => {
   const markdownFile = files.find(f => f.name === "index.md");
   return getTextFromIndexMd(markdownFile);
 };
+
+/**
+ * Returns the proposal censorship token
+ * @param {Object} proposal
+ * @returns {String} censorhipToken
+ */
+export const getProposalToken = proposal => {
+  return (
+    proposal && proposal.censorshiprecord && proposal.censorshiprecord.token
+  );
+};

--- a/src/containers/Proposal/hooks.js
+++ b/src/containers/Proposal/hooks.js
@@ -1,7 +1,6 @@
 import { useMemo } from "react";
-import { useLoaderContext } from "src/Appv2/Loader";
 import * as sel from "src/selectors";
-import { useRedux } from "src/redux";
+import { useSelector } from "src/redux";
 import {
   getVoteBlocksLeft,
   isVoteActiveProposal,
@@ -9,15 +8,13 @@ import {
 } from "./helpers";
 
 export function useProposalVote(token) {
-  const mapStateToProps = useMemo(() => {
-    const voteSummarySelector = sel.makeGetProposalVoteSummary(token);
-    return {
-      voteSummary: voteSummarySelector,
-      bestBlock: sel.bestBlock
-    };
-  }, [token]);
-  const { voteSummary, bestBlock } = useRedux({}, mapStateToProps, {});
-  const { apiInfo } = useLoaderContext();
+  const voteSummarySelector = useMemo(
+    () => sel.makeGetProposalVoteSummary(token),
+    [token]
+  );
+  const voteSummary = useSelector(voteSummarySelector);
+  const bestBlock = useSelector(sel.bestBlock);
+  const apiInfo = useSelector(sel.apiInitResponse);
   const voteTimeInWords = getVoteTimeInWords(
     voteSummary,
     bestBlock,

--- a/src/containers/Routes/Route.jsx
+++ b/src/containers/Routes/Route.jsx
@@ -4,7 +4,7 @@ import { Route as ReactRoute } from "react-router-dom";
 import { useSelector } from "src/redux";
 
 const useTitleFromState = selector => {
-  const title = useSelector(selector);
+  const title = useSelector(selector || (() => ""));
   return title;
 };
 

--- a/src/containers/Routes/Route.jsx
+++ b/src/containers/Routes/Route.jsx
@@ -1,13 +1,10 @@
-import React, { useMemo } from "react";
+import React from "react";
 import { useDocumentTitle } from "src/hooks/utils/useDocumentTitle";
 import { Route as ReactRoute } from "react-router-dom";
-import { useRedux } from "src/redux";
+import { useSelector } from "src/redux";
 
 const useTitleFromState = selector => {
-  const mapStateToProps = useMemo(() => (selector ? { title: selector } : {}), [
-    selector
-  ]);
-  const { title } = useRedux({}, mapStateToProps, {});
+  const title = useSelector(selector);
   return title;
 };
 

--- a/src/containers/User/Login/hooks.js
+++ b/src/containers/User/Login/hooks.js
@@ -1,15 +1,11 @@
 import { useEffect, useState } from "react";
 import * as act from "src/actions";
-import { useRedux } from "src/redux";
+import { useAction } from "src/redux";
 import usePolicy from "src/hooks/api/usePolicy";
 import { loginValidationSchema } from "./validation";
 
-const mapDispatchToProps = {
-  onLogin: act.onLogin
-};
-
-export function useLogin(ownProps) {
-  const fromRedux = useRedux(ownProps, {}, mapDispatchToProps);
+export function useLogin() {
+  const onLogin = useAction(act.onLogin);
   const { policy, loading: loadingPolicy } = usePolicy();
   const [validationSchema, setValidationSchema] = useState(
     policy ? loginValidationSchema(policy) : null
@@ -24,5 +20,5 @@ export function useLogin(ownProps) {
     [policy, validationSchema]
   );
 
-  return { ...fromRedux, validationSchema, loadingPolicy };
+  return { onLogin, validationSchema, loadingPolicy };
 }

--- a/src/containers/User/SessionChecker/hooks.js
+++ b/src/containers/User/SessionChecker/hooks.js
@@ -1,9 +1,10 @@
 import { useState, useEffect, useCallback } from "react";
-import { useLoaderContext } from "src/Appv2/Loader";
+import * as sel from "src/selectors";
+import { useSelector } from "src/redux";
 
 export function useSessionChecker() {
+  const currentUser = useSelector(sel.currentUser);
   const [sessionExpired, setSessionExpired] = useState(false);
-  const { currentUser } = useLoaderContext();
 
   const checkUserSession = useCallback(() => {
     if (currentUser && !sessionExpired) {

--- a/src/hooks/api/useNavigation.js
+++ b/src/hooks/api/useNavigation.js
@@ -1,18 +1,11 @@
 import * as act from "src/actions";
 import * as sel from "src/selectors";
-import { useRedux } from "src/redux";
+import { useSelector, useAction } from "src/redux";
 
-const mapStateToProps = {
-  username: sel.currentUserUsername,
-  user: sel.currentUser
-};
-
-const mapDispatchToProps = {
-  onLogout: act.onLogout,
-  handleLogout: act.handleLogout
-};
-
-export default function useNavigation(ownProps) {
-  const fromRedux = useRedux(ownProps, mapStateToProps, mapDispatchToProps);
-  return fromRedux;
+export default function useNavigation() {
+  const user = useSelector(sel.currentUser);
+  const username = user && user.username;
+  const onLogout = useAction(act.onLogout);
+  const handleLogout = useAction(act.handleLogout);
+  return { user, username, onLogout, handleLogout };
 }

--- a/src/hooks/api/usePaywall.js
+++ b/src/hooks/api/usePaywall.js
@@ -1,33 +1,38 @@
 import * as act from "src/actions";
-import { useRedux } from "src/redux";
+import { useAction, useSelector } from "src/redux";
 import * as sel from "src/selectors";
 import { PAYWALL_STATUS_PAID } from "src/constants";
 import { useConfig } from "src/Config";
 
-const mapStateToProps = {
-  currentUserEmail: sel.currentUserEmail,
-  paywallAddress: sel.currentUserPaywallAddress,
-  paywallAmount: sel.currentUserPaywallAmount,
-  paywallTxNotBefore: sel.currentUserPaywallTxNotBefore,
-  userPaywallStatus: sel.getUserPaywallStatus,
-  userPaywallConfirmations: sel.getUserPaywallConfirmations,
-  userPaywallTxid: sel.getUserPaywallTxid,
-  userAlreadyPaid: sel.getUserAlreadyPaid,
-  verificationToken: sel.verificationToken,
-  isTestnet: sel.isTestNet
-};
+function usePaywall() {
+  const currentUserEmail = useSelector(sel.currentUserEmail);
+  const paywallAddress = useSelector(sel.currentUserPaywallAddress);
+  const paywallAmount = useSelector(sel.currentUserPaywallAmount);
+  const paywallTxNotBefore = useSelector(sel.currentUserPaywallTxNotBefore);
+  const userPaywallStatus = useSelector(sel.getUserPaywallStatus);
+  const userPaywallConfirmations = useSelector(sel.getUserPaywallConfirmations);
+  const userPaywallTxid = useSelector(sel.getUserPaywallTxid);
+  const userAlreadyPaid = useSelector(sel.getUserAlreadyPaid);
+  const verificationToken = useSelector(sel.verificationToken);
+  const isTestnet = useSelector(sel.isTestNet);
 
-const mapDispatchToProps = {
-  onResetAppPaywallInfo: act.onResetPaywallInfo
-};
+  const onResetAppPaywallInfo = useAction(act.onResetPaywallInfo);
 
-function usePaywall(ownProps) {
-  const fromRedux = useRedux(ownProps, mapStateToProps, mapDispatchToProps);
   const { enablePaywall } = useConfig();
 
   return {
-    ...fromRedux,
-    isPaid: fromRedux.userPaywallStatus === PAYWALL_STATUS_PAID,
+    currentUserEmail,
+    paywallAddress,
+    paywallAmount,
+    paywallTxNotBefore,
+    userPaywallStatus,
+    userPaywallConfirmations,
+    userPaywallTxid,
+    userAlreadyPaid,
+    verificationToken,
+    isTestnet,
+    onResetAppPaywallInfo,
+    isPaid: userPaywallStatus === PAYWALL_STATUS_PAID,
     paywallEnabled: enablePaywall
   };
 }

--- a/src/hooks/api/usePolicy.js
+++ b/src/hooks/api/usePolicy.js
@@ -1,31 +1,20 @@
 import { useEffect } from "react";
 import * as act from "src/actions";
-import { useRedux } from "src/redux";
+import { useSelector, useAction } from "src/redux";
 import * as sel from "src/selectors";
 
-const mapStateToProps = {
-  policy: sel.policy,
-  loading: sel.isApiRequestingPolicy
-};
-
-const mapDispatchToProps = {
-  onGetPolicy: act.onGetPolicy
-};
-
 function usePolicy() {
-  const { onGetPolicy, policy, loading } = useRedux(
-    {},
-    mapStateToProps,
-    mapDispatchToProps
-  );
+  const policy = useSelector(sel.policy);
+  const loading = useSelector(sel.isApiRequestingPolicy);
+  const onFetchPolicy = useAction(act.onGetPolicy);
 
   useEffect(
     function handleSetValidationSchemaFromPolicy() {
       if (!policy) {
-        onGetPolicy();
+        onFetchPolicy();
       }
     },
-    [policy, onGetPolicy]
+    [policy, onFetchPolicy]
   );
 
   return { policy, loading };

--- a/src/pages/Proposals/Detail.jsx
+++ b/src/pages/Proposals/Detail.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import MultipleContentPage from "src/componentsv2/layout/MultipleContentPage";
 import ProposalDetail from "src/containers/Proposal/Detail";
 
-const PublicList = () => {
+const ProposalDetailPage = () => {
   return (
     <MultipleContentPage topBannerHeight={0}>
       {props => {
@@ -12,4 +12,4 @@ const PublicList = () => {
   );
 };
 
-export default PublicList;
+export default ProposalDetailPage;

--- a/src/redux/hooks.js
+++ b/src/redux/hooks.js
@@ -1,13 +1,19 @@
 import React, { useState, useMemo, useEffect, useContext } from "react";
 import { bindActionCreators } from "redux";
 import { selectorMap } from "src/selectors";
-import { createSelectorHook } from "react-redux";
+import { createSelectorHook, createDispatchHook } from "react-redux";
 import throttle from "lodash/throttle";
 
 export const reduxContext = React.createContext();
 export const useReduxContext = () => useContext(reduxContext);
 
 export const useSelector = createSelectorHook(reduxContext);
+export const useDispatch = createDispatchHook(reduxContext);
+
+export function useAction(action) {
+  const dispatch = useDispatch();
+  return bindActionCreators(action, dispatch);
+}
 
 const DEFAULT_MAP_DISPATCH = {};
 

--- a/src/redux/hooks.js
+++ b/src/redux/hooks.js
@@ -12,7 +12,11 @@ export const useDispatch = createDispatchHook(reduxContext);
 
 export function useAction(action) {
   const dispatch = useDispatch();
-  return bindActionCreators(action, dispatch);
+  const boundAction = useMemo(() => bindActionCreators(action, dispatch), [
+    action,
+    dispatch
+  ]);
+  return boundAction;
 }
 
 const DEFAULT_MAP_DISPATCH = {};

--- a/src/redux/hooks.js
+++ b/src/redux/hooks.js
@@ -1,10 +1,13 @@
 import React, { useState, useMemo, useEffect, useContext } from "react";
 import { bindActionCreators } from "redux";
 import { selectorMap } from "src/selectors";
+import { createSelectorHook } from "react-redux";
 import throttle from "lodash/throttle";
 
 export const reduxContext = React.createContext();
 export const useReduxContext = () => useContext(reduxContext);
+
+export const useSelector = createSelectorHook(reduxContext);
 
 const DEFAULT_MAP_DISPATCH = {};
 


### PR DESCRIPTION
This PR adds many points of performance improvements for the Proposal Detail page. This intended to fix the high CPU usage reported on https://github.com/decred/politeiagui/issues/1577. While I couldn't reproduce an extreme case as reported in the issue where the browser offer to "kill the tab" I did notice that, especially for Firefox, the response to actions such as voting on a comment or posting a comment was much slower than Chrome.
After profiling what was happening I found many opportunities to prevent needless repaintings (or re-renders). 
By using the React profiling tool I could reduce the most costly rendering step from ~163ms to ~9ms. In the screenshots below it is possible to see how the number of components affected for an action reduced drastically:
**Before:**
<img width="653" alt="Screenshot 2019-11-18 at 12 42 03" src="https://user-images.githubusercontent.com/14864439/69049896-2fb72c00-0a01-11ea-94a0-9c8c2801515d.png">

**After:**
<img width="577" alt="Screenshot 2019-11-18 at 12 43 06" src="https://user-images.githubusercontent.com/14864439/69049916-3776d080-0a01-11ea-92b0-e5272bff5f01.png">


There is still room for improvement among other components. For that, I will create an issue which shall be done after the competition of #1490 which will probably modify the selectors' structures which affect directly the changes required for improving performance during state updates.

closes #1583 