### PR TITLE
[cms-v2] Dcc approval/rejection timestamps

### DIFF
--- a/src/componentsv2/DCC/DCC.jsx
+++ b/src/componentsv2/DCC/DCC.jsx
@@ -14,18 +14,20 @@ import {
   presentationalDccDomain,
   presentationalStatement,
   isRevocationDcc,
-  isDccActive
+  isDccActive,
+  isDccApproved
 } from "src/containers/DCC/helpers";
 
 const Dcc = ({ dcc, extended }) => {
   const {
     censorshiprecord,
     dccpayload,
-    timestamp,
+    timesubmitted,
     sponsoruserid,
     nomineeusername,
     sponsorusername,
-    statuschangereason
+    statuschangereason,
+    timereviewed
   } = dcc;
 
   const dccToken = censorshiprecord && censorshiprecord.token;
@@ -71,7 +73,8 @@ const Dcc = ({ dcc, extended }) => {
                       {presentationalDccDomain(dccDomain)}
                     </Text>
                   }
-                  <Event event="submitted" timestamp={timestamp} />
+                  <Event event="submitted" timestamp={timesubmitted} />
+                  {timereviewed && <Event event={isDccApproved(dcc) ? "approved" : "rejected"} timestamp={timereviewed} />}
                 </Subtitle>
               }
               status={

--- a/src/containers/Comments/Comments.jsx
+++ b/src/containers/Comments/Comments.jsx
@@ -34,7 +34,6 @@ import { commentsReducer, initialState, actions } from "./commentsReducer";
 import { getQueryStringValue } from "src/lib/queryString";
 
 const Comments = ({
-  useNumOfCommentsFromParent,
   numOfComments,
   recordToken,
   recordAuthorID,
@@ -53,9 +52,6 @@ const Comments = ({
     commentSortOptions.SORT_BY_TOP
   );
 
-  const shouldFetchComments = useNumOfCommentsFromParent
-    ? numOfComments > 0
-    : true;
   const {
     onSubmitComment,
     onLikeComment,
@@ -67,11 +63,9 @@ const Comments = ({
     currentUser,
     userEmail,
     ...commentsCtx
-  } = useComments(recordToken, shouldFetchComments);
+  } = useComments(recordToken);
 
-  const commentsCount = useNumOfCommentsFromParent
-    ? numOfComments
-    : comments
+  const commentsCount = comments
     ? comments.length
     : 0;
 

--- a/src/containers/Comments/hooks.js
+++ b/src/containers/Comments/hooks.js
@@ -14,7 +14,7 @@ import { useLoaderContext } from "src/containers/Loader";
 export const CommentContext = createContext();
 export const useComment = () => useContext(CommentContext);
 
-export function useComments(recordToken, fetchComments = false) {
+export function useComments(recordToken) {
   const { enableCommentVote, recordType, constants } = useConfig();
   const commentsSelector = useMemo(
     () => sel.makeGetProposalComments(recordToken),
@@ -51,13 +51,9 @@ export function useComments(recordToken, fetchComments = false) {
 
   const userLoggedIn = !!email;
 
-  const needsToFetchComments = !!recordToken && !comments && fetchComments;
+  const needsToFetchComments = !!recordToken && !comments;
   const needsToFetchCommentsLikes =
-    !!recordToken &&
-    !commentsLikes &&
-    fetchComments &&
-    enableCommentVote &&
-    userLoggedIn;
+    !!recordToken && !commentsLikes && enableCommentVote && userLoggedIn;
 
   useEffect(
     function handleFetchOfComments() {

--- a/src/containers/DCC/Detail/Detail.jsx
+++ b/src/containers/DCC/Detail/Detail.jsx
@@ -24,7 +24,6 @@ const DccDetail = ({ Main, match }) => {
         <Comments
           recordAuthorID={dcc && dcc.sponsoruserid}
           recordToken={dccToken}
-          numOfComments={1}
           threadParentID={threadParentCommentID}
           readOnly={dcc && !isDccActive(dcc)}
           readOnlyReason={

--- a/src/containers/DCC/helpers.js
+++ b/src/containers/DCC/helpers.js
@@ -99,6 +99,12 @@ export const isRevocationDcc = (dcc) =>
 export const isDccActive = (dcc) => dcc && dcc.status === DCC_STATUS_ACTIVE;
 
 /**
+ * Returns if dcc's status is approved
+ * @param {Object} dcc
+ */
+export const isDccApproved = (dcc) => dcc && dcc.status === DCC_STATUS_APPROVED;
+
+/**
  * Returns domain options for selectors
  */
 export const getDomainOptions = () =>

--- a/src/containers/Invoice/Detail/Detail.jsx
+++ b/src/containers/Invoice/Detail/Detail.jsx
@@ -25,7 +25,6 @@ const InvoiceDetail = ({ Main, match }) => {
           <Comments
             recordAuthorID={invoice && invoice.userid}
             recordToken={invoiceToken}
-            numOfComments={1}
             threadParentID={threadParentCommentID}
             readOnly={invoice && !isUnreviewedInvoice(invoice)}
             readOnlyReason={

--- a/src/pages/RoutesCMS.jsx
+++ b/src/pages/RoutesCMS.jsx
@@ -75,6 +75,12 @@ const Routes = ({ location }) => {
             component={PageInvoiceDetail}
           />
           <AuthenticatedRoute
+            path="/invoices/:token/comments/:commentid"
+            title="Invoice Detail"
+            exact
+            component={PageInvoiceDetail}
+          />
+          <AuthenticatedRoute
             path="/invoices/:token/edit"
             title="Edit Invoice"
             exact
@@ -113,6 +119,12 @@ const Routes = ({ location }) => {
           />
           <AuthenticatedRoute
             path="/dccs/:token"
+            title="DCC Detail"
+            exact
+            component={withDcc(PageDccDetail)}
+          />
+          <AuthenticatedRoute
+            path="/dccs/:token/comments/:commentid"
             title="DCC Detail"
             exact
             component={withDcc(PageDccDetail)}


### PR DESCRIPTION
 - closes #1753
-  cleanup unused `useNumOfCommentsFromParent` prop in `containers/Comments/Comments.jsx` 