### PR TITLE
set button type to button.

### DIFF
--- a/src/componentsv2/ModalOnboard/ModalOnboard.jsx
+++ b/src/componentsv2/ModalOnboard/ModalOnboard.jsx
@@ -22,10 +22,10 @@ const ModalOnboard = ({ show, onClose }) => {
         Politiea” in the sidebar.
       </P>
       <div className="justify-right margin-top-l">
-        <Button kind="secondary" onClick={onClose}>
+        <Button kind="secondary" type="button" onClick={onClose}>
           Maybe later
         </Button>
-        <Button onClick={goToDocs}>Yes, show me more</Button>
+        <Button type="button" onClick={goToDocs}>Yes, show me more</Button>
       </div>
     </Modal>
   );


### PR DESCRIPTION
The default button type is submit, but we are using onClick.  By
setting the type to button, the button does nothing if js is
disabled.

Firefox recommends explicitly setting the button type.