### PR TITLE
[cms] Fix line item payout export

### DIFF
--- a/src/selectors/api.js
+++ b/src/selectors/api.js
@@ -729,7 +729,7 @@ export const lineItemPayouts = compose(
           token: invoice.censorshiprecord.token,
           labor: (lineItem.labor / 60) * (invoice.input.contractorrate / 100),
           expenses: lineItem.expenses / 100,
-          description: lineItem.description.replace(/#(\S*)/g, "")
+          description: lineItem.description.replace(/#/g, "")
         }))
       );
     }, []),

--- a/src/selectors/api.js
+++ b/src/selectors/api.js
@@ -152,10 +152,7 @@ export const apiStartVoteResponse = getApiResponse("startVote");
 export const apiStartVotePayload = getApiPayload("startVote");
 export const apiStartVoteError = getApiError("startVote");
 export const isApiRequestingStartVote = getIsApiRequesting("startVote");
-export const apiStartVoteToken = compose(
-  get("token"),
-  apiStartVotePayload
-);
+export const apiStartVoteToken = compose(get("token"), apiStartVotePayload);
 
 export const isApiRequestingSetProposalStatusByToken = state => token => {
   return (
@@ -283,15 +280,9 @@ export const apiError = or(
   apiSetStatusProposalError
 );
 
-export const csrf = compose(
-  get("csrfToken"),
-  apiInitResponse
-);
+export const csrf = compose(get("csrfToken"), apiInitResponse);
 
-export const newUserEmail = compose(
-  get("email"),
-  apiNewUserPayload
-);
+export const newUserEmail = compose(get("email"), apiNewUserPayload);
 export const forgottenPassEmail = compose(
   get("email"),
   apiForgottenPasswordPayload
@@ -302,62 +293,28 @@ export const emailForResendVerification = compose(
 );
 
 export const email = or(
-  compose(
-    get("email"),
-    apiMeResponse
-  ),
-  compose(
-    get("email"),
-    apiLoginPayload
-  )
+  compose(get("email"), apiMeResponse),
+  compose(get("email"), apiLoginPayload)
 );
 
-export const loggedInAsEmail = or(
-  compose(
-    get("email"),
-    apiMeResponse
-  )
-);
+export const loggedInAsEmail = or(compose(get("email"), apiMeResponse));
 
-export const lastLoginTime = or(
-  compose(
-    get("lastlogintime"),
-    apiMeResponse
-  )
-);
+export const lastLoginTime = or(compose(get("lastlogintime"), apiMeResponse));
 
 export const getUserUsername = or(
-  compose(
-    get("username"),
-    apiChangeUsernameResponse
-  ),
-  compose(
-    get("username"),
-    apiUserResponse
-  )
+  compose(get("username"), apiChangeUsernameResponse),
+  compose(get("username"), apiUserResponse)
 );
 
 export const loggedInAsUsername = or(
-  compose(
-    get("username"),
-    apiChangeUsernameResponse
-  ),
-  compose(
-    get("username"),
-    apiMeResponse
-  )
+  compose(get("username"), apiChangeUsernameResponse),
+  compose(get("username"), apiMeResponse)
 );
 
 export const isAdmin = bool(
   or(
-    compose(
-      get("isadmin"),
-      apiMeResponse
-    ),
-    compose(
-      get("isadmin"),
-      apiLoginResponse
-    )
+    compose(get("isadmin"), apiMeResponse),
+    compose(get("isadmin"), apiLoginResponse)
   )
 );
 
@@ -372,14 +329,8 @@ export const userAlreadyPaid = bool(state => {
   return false;
 });
 
-export const paywallAddress = compose(
-  get("paywalladdress"),
-  apiMeResponse
-);
-export const paywallTxid = compose(
-  get("paywalltxid"),
-  apiMeResponse
-);
+export const paywallAddress = compose(get("paywalladdress"), apiMeResponse);
+export const paywallTxid = compose(get("paywalltxid"), apiMeResponse);
 
 export const paywallAmount = state => {
   let paywallAmount = 0;
@@ -399,10 +350,7 @@ export const paywallTxNotBefore = state => {
   return null;
 };
 
-export const isTestNet = compose(
-  get("testnet"),
-  apiInitResponse
-);
+export const isTestNet = compose(get("testnet"), apiInitResponse);
 export const isMainNet = not(isTestNet);
 
 export const getPropVoteStatus = createDeepEqualSelector(
@@ -415,9 +363,8 @@ export const getPropVoteStatus = createDeepEqualSelector(
 );
 
 export const makeGetPropVoteStatus = token => {
-  return createSelector(
-    apiPropsVoteStatusResponse,
-    vsResponse => (vsResponse ? vsResponse[token] : null)
+  return createSelector(apiPropsVoteStatusResponse, vsResponse =>
+    vsResponse ? vsResponse[token] : null
   );
 };
 
@@ -427,9 +374,8 @@ export const apiPropsVoteSummaryError = getApiError(
 
 const apiPropsVoteSummaries = getApiResponse("proposalsVoteSummary");
 export const makeGetPropVoteSummary = token => {
-  return createSelector(
-    apiPropsVoteSummaries,
-    vsResponse => (vsResponse ? vsResponse[token] : null)
+  return createSelector(apiPropsVoteSummaries, vsResponse =>
+    vsResponse ? vsResponse[token] : null
   );
 };
 
@@ -464,19 +410,10 @@ export const lastLoadedVettedProposal = getApiLastLoaded("vetted");
 export const lastLoadedUserProposal = getApiLastLoaded("userProposals");
 export const lastLoadedUserDetailProposal = getApiLastLoaded("user");
 
-export const serverPubkey = compose(
-  get("pubkey"),
-  apiInitResponse
-);
-export const userPubkey = compose(
-  get("publickey"),
-  apiMeResponse
-);
+export const serverPubkey = compose(get("pubkey"), apiInitResponse);
+export const userPubkey = compose(get("publickey"), apiMeResponse);
 export const commentsLikes = or(
-  compose(
-    get("commentslikes"),
-    apiCommentsLikesResponse
-  ),
+  compose(get("commentslikes"), apiCommentsLikesResponse),
   constant(null)
 );
 export const policy = apiPolicyResponse;
@@ -486,10 +423,7 @@ export const isLoadingSubmit = or(
   isApiRequestingEditProposal
 );
 export const apiVettedProposals = or(
-  compose(
-    get("proposals"),
-    apiVettedResponse
-  ),
+  compose(get("proposals"), apiVettedResponse),
   constant([])
 );
 
@@ -506,10 +440,7 @@ export const vettedProposalsIsRequesting = isApiRequestingVetted;
 export const vettedProposalsError = or(apiInitError, apiVettedError);
 
 export const apiUserProposals = or(
-  compose(
-    get("proposals"),
-    apiUserProposalsResponse
-  ),
+  compose(get("proposals"), apiUserProposalsResponse),
   constant([])
 );
 
@@ -521,22 +452,11 @@ export const numOfUserProposals = compose(
 export const userProposalsIsRequesting = isApiRequestingUserProposals;
 export const userProposalsError = or(apiInitError, apiUserProposalsError);
 export const apiUnvettedProposals = or(
-  compose(
-    get("proposals"),
-    apiUnvettedResponse
-  ),
+  compose(get("proposals"), apiUnvettedResponse),
   constant([])
 );
 const filtered = status =>
-  compose(
-    filter(
-      compose(
-        eq(status),
-        get("status")
-      )
-    ),
-    apiUnvettedProposals
-  );
+  compose(filter(compose(eq(status), get("status"))), apiUnvettedProposals);
 export const unreviewedProposals = filtered(PROPOSAL_STATUS_UNREVIEWED);
 export const abandonedProposals = filtered(PROPOSAL_STATUS_ABANDONED);
 export const censoredProposals = filtered(PROPOSAL_STATUS_CENSORED);
@@ -545,49 +465,28 @@ export const unvettedProposalsIsRequesting = or(
   isApiRequestingUnvetted
 );
 export const unvettedProposalsError = or(apiInitError, apiUnvettedError);
-export const apiProposal = compose(
-  get("proposal"),
-  apiProposalResponse
-);
-export const apiInvoice = compose(
-  get("invoice"),
-  apiInvoiceResponse
-);
+export const apiProposal = compose(get("proposal"), apiProposalResponse);
+export const apiInvoice = compose(get("invoice"), apiInvoiceResponse);
 export const proposalPayload = state => state.api.proposal.payload;
 export const proposalToken = compose(
   get(["censorshiprecord", "token"]),
   apiProposal
 );
-export const proposalStatus = compose(
-  get("status"),
-  apiProposal
-);
+export const proposalStatus = compose(get("status"), apiProposal);
 
-export const proposalAuthor = compose(
-  get(["username"]),
-  apiProposal
-);
+export const proposalAuthor = compose(get(["username"]), apiProposal);
 
-export const proposalName = compose(
-  get(["name"]),
-  apiProposal
-);
+export const proposalName = compose(get(["name"]), apiProposal);
 
 export const apiProposalComments = or(
-  compose(
-    get("comments"),
-    apiProposalCommentsResponse
-  ),
+  compose(get("comments"), apiProposalCommentsResponse),
   constant([])
 );
 
 export const apiProposalsBatchError = getApiError("proposalsBatch");
 
 export const apiInvoiceComments = or(
-  compose(
-    get("comments"),
-    apiInvoiceCommentsResponse
-  ),
+  compose(get("comments"), apiInvoiceCommentsResponse),
   constant([])
 );
 export const proposalIsRequesting = or(
@@ -596,10 +495,7 @@ export const proposalIsRequesting = or(
 );
 export const invoiceIsRequesting = isApiRequestingInvoice;
 export const proposalError = or(apiInitError, apiProposalError);
-export const user = compose(
-  get("user"),
-  apiUserResponse
-);
+export const user = compose(get("user"), apiUserResponse);
 export const newUserResponse = bool(apiNewUserResponse);
 export const newProposalIsRequesting = isApiRequestingNewProposal;
 export const newInvoiceIsRequesting = isApiRequestingNewInvoice;
@@ -618,18 +514,12 @@ export const newProposalSignature = compose(
   get(["censorshiprecord", "signature"]),
   apiNewProposalResponse
 );
-export const newProposalName = compose(
-  get("name"),
-  apiNewProposalPayload
-);
+export const newProposalName = compose(get("name"), apiNewProposalPayload);
 export const newProposalDescription = compose(
   get("description"),
   apiNewProposalPayload
 );
-export const newProposalFiles = compose(
-  get("files"),
-  apiNewProposalPayload
-);
+export const newProposalFiles = compose(get("files"), apiNewProposalPayload);
 export const newInvoiceMerkle = compose(
   get(["censorshiprecord", "merkle"]),
   apiNewInvoiceResponse
@@ -642,18 +532,9 @@ export const newInvoiceSignature = compose(
   get(["censorshiprecord", "signature"]),
   apiNewInvoiceResponse
 );
-export const newInvoiceYear = compose(
-  get("year"),
-  apiNewInvoicePayload
-);
-export const newInvoiceMonth = compose(
-  get("month"),
-  apiNewInvoicePayload
-);
-export const newInvoiceFiles = compose(
-  get("files"),
-  apiNewInvoicePayload
-);
+export const newInvoiceYear = compose(get("year"), apiNewInvoicePayload);
+export const newInvoiceMonth = compose(get("month"), apiNewInvoicePayload);
+export const newInvoiceFiles = compose(get("files"), apiNewInvoicePayload);
 export const apiUserInvoices = compose(
   get("invoices"),
   apiUserInvoicesResponse
@@ -677,10 +558,7 @@ export const verificationToken = compose(
   apiNewUserResponse
 );
 export const getKeyMismatch = state => state.api.keyMismatch;
-export const manageUserAction = compose(
-  get("action"),
-  apiManageUserPayload
-);
+export const manageUserAction = compose(get("action"), apiManageUserPayload);
 export const lastLoginTimeFromLoginResponse = compose(
   get("lastlogintime"),
   apiLoginResponse
@@ -689,10 +567,7 @@ export const lastLoginTimeFromMeResponse = compose(
   get("lastlogintime"),
   apiMeResponse
 );
-export const sessionMaxAge = compose(
-  get("sessionmaxage"),
-  apiMeResponse
-);
+export const sessionMaxAge = compose(get("sessionmaxage"), apiMeResponse);
 
 export const visitedProposal = compose(
   get("accesstime"),
@@ -788,10 +663,7 @@ export const isApiRequestingComments = or(
 export const isApiRequestingCommentsLikes = getIsApiRequesting("commentslikes");
 
 // CMS Selectors
-const mode = compose(
-  get("mode"),
-  apiInitResponse
-);
+const mode = compose(get("mode"), apiInitResponse);
 
 export const isModeFetched = state => {
   if (mode(state) === undefined) {
@@ -815,10 +687,7 @@ export const isApiRequestingPayInvoices = getIsApiRequesting("payApproved");
 
 export const isApiRequestingAdminInvoices = getIsApiRequesting("adminInvoices");
 export const adminInvoicesResponse = getApiResponse("adminInvoices");
-export const apiAdminInvoices = compose(
-  get("invoices"),
-  adminInvoicesResponse
-);
+export const apiAdminInvoices = compose(get("invoices"), adminInvoicesResponse);
 export const resetPassEmail = compose(
   get("email"),
   getApiPayload("resetPassword")
@@ -845,10 +714,7 @@ export const invoicePayoutsError = getApiError("invoicePayouts");
 export const isApiRequestingInvoicePayouts = getIsApiRequesting(
   "invoicePayouts"
 );
-export const invoicePayouts = compose(
-  get("invoices"),
-  invoicePayoutsResponse
-);
+export const invoicePayouts = compose(get("invoices"), invoicePayoutsResponse);
 
 // TODO: Use createSelector instead of compose once we refactor the CMS connectors
 // b/c the createSelector doesn't work properly whe used in combination with the selectorMap
@@ -863,7 +729,7 @@ export const lineItemPayouts = compose(
           token: invoice.censorshiprecord.token,
           labor: (lineItem.labor / 60) * (invoice.input.contractorrate / 100),
           expenses: lineItem.expenses / 100,
-          description: lineItem.description.replace("#", "")
+          description: lineItem.description.replace(/#(\S*)/g, "")
         }))
       );
     }, []),
@@ -873,10 +739,7 @@ export const lineItemPayouts = compose(
 export const generatePayoutsResponse = getApiResponse("payouts");
 export const generatePayoutsError = getApiError("payouts");
 export const isApiRequestingGeneratePayouts = getIsApiRequesting("payouts");
-export const payouts = compose(
-  get("payouts"),
-  generatePayoutsResponse
-);
+export const payouts = compose(get("payouts"), generatePayoutsResponse);
 
 export const isApiRequestingSetInvoiceStatusByToken = state => token => {
   return (


### PR DESCRIPTION
Previously only the first instance of a "#" was being replaced in a string.
This regex now finds them all and replaces them with "".