### PR TITLE
Add loading indicator for like comment action

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -786,11 +786,13 @@ export const onLikeComment = (loggedInAsEmail, token, commentid, action) =>
       return;
     }
     dispatch(act.REQUEST_LIKE_COMMENT({ commentid, token }));
-    dispatch(act.RECEIVE_SYNC_LIKE_COMMENT({ token, commentid, action }));
     return Promise.resolve(api.makeLikeComment(token, action, commentid))
       .then((comment) => api.signLikeComment(loggedInAsEmail, comment))
       .then((comment) => api.likeComment(csrf, comment))
-      .then(() => dispatch(act.RECEIVE_LIKE_COMMENT({ token })))
+      .then(() => {
+        dispatch(act.RECEIVE_LIKE_COMMENT({ token }));
+        dispatch(act.RECEIVE_SYNC_LIKE_COMMENT({ token, commentid, action }));
+      })
       .catch((error) => {
         dispatch(act.RESET_SYNC_LIKE_COMMENT({ token }));
         dispatch(act.RECEIVE_LIKE_COMMENT(null, error));

--- a/src/actions/tests/api.test.js
+++ b/src/actions/tests/api.test.js
@@ -662,7 +662,8 @@ describe("test api actions (actions/api.js)", () => {
     await store.dispatch(api.onLikeComment.apply(null, params));
     const dispatchedActions = store.getActions();
     expect(dispatchedActions[0].type).toEqual(act.REQUEST_LIKE_COMMENT);
-    expect(dispatchedActions[1].type).toEqual(act.RECEIVE_SYNC_LIKE_COMMENT);
+    expect(dispatchedActions[1].type).toEqual(act.RECEIVE_LIKE_COMMENT);
+    expect(dispatchedActions[2].type).toEqual(act.RECEIVE_SYNC_LIKE_COMMENT);
 
     const keys = await pki.generateKeys(FAKE_USER.email);
     await pki.loadKeys(FAKE_USER.email, keys);
@@ -676,11 +677,6 @@ describe("test api actions (actions/api.js)", () => {
           type: act.REQUEST_LIKE_COMMENT,
           error: false,
           payload: { commentid, token: FAKE_PROPOSAL_TOKEN }
-        },
-        {
-          type: act.RECEIVE_SYNC_LIKE_COMMENT,
-          error: false,
-          payload: { commentid, token: FAKE_PROPOSAL_TOKEN, action: up_action }
         },
         {
           type: act.RESET_SYNC_LIKE_COMMENT,

--- a/src/componentsv2/Likes/Likes.jsx
+++ b/src/componentsv2/Likes/Likes.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useCallback } from "react";
 import PropTypes from "prop-types";
 import {
   Icon,
@@ -6,6 +6,7 @@ import {
   Text,
   getThemeProperty,
   useHover,
+  Spinner,
   classNames
 } from "pi-ui";
 import styles from "./Likes.module.css";
@@ -13,8 +14,7 @@ import styles from "./Likes.module.css";
 export const isLiked = (action) => action === 1 || action === "1";
 export const isDisliked = (action) => action === -1 || action === "-1";
 
-const Likes = ({ upLikes, downLikes, onLike, onDislike, option, disabled }) => {
-  const [loading, setLoading] = useState(false);
+const Likes = ({ upLikes, downLikes, onLike, onDislike, option, disabled, loading }) => {
   const [likeRef, isLikeHovered] = useHover();
   const [dislikeRef, isDislikeHovered] = useHover();
   const { theme } = useTheme();
@@ -29,29 +29,17 @@ const Likes = ({ upLikes, downLikes, onLike, onDislike, option, disabled }) => {
   const handleLike = useCallback(
     async function handleLike() {
       if (disabled || loading) return;
-      try {
-        setLoading(true);
-        await onLike();
-        setLoading(false);
-      } catch (e) {
-        setLoading(false);
-      }
+      await onLike();
     },
-    [disabled, loading, setLoading, onLike]
+    [disabled, loading, onLike]
   );
 
   const handleDislike = useCallback(
     async function handleDislike() {
       if (disabled || loading) return;
-      try {
-        setLoading(true);
-        await onDislike();
-        setLoading(false);
-      } catch (e) {
-        setLoading(false);
-      }
+      await onDislike();
     },
-    [disabled, loading, setLoading, onDislike]
+    [disabled, loading, onDislike]
   );
 
   const renderCount = useCallback(
@@ -67,30 +55,42 @@ const Likes = ({ upLikes, downLikes, onLike, onDislike, option, disabled }) => {
 
   return (
     <div className="align-center">
-      <div className={styles.leftLikeBox}>
-        <button
-          disabled={loading || disabled}
-          ref={likeRef}
-          className={styles.likeBtn}
-          onClick={handleLike}>
-          <Icon iconColor={likeColor} backgroundColor={likeColor} type="like" />
-        </button>
-        {renderCount(upLikes)}
-      </div>
-      <div className={styles.rightLikeBox}>
-        <button
-          disabled={loading || disabled}
-          ref={dislikeRef}
-          className={styles.likeBtn}
-          onClick={handleDislike}>
-          <Icon
-            iconColor={dislikeColor}
-            backgroundColor={dislikeColor}
-            type="dislike"
-          />
-        </button>
-        {renderCount(downLikes)}
-      </div>
+      {!loading ? (
+      <>
+        <div className={styles.leftLikeBox}>
+          <button
+            disabled={loading || disabled}
+            ref={likeRef}
+            className={styles.likeBtn}
+            onClick={handleLike}>
+            <Icon
+              iconColor={likeColor}
+              backgroundColor={likeColor}
+              type="like"
+            />
+          </button>
+          {renderCount(upLikes)}
+        </div>
+        <div className={styles.rightLikeBox}>
+          <button
+            disabled={loading || disabled}
+            ref={dislikeRef}
+            className={styles.likeBtn}
+            onClick={handleDislike}>
+            <Icon
+              iconColor={dislikeColor}
+              backgroundColor={dislikeColor}
+              type="dislike"
+            />
+          </button>
+          {renderCount(downLikes)}
+        </div>
+      </>
+      ) : (
+        <div className={styles.likeBoxSpinner}>
+          <Spinner invert />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/componentsv2/Likes/Likes.jsx
+++ b/src/componentsv2/Likes/Likes.jsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState, useEffect } from "react";
 import PropTypes from "prop-types";
+import { delay } from "lodash";
 import {
   Icon,
   useTheme,
@@ -29,10 +30,10 @@ const Likes = ({ upLikes, downLikes, onLike, onDislike, option, disabled, apiLoa
 
   useEffect(() => {
     if (apiLoading) {
-      setTimeout(() => setLoading(true), 1000);
+      delay(() => setLoading(true), 1000);
     } else if (loading) {
-        setLoading(false);
-      }
+      setLoading(false);
+    }
   },
     [apiLoading, loading, setLoading]
   );

--- a/src/componentsv2/Likes/Likes.jsx
+++ b/src/componentsv2/Likes/Likes.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import {
   Icon,
@@ -14,7 +14,8 @@ import styles from "./Likes.module.css";
 export const isLiked = (action) => action === 1 || action === "1";
 export const isDisliked = (action) => action === -1 || action === "-1";
 
-const Likes = ({ upLikes, downLikes, onLike, onDislike, option, disabled, loading }) => {
+const Likes = ({ upLikes, downLikes, onLike, onDislike, option, disabled, apiLoading }) => {
+  const [loading, setLoading] = useState(false);
   const [likeRef, isLikeHovered] = useHover();
   const [dislikeRef, isDislikeHovered] = useHover();
   const { theme } = useTheme();
@@ -26,20 +27,30 @@ const Likes = ({ upLikes, downLikes, onLike, onDislike, option, disabled, loadin
   const dislikeColor =
     disliked || isDislikeHovered ? activeColor : defaultColor;
 
+  useEffect(() => {
+    if (apiLoading) {
+      setTimeout(() => setLoading(true), 1000);
+    } else if (loading) {
+        setLoading(false);
+      }
+  },
+    [apiLoading, loading, setLoading]
+  );
+
   const handleLike = useCallback(
     async function handleLike() {
-      if (disabled || loading) return;
+      if (disabled) return;
       await onLike();
     },
-    [disabled, loading, onLike]
+    [disabled, onLike]
   );
 
   const handleDislike = useCallback(
     async function handleDislike() {
-      if (disabled || loading) return;
+      if (disabled) return;
       await onDislike();
     },
-    [disabled, loading, onDislike]
+    [disabled, onDislike]
   );
 
   const renderCount = useCallback(
@@ -55,11 +66,15 @@ const Likes = ({ upLikes, downLikes, onLike, onDislike, option, disabled, loadin
 
   return (
     <div className="align-center">
-      {!loading ? (
+      {loading && apiLoading ?  (
+        <div className={styles.likeBoxSpinner}>
+          <Spinner invert />
+        </div>
+      ) : (
       <>
         <div className={styles.leftLikeBox}>
           <button
-            disabled={loading || disabled}
+            disabled={disabled}
             ref={likeRef}
             className={styles.likeBtn}
             onClick={handleLike}>
@@ -73,7 +88,7 @@ const Likes = ({ upLikes, downLikes, onLike, onDislike, option, disabled, loadin
         </div>
         <div className={styles.rightLikeBox}>
           <button
-            disabled={loading || disabled}
+            disabled={disabled}
             ref={dislikeRef}
             className={styles.likeBtn}
             onClick={handleDislike}>
@@ -86,10 +101,6 @@ const Likes = ({ upLikes, downLikes, onLike, onDislike, option, disabled, loadin
           {renderCount(downLikes)}
         </div>
       </>
-      ) : (
-        <div className={styles.likeBoxSpinner}>
-          <Spinner invert />
-        </div>
       )}
     </div>
   );

--- a/src/componentsv2/Likes/Likes.module.css
+++ b/src/componentsv2/Likes/Likes.module.css
@@ -14,6 +14,10 @@
   padding-left: 1rem;
 }
 
+.likeBoxSpinner {
+  padding-right: 2.5rem;
+}
+
 .likeBtn {
   cursor: pointer;
   border: none;

--- a/src/containers/Comments/Comment/Comment.jsx
+++ b/src/containers/Comments/Comment/Comment.jsx
@@ -88,7 +88,7 @@ const Comment = ({
           <div className={styles.likesWrapper}>
             <Likes
               disabled={disableLikesClick}
-              loading={loadingLikeAction}
+              apiLoading={!!loadingLikeAction}
               upLikes={likesUpCount}
               downLikes={likesDownCount}
               option={likeOption}

--- a/src/containers/Comments/Comment/Comment.jsx
+++ b/src/containers/Comments/Comment/Comment.jsx
@@ -37,6 +37,7 @@ const Comment = ({
   censorable,
   isFlatMode,
   seeInContextLink,
+  loadingLikeAction,
   ...props
 }) => {
   const extraSmall = useMediaQuery("(max-width: 560px)");
@@ -87,6 +88,7 @@ const Comment = ({
           <div className={styles.likesWrapper}>
             <Likes
               disabled={disableLikesClick}
+              loading={loadingLikeAction}
               upLikes={likesUpCount}
               downLikes={likesDownCount}
               option={likeOption}

--- a/src/containers/Comments/Comment/CommentWrapper.jsx
+++ b/src/containers/Comments/Comment/CommentWrapper.jsx
@@ -58,6 +58,7 @@ const CommentWrapper = ({ comment, children, numOfReplies, isFlatMode, ...props 
     enableCommentVote,
     recordAuthorID,
     loadingLikes,
+    loadingLikeAction,
     userLoggedIn,
     recordToken,
     recordType,
@@ -165,9 +166,11 @@ const CommentWrapper = ({ comment, children, numOfReplies, isFlatMode, ...props 
         disableLikes={!enableCommentVote}
         disableLikesClick={
           loadingLikes ||
+          !!loadingLikeAction ||
           readOnly ||
           (userLoggedIn && (identityError || paywallMissing))
         }
+        loadingLikeAction={loadingLikeAction[commentid]}
         disableReply={readOnly || !!identityError || paywallMissing}
         likesUpCount={upvotes}
         likesDownCount={downvotes}

--- a/src/containers/Comments/Comment/CommentWrapper.jsx
+++ b/src/containers/Comments/Comment/CommentWrapper.jsx
@@ -170,13 +170,13 @@ const CommentWrapper = ({ comment, children, numOfReplies, isFlatMode, ...props 
           readOnly ||
           (userLoggedIn && (identityError || paywallMissing))
         }
-        loadingLikeAction={loadingLikeAction[commentid]}
         disableReply={readOnly || !!identityError || paywallMissing}
         likesUpCount={upvotes}
         likesDownCount={downvotes}
         likeOption={getCommentLikeOption(commentid)}
         onLike={handleLikeComment}
         onDislike={handleDislikeComment}
+        loadingLikeAction={loadingLikeAction[commentid]}
         showReplies={showReplies}
         isFlatMode={isFlatMode}
         onClickCensor={handleClickCensor}

--- a/src/containers/Comments/hooks.js
+++ b/src/containers/Comments/hooks.js
@@ -30,6 +30,7 @@ export function useComments(ownProps) {
   const lastVisitTimestamp = useSelector(sel.visitedProposal);
   const loading = useSelector(sel.isApiRequestingComments);
   const loadingLikes = useSelector(sel.isApiRequestingCommentsLikes);
+  const loadingLikeAction = useSelector(sel.isApiRequestingLikeComment);
   const onSubmitComment = useAction(act.onSaveNewCommentV2);
   const onFetchComments = useAction(act.onFetchProposalComments);
   const onFetchLikes = useAction(act.onFetchLikedComments);
@@ -103,6 +104,7 @@ export function useComments(ownProps) {
     lastVisitTimestamp,
     loading,
     loadingLikes,
+    loadingLikeAction,
     onSubmitComment,
     onResetComments
   };

--- a/src/reducers/api/api.js
+++ b/src/reducers/api/api.js
@@ -25,7 +25,8 @@ import {
   onReceiveSyncLikeComment,
   onReceiveUser,
   onReceiveVoteStatusChange,
-  onResetSyncLikeComment
+  onResetSyncLikeComment,
+  onRequestLikeComment
 } from "./handlers";
 import {
   onReceiveCensorInvoiceComment,
@@ -163,7 +164,7 @@ const api = (state = DEFAULT_STATE, action) =>
         request("proposalComments", state, action),
       [act.RECEIVE_PROPOSAL_COMMENTS]: () =>
         receive("proposalComments", state, action),
-      [act.REQUEST_LIKE_COMMENT]: () => request("likeComment", state, action),
+      [act.REQUEST_LIKE_COMMENT]: () => onRequestLikeComment(state, action),
       [act.RECEIVE_LIKE_COMMENT]: () => receive("likeComment", state, action),
       [act.REQUEST_CENSOR_COMMENT]: () =>
         request("censorComment", state, action),

--- a/src/reducers/api/handlers.js
+++ b/src/reducers/api/handlers.js
@@ -19,7 +19,7 @@ import {
   PROPOSAL_VOTING_AUTHORIZED,
   PROPOSAL_VOTING_NOT_AUTHORIZED
 } from "../../constants";
-import { receive } from "../util";
+import { request, receive } from "../util";
 
 const getProposalToken = (prop) => get(["censorshiprecord", "token"], prop);
 
@@ -584,6 +584,20 @@ export const onReceiveProposalVoteStatus = (state, action) => {
       response: {
         ...proposalsVoteStatus,
         [action.payload.token]: { ...action.payload }
+      }
+    }
+  };
+};
+
+export const onRequestLikeComment = (state, action) => {
+  state = request("likeComment", state, action);
+  const id = action.payload.commentid;
+  return {
+    ...state,
+    likeComment: {
+      ...state.likeComment,
+      isRequesting: {
+        [id]: true
       }
     }
   };

--- a/src/reducers/tests/api.test.js
+++ b/src/reducers/tests/api.test.js
@@ -773,7 +773,6 @@ describe("test api reducer", () => {
         key: "invoice",
         type: "request"
       },
-      { action: act.REQUEST_LIKE_COMMENT, key: "likeComment", type: "request" },
       { action: act.RECEIVE_LIKE_COMMENT, key: "likeComment", type: "receive" },
       {
         action: act.REQUEST_LIKED_COMMENTS,

--- a/src/selectors/api.js
+++ b/src/selectors/api.js
@@ -136,6 +136,11 @@ export const manageUserResponse = getApiResponse("manageUser");
 export const apiLikeCommentResponse = getApiResponse("likeComment");
 export const apiLikeCommentError = getApiError("likeComment");
 export const apiLikeCommentPayload = getApiPayload("likeComment");
+export const isApiRequestingLikeComment = get([
+  "api",
+  "likeComment",
+  "isRequesting"
+]);
 
 export const apiPropsVoteStatusResponse = getApiResponse("proposalsVoteStatus");
 export const apiPropsVoteStatusError = getApiError("proposalsVoteStatus");


### PR DESCRIPTION
This PR adds a visual indicator that the like comment request is still in progress, so that the user is sure his vote was casted properly.

closes #1792
