### PR TITLE
Check for duplicate signatures before submitting a new comment

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -847,6 +847,18 @@ export const onSubmitComment = (
     dispatch(act.REQUEST_NEW_COMMENT({ token, comment, parentid }));
     return Promise.resolve(api.makeComment(token, comment, parentid))
       .then(comment => api.signComment(loggedInAsEmail, comment))
+      .then(comment => {
+        // make sure this is not a duplicate comment by comparing to the existent
+        // comments signatures
+        const comments = sel.commentsByToken(getState())[token];
+        const signatureFound = comments.find(
+          cm => cm.signature === comment.signature
+        );
+        if (signatureFound) {
+          throw new Error("That is a duplicate comment.");
+        }
+        return comment;
+      })
       .then(comment => api.newComment(csrf, comment))
       .then(response => {
         const responsecomment = response.comment;

--- a/src/actions/tests/api.test.js
+++ b/src/actions/tests/api.test.js
@@ -40,6 +40,13 @@ describe("test api actions (actions/api.js)", () => {
     password: "foobar1234"
   };
   const MOCK_STATE = {
+    comments: {
+      comments: {
+        byToken: {
+          [FAKE_PROPOSAL_TOKEN]: []
+        }
+      }
+    },
     api: {
       me: {
         response: {


### PR DESCRIPTION
This part of the effort to avoid what is reported on https://github.com/decred/politeiagui/issues/1601.

This diff will execute a synchronous check before submitting a new comment. This check makes sure that the new comment does not have a duplicated signature.