### PR TITLE
[cms] Update payout summaries for additional fields

### DIFF
--- a/src/components/InvoicePayouts/InvoicePayoutsPage.js
+++ b/src/components/InvoicePayouts/InvoicePayoutsPage.js
@@ -41,7 +41,12 @@ const InvoicePayoutsPage = ({
     "proposaltoken",
     "expenses",
     "labor",
-    "combinedtotal"
+    "combinedtotal",
+    "username",
+    "month",
+    "year",
+    "paiddate",
+    "amountreceived"
   ];
   return loggedInAsEmail ? (
     loading ? (
@@ -83,7 +88,10 @@ const InvoicePayoutsPage = ({
         </div>
 
         <div style={{ paddingLeft: "24px" }}>
-          <ExportToCsv data={csvData} fields={csvFields} filename={"payouts"}>
+          <ExportToCsv
+            data={csvData}
+            fields={csvFields}
+            filename={"payouts.csv"}>
             <button className="inverse payouts-btn-export-to-csv ">
               {"Export to CSV"}
             </button>

--- a/src/components/InvoicePayouts/InvoicePayoutsTable.js
+++ b/src/components/InvoicePayouts/InvoicePayoutsTable.js
@@ -8,10 +8,16 @@ const PayoutRow = ({
   expenses,
   labor,
   proposaltoken,
-  subdomain
+  subdomain,
+  month,
+  year,
+  paiddate,
+  amountreceived
 }) => {
   return (
     <tr>
+      <td>{month}</td>
+      <td>{year}</td>
       <td>{token}</td>
       <td>{domain}</td>
       <td>{subdomain}</td>
@@ -20,6 +26,8 @@ const PayoutRow = ({
       <td>{expenses}</td>
       <td>{labor}</td>
       <td>{expenses + labor}</td>
+      <td>{paiddate}</td>
+      <td>{amountreceived}</td>
     </tr>
   );
 };
@@ -29,6 +37,8 @@ const PayoutsTable = ({ lineItemPayouts }) => {
     <table className="payouts-table">
       <tbody>
         <tr>
+          <th>Month</th>
+          <th>Year</th>
           <th>Invoice Token</th>
           <th>Domain</th>
           <th>Sub Domain</th>
@@ -37,6 +47,8 @@ const PayoutsTable = ({ lineItemPayouts }) => {
           <th>Expenses (USD)</th>
           <th>Labor (USD)</th>
           <th>Total (USD)</th>
+          <th>Paid Date</th>
+          <th>Amount Received</th>
         </tr>
         {lineItemPayouts.map((payout, idx) => (
           <PayoutRow key={`payout-${idx}`} {...payout} />

--- a/src/selectors/api.js
+++ b/src/selectors/api.js
@@ -736,7 +736,13 @@ export const lineItemPayouts = compose(
           token: invoice.censorshiprecord.token,
           labor: (lineItem.labor / 60) * (invoice.input.contractorrate / 100),
           expenses: lineItem.expenses / 100,
-          description: lineItem.description.replace(/#/g, "")
+          description: lineItem.description.replace(/#/g, ""),
+          month: invoice.input.month,
+          year: invoice.input.year,
+          paiddate: new Date(
+            invoice.payment.timelastupdated * 1000
+          ).toLocaleString(),
+          amountreceived: invoice.payment.amountreceived / 100000000
         }))
       );
     }, []),


### PR DESCRIPTION
This adds more fields to the payout summary page and export.  Needs https://github.com/decred/politeia/pull/1090 to fully populate the fields.