### PR TITLE
Proposal: refactor useAPIAction hook

### DIFF
--- a/src/containers/User/Detail/hooks/useUserDetail.js
+++ b/src/containers/User/Detail/hooks/useUserDetail.js
@@ -13,7 +13,7 @@ export default function useUserDetail(userID) {
   const onFetchUser = useAction(act.onFetchUser);
   const userMissingData = !user || (user && !user.identities);
   const needsFetch = !!userID && userMissingData;
-  const args = useMemo(() => [userID], [userID]);
+  const args = [userID];
   const [loading, error] = useAPIAction(onFetchUser, args, needsFetch);
 
   useThrowError(error);

--- a/src/hooks/utils/useAPIAction.js
+++ b/src/hooks/utils/useAPIAction.js
@@ -1,8 +1,8 @@
-import { useEffect, useState } from "react";
+import { useRef, useEffect, useState } from "react";
 
 const DEFAULT_ARGS = [];
 
-function useAPIAction(action, args = DEFAULT_ARGS, enabled = true) {
+function useApplyAction(action, args = DEFAULT_ARGS, enabled = true) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
   const [fired, setFired] = useState(false);
@@ -23,6 +23,33 @@ function useAPIAction(action, args = DEFAULT_ARGS, enabled = true) {
     }
   }, [action, args, enabled]);
   return [loading, error, fired];
+}
+
+function areArgsEqual(newArgs, oldArgs) {
+  if (newArgs.length !== oldArgs.length) {
+    return false;
+  }
+  const shallowEqual = (a, b) => a === b;
+  return newArgs.every((newArg, index) => shallowEqual(newArg, oldArgs[index]));
+}
+
+/**
+ * useAPIAction hook memoizes the args array and applies the action if enabled. args should be an array of primitives.
+ * @param {function} action
+ * @param {array} args
+ * @param {boolean} enabled
+ */
+function useAPIAction(action, args = DEFAULT_ARGS, enabled = true) {
+  const actionArgs = useRef(args);
+  const areArgsMatched =
+    args && actionArgs.current && areArgsEqual(args, actionArgs.current);
+  const cached = areArgsMatched ? actionArgs.current : args;
+
+  useEffect(() => {
+    actionArgs.current = cached;
+  }, [cached]);
+
+  return useApplyAction(action, cached, enabled);
 }
 
 export default useAPIAction;

--- a/src/hooks/utils/useAPIAction.js
+++ b/src/hooks/utils/useAPIAction.js
@@ -43,13 +43,13 @@ function useAPIAction(action, args = DEFAULT_ARGS, enabled = true) {
   const actionArgs = useRef(args);
   const areArgsMatched =
     args && actionArgs.current && areArgsEqual(args, actionArgs.current);
-  const cached = areArgsMatched ? actionArgs.current : args;
+  const cachedArgs = areArgsMatched ? actionArgs.current : args;
 
   useEffect(() => {
-    actionArgs.current = cached;
-  }, [cached]);
+    actionArgs.current = cachedArgs;
+  }, [cachedArgs]);
 
-  return useApplyAction(action, cached, enabled);
+  return useApplyAction(action, cachedArgs, enabled);
 }
 
 export default useAPIAction;


### PR DESCRIPTION
This PR is my proposal to improve the useAPIAction hook as discussed in https://github.com/decred/politeiagui/issues/1764.

* Remove semantic usage of useMemo
* Uses useRef to create a cache
* Endorse hook users to pass an array of primitives to the args argument of useAPIAction

Closes https://github.com/decred/politeiagui/issues/1764