### PR TITLE
[cmsv2] Fix USD format

### DIFF
--- a/src/componentsv2/Invoice/Invoice.jsx
+++ b/src/componentsv2/Invoice/Invoice.jsx
@@ -17,7 +17,7 @@ import {
 } from "src/containers/Invoice/helpers";
 import Field from "./Field";
 import InvoiceDatasheet from "../InvoiceDatasheet";
-import { convertAtomsToDcr } from "src/utilsv2";
+import { convertAtomsToDcr, usdFormatter } from "src/utilsv2";
 import ThumbnailGrid from "src/componentsv2/Files";
 import { useLoaderContext } from "src/containers/Loader";
 
@@ -136,14 +136,20 @@ const Invoice = ({ invoice, extended }) => {
                   <Field label="Total hours:" value={`${totalHours}h`} />
                   <Field
                     label="Contractor Rate:"
-                    value={`$${invContractorRate / 100}`}
+                    value={usdFormatter.format(invContractorRate / 100)}
                   />
-                  <Field label="Total expenses:" value={`$${totalExpenses}`} />
+                  <Field
+                    label="Total expenses:"
+                    value={usdFormatter.format(totalExpenses)}
+                  />
                   <Field
                     label="Exchange rate:"
-                    value={`$${exchangeRate / 100}`}
+                    value={usdFormatter.format(exchangeRate / 100)}
                   />
-                  <Field label="Amount:" value={`$${totalAmount}`} />
+                  <Field
+                    label="Amount:"
+                    value={usdFormatter.format(totalAmount)}
+                  />
                   <Field label="Amount (dcr):" value={totalDcrAmount} />
                 </Row>
                 {extended && !!invoiceAttachments.length && (

--- a/src/componentsv2/InvoiceForm/ExchangeRateField.jsx
+++ b/src/componentsv2/InvoiceForm/ExchangeRateField.jsx
@@ -1,12 +1,14 @@
 import React, { useCallback, useEffect } from "react";
 import { Text, Spinner } from "pi-ui";
 import { FormikConsumer } from "formik";
+import { usdFormatter } from "src/utilsv2";
+
 import useExchangeRate from "src/hooks/api/useExchangeRate";
 
 export const ExchangeRateField = ({ month, year, onChange, name }) => {
   const [rate, loading] = useExchangeRate(month, year);
   const handleChange = useCallback(
-    rate => {
+    (rate) => {
       onChange(name, rate);
     },
     [onChange, name]
@@ -17,7 +19,11 @@ export const ExchangeRateField = ({ month, year, onChange, name }) => {
   return (
     <div style={{ display: "grid" }}>
       <Text color="gray">Exchange rate</Text>
-      {loading ? <Spinner invert /> : <Text>${rate / 100}</Text>}
+      {loading ? (
+        <Spinner invert />
+      ) : (
+        <Text>{usdFormatter.format(rate / 100)}</Text>
+      )}
     </div>
   );
 };

--- a/src/utilsv2.js
+++ b/src/utilsv2.js
@@ -43,3 +43,16 @@ export const formatShortUnixTimestamp = (unixtimestamp) => {
     months[currentdate.getUTCMonth()]
   } ${currentdate.getUTCFullYear()}`;
 };
+
+/**
+ * Returns a formatter to format a number to US standard currency string. Example: const f = currencyFormatter("USD"); f.format(2500) // $2,500.00
+ * @param {string} currency
+ */
+export const currencyFormatter = (currency) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: currency
+  });
+
+/** exports an usdFormatter */
+export const usdFormatter = currencyFormatter("USD");


### PR DESCRIPTION
This PR creates a `currencyFormatter` utility that uses `Intl.NumberFormat` to improve currency format.

Fixes #1715  