### PR TITLE
Handle permalink error for non-existent or duplicated comment case

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -851,9 +851,8 @@ export const onSubmitComment = (
         // make sure this is not a duplicate comment by comparing to the existent
         // comments signatures
         const comments = sel.commentsByToken(getState())[token];
-        const signatureFound = comments.find(
-          (cm) => cm.signature === comment.signature
-        );
+        const signatureFound =
+          comments && comments.find((cm) => cm.signature === comment.signature);
         if (signatureFound) {
           throw new Error("That is a duplicate comment.");
         }

--- a/src/containers/Comments/Comments.jsx
+++ b/src/containers/Comments/Comments.jsx
@@ -182,8 +182,8 @@ const Comments = ({
 
   const singleThreadCommentCannotBeAccessed =
     isSingleThread &&
-    comments &&
-    !comments.find((c) => c.commentid === threadParentID);
+    ((comments && !comments.find((c) => c.commentid === threadParentID)) ||
+      numOfComments === 0);
 
   return (
     <>

--- a/src/containers/Comments/Comments.jsx
+++ b/src/containers/Comments/Comments.jsx
@@ -83,7 +83,7 @@ const Comments = ({
   const isSingleThread = !!threadParentID;
 
   const handleSubmitComment = useCallback(
-    comment => {
+    (comment) => {
       return onSubmitComment({
         comment,
         token: recordToken,
@@ -94,7 +94,7 @@ const Comments = ({
   );
 
   const handleSetSortOption = useCallback(
-    option => {
+    (option) => {
       setSortOption(option.value);
       dispatch({
         type: actions.SORT,
@@ -165,7 +165,7 @@ const Comments = ({
   );
 
   const handleCensorComment = useCallback(
-    reason => {
+    (reason) => {
       return onCensorComment(
         userEmail,
         recordToken,
@@ -180,12 +180,16 @@ const Comments = ({
   const hasDuplicatedComments =
     !!state.comments.length && numOfDuplicatedComments > 0;
 
+  const singleThreadCommentCannotBeAccessed =
+    isSingleThread &&
+    comments &&
+    !comments.find((c) => c.commentid === threadParentID);
+
   return (
     <>
       <Card
         id="commentArea"
-        className={classNames(styles.commentAreaContainer, className)}
-      >
+        className={classNames(styles.commentAreaContainer, className)}>
         <div className={classNames("container", styles.commentsHeaderWrapper)}>
           <LoggedInContent
             fallback={
@@ -193,8 +197,7 @@ const Comments = ({
                 onLoginClick={handleOpenLoginModal}
                 onSignupClick={onRedirectToSignup}
               />
-            }
-          >
+            }>
             <Or>
               {readOnly && (
                 <Message kind="blocked" title={"Comments are not allowed"}>
@@ -226,8 +229,7 @@ const Comments = ({
                 {hasDuplicatedComments && (
                   <Text
                     color="gray"
-                    size="small"
-                  >{`(${numOfDuplicatedComments} duplicate comments omitted)`}</Text>
+                    size="small">{`(${numOfDuplicatedComments} duplicate comments omitted)`}</Text>
                 )}
               </div>
             )}
@@ -252,7 +254,7 @@ const Comments = ({
         <div className={styles.commentsWrapper}>
           {loading ? (
             commentLoaders
-          ) : (
+          ) : !singleThreadCommentCannotBeAccessed ? (
             <CommentContext.Provider
               value={{
                 onSubmitComment,
@@ -268,8 +270,7 @@ const Comments = ({
                 openCensorModal: setCommentIDCensorTarget,
                 openLoginModal: handleOpenLoginModal,
                 ...commentsCtx
-              }}
-            >
+              }}>
               <CommentsListWrapper
                 lastTimeAccessed={lastVisitTimestamp}
                 threadParentID={threadParentID}
@@ -277,6 +278,12 @@ const Comments = ({
                 comments={state.comments}
               />
             </CommentContext.Provider>
+          ) : null}
+          {singleThreadCommentCannotBeAccessed && (
+            <Message kind="error">
+              The comment you are trying to access does not exist or it is a
+              duplicated. Return to the full thread to select a valid comment.
+            </Message>
           )}
         </div>
         <ModalConfirmWithReason


### PR DESCRIPTION
This PR adds a verification for non-existent comments when accessing a comment permalink. Accessing a non-existent or duplicated comment currently breaks the GUI.

<img width="854" alt="Screenshot 2019-12-11 at 12 41 32" src="https://user-images.githubusercontent.com/14864439/70619054-8258c200-1c14-11ea-8ffb-7aaf1f1fff50.png">
