### PR TITLE
Use international date format 

### DIFF
--- a/src/componentsv2/DateTooltip/DateTooltip.jsx
+++ b/src/componentsv2/DateTooltip/DateTooltip.jsx
@@ -3,12 +3,12 @@ import PropTypes from "prop-types";
 import distance from "date-fns/distance_in_words";
 import { Tooltip, classNames, useTheme } from "pi-ui";
 import styles from "./DateTooltip.module.css";
+import { formatUnixTimestamp } from "src/utilsv2";
 
 const getTimeAgo = timestamp =>
   distance(new Date(), new Date(timestamp * 1000), { addSuffix: true });
 
 const DateTooltip = ({ timestamp, placement, className, children }) => {
-  const date = new Date(timestamp * 1000);
   const timeAgo = useMemo(() => getTimeAgo(timestamp), [timestamp]);
 
   const { themeName } = useTheme();
@@ -17,7 +17,7 @@ const DateTooltip = ({ timestamp, placement, className, children }) => {
   return (
     <Tooltip
       className={classNames(className, styles.dateTooltip, isDarkTheme && styles.darkDateTooltip)}
-      content={date.toLocaleString()}
+      content={formatUnixTimestamp(timestamp)}
       placement={placement}
     >
       {children({ timeAgo })}


### PR DESCRIPTION
As agreed in https://github.com/decred/politeiagui/issues/834, the below date format is the preferable one:

![image](https://user-images.githubusercontent.com/10324528/75099169-d42baa00-55be-11ea-89dc-f64e8b0b4498.png)


closes #1741 