### PR TITLE
Pass policy to helper function fix

### DIFF
--- a/src/componentsv2/InvoiceForm/InvoiceForm.jsx
+++ b/src/componentsv2/InvoiceForm/InvoiceForm.jsx
@@ -183,7 +183,7 @@ const InvoiceFormWrapper = ({ initialValues, onSubmit, history, approvedProposal
     address: "",
     exchangerate: "",
     date: getInitialDateValue(),
-    lineitems: [generateBlankLineItem()],
+    lineitems: [generateBlankLineItem(policy)],
     files: []
   };
   let formInitialValues = initialValues || FORM_INITIAL_VALUES;


### PR DESCRIPTION
This fixes an error introduced on PR #1734 . `generateBlankLineItem` needs the policy as a parameter now.