### PR TITLE
[cms] User proper userid field for request

### DIFF
--- a/src/components/UserDetail/ManageUserTab.js
+++ b/src/components/UserDetail/ManageUserTab.js
@@ -86,7 +86,7 @@ const ManageUserTab = ({
 
   const handleManageUser = useCallback(async () => {
     const args = {
-      userid: user.id,
+      userid: user.userid,
       domain: contractorDomain,
       contractortype: contractorType,
       supervisoruserids: newSupervisorIds


### PR DESCRIPTION
Previously user.id was undefined and thus causing any manageCmsUser request to fail.