### PR TITLE
[cms] Show usernames instead of count for support/oppose

### DIFF
--- a/src/components/DCC/Details/Details.jsx
+++ b/src/components/DCC/Details/Details.jsx
@@ -46,7 +46,6 @@ const DCCDetail = props => {
         confirm && onChangeDCCStatus(status, reason)
     ) && e.preventDefault();
 
-
   return (
     <div className="content" role="main">
       <div className="dcc-info">
@@ -104,8 +103,8 @@ const DCCDetail = props => {
             <p className="dcc-info">{dcc.dccpayload.statement}</p>
 
             <h2>Votes</h2>
-            <DCCInfo label="Support">{dcc.supportuserids.length}</DCCInfo>
-            <DCCInfo label="Against">{dcc.againstuserids.length}</DCCInfo>
+            <DCCInfo label="Support">{dcc.supportusernames}</DCCInfo>
+            <DCCInfo label="Against">{dcc.againstusernames}</DCCInfo>
 
             <Button
               className={`togglebutton access-required${(!userCanVote || !isActiveDCC) &&

--- a/src/components/DCC/Details/Details.jsx
+++ b/src/components/DCC/Details/Details.jsx
@@ -6,7 +6,7 @@ import dccConnector from "../../../connectors/dcc";
 import Button from "../../snew/ButtonWithLoadingIcon";
 import Message from "../../Message";
 import * as modalTypes from "../../Modal/modalTypes";
-import { dccChangeStatusList } from "../helpers";
+import { dccChangeStatusList, getVotesUsernameList } from "../helpers";
 import Comments from "../Comments";
 
 const DCCInfo = ({ label = "", children }) => (
@@ -103,8 +103,8 @@ const DCCDetail = props => {
             <p className="dcc-info">{dcc.dccpayload.statement}</p>
 
             <h2>Votes</h2>
-            <DCCInfo label="Support">{dcc.supportusernames}</DCCInfo>
-            <DCCInfo label="Against">{dcc.againstusernames}</DCCInfo>
+            <DCCInfo label="Support">{getVotesUsernameList(dcc.supportusernames)}</DCCInfo>
+            <DCCInfo label="Against">{getVotesUsernameList(dcc.againstusernames)}</DCCInfo>
 
             <Button
               className={`togglebutton access-required${(!userCanVote || !isActiveDCC) &&

--- a/src/components/DCC/helpers.js
+++ b/src/components/DCC/helpers.js
@@ -50,3 +50,9 @@ export const getDCCStatus = (status) => {
   const { label } = dccStatusList.find((st) => st.value === status);
   return label;
 };
+
+const separateName = (length) => (name, index) =>
+  index < length - 1 ? name + ", " : name;
+
+export const getVotesUsernameList = (names) =>
+  names.map(separateName(names.length));

--- a/src/components/DCC/helpers.js
+++ b/src/components/DCC/helpers.js
@@ -52,7 +52,7 @@ export const getDCCStatus = (status) => {
 };
 
 const separateName = (length) => (name, index) =>
-  index < length - 1 ? name + ", " : name;
+  index < length - 1 ? `${name}, ` : name;
 
 export const getVotesUsernameList = (names) =>
   names.map(separateName(names.length));


### PR DESCRIPTION
Instead of showing just the counts of support/opposing users, we should show the usernames.

~This requires https://github.com/decred/politeia/pull/1102~