### PR TITLE
build: readd node 13.x

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [12.x, 13.x]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
13.3 fixed a regression in 13.2 that broke jest scripts.