### PR TITLE
Cache normalized state for paywall data

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -70,14 +70,18 @@ export const setPollingPointer = (paymentpolling) => {
 };
 
 const POLL_INTERVAL = 10 * 1000;
-export const onPollUserPayment = () => (dispatch) => {
+export const onPollUserPayment = () => (dispatch, getState) => {
+  const userid = sel.currentUserID(getState());
   return api
     .verifyUserPayment()
     .then((response) => response.haspaid)
     .then((verified) => {
       if (verified) {
         dispatch(
-          act.UPDATE_USER_PAYWALL_STATUS({ status: PAYWALL_STATUS_PAID })
+          act.UPDATE_USER_PAYWALL_STATUS({
+            status: PAYWALL_STATUS_PAID,
+            userid
+          })
         );
       } else {
         const paymentpolling = setTimeout(
@@ -984,12 +988,13 @@ export const onStartVote = (
       });
   });
 
-export const onFetchProposalPaywallDetails = () => (dispatch) => {
+export const onFetchProposalPaywallDetails = () => (dispatch, getState) => {
   dispatch(act.REQUEST_PROPOSAL_PAYWALL_DETAILS());
+  const userid = sel.currentUserID(getState());
   return api
     .proposalPaywallDetails()
     .then((response) =>
-      dispatch(act.RECEIVE_PROPOSAL_PAYWALL_DETAILS(response))
+      dispatch(act.RECEIVE_PROPOSAL_PAYWALL_DETAILS({ ...response, userid }))
     )
     .catch((error) => {
       dispatch(act.RECEIVE_PROPOSAL_PAYWALL_DETAILS(null, error));
@@ -1093,12 +1098,13 @@ export const onRevokeVote = (email, token, version) =>
       });
   });
 
-export const onFetchProposalPaywallPayment = () => (dispatch) => {
+export const onFetchProposalPaywallPayment = () => (dispatch, getState) => {
+  const userid = sel.currentUserID(getState());
   dispatch(act.REQUEST_PROPOSAL_PAYWALL_PAYMENT());
   return api
     .proposalPaywallPayment()
     .then((response) =>
-      dispatch(act.RECEIVE_PROPOSAL_PAYWALL_PAYMENT(response))
+      dispatch(act.RECEIVE_PROPOSAL_PAYWALL_PAYMENT({ ...response, userid }))
     )
     .catch((error) => {
       dispatch(act.RECEIVE_PROPOSAL_PAYWALL_PAYMENT(null, error));
@@ -1124,6 +1130,7 @@ export const onPollProposalPaywallPayment = (isLimited) => (
   dispatch,
   getState
 ) => {
+  const userid = sel.currentUserID(getState());
   const proposalPaymentReceived = sel.proposalPaymentReceived(getState());
   if (proposalPaymentReceived) {
     clearProposalPaymentPollingPointer();
@@ -1150,7 +1157,7 @@ export const onPollProposalPaywallPayment = (isLimited) => (
       return response;
     })
     .then((response) =>
-      dispatch(act.RECEIVE_PROPOSAL_PAYWALL_PAYMENT(response))
+      dispatch(act.RECEIVE_PROPOSAL_PAYWALL_PAYMENT({ ...response, userid }))
     )
     .catch((error) => {
       dispatch(act.RECEIVE_PROPOSAL_PAYWALL_PAYMENT(null, error));

--- a/src/actions/external_api.js
+++ b/src/actions/external_api.js
@@ -1,7 +1,7 @@
 import * as external_api from "../lib/external_api";
 import act from "./methods";
 
-export const payWithFaucet = (address, amount) => (dispatch) => {
+export const payWithFaucet = (address, amount, userid) => (dispatch) => {
   dispatch(act.REQUEST_PAYWALL_PAYMENT_WITH_FAUCET());
   return external_api
     .payWithFaucet(address, amount)
@@ -11,7 +11,9 @@ export const payWithFaucet = (address, amount) => (dispatch) => {
           act.RECEIVE_PAYWALL_PAYMENT_WITH_FAUCET(null, new Error(json.Error))
         );
       }
-      return dispatch(act.RECEIVE_PAYWALL_PAYMENT_WITH_FAUCET(json));
+      return dispatch(
+        act.RECEIVE_PAYWALL_PAYMENT_WITH_FAUCET({ ...json, userid })
+      );
     })
     .catch((error) => {
       dispatch(act.RECEIVE_PAYWALL_PAYMENT_WITH_FAUCET(null, error));

--- a/src/components/ModalBuyProposalCredits/ModalBuyProposalCredits.jsx
+++ b/src/components/ModalBuyProposalCredits/ModalBuyProposalCredits.jsx
@@ -1,3 +1,4 @@
+
 import {
   Button,
   classNames,
@@ -35,8 +36,15 @@ const ModalBuyProposalCredits = ({
     setModalType(1);
     setNumber(+values.creditsNumber);
   }
+
   useEffect(() => {
-    if (!isPollingCreditsPayment && modalType === 1) startPollingPayment();
+    setModalType(initialStep);
+  }, [initialStep]);
+
+  useEffect(() => {
+    if (!isPollingCreditsPayment && modalType === 1) {
+      startPollingPayment();
+    }
   }, [isPollingCreditsPayment, startPollingPayment, modalType]);
 
   const extraSmall = useMediaQuery("(max-width: 560px)");

--- a/src/components/PaymentFaucet/PaymentFaucet.jsx
+++ b/src/components/PaymentFaucet/PaymentFaucet.jsx
@@ -1,5 +1,6 @@
 import { Button, Link, Message, P } from "pi-ui";
 import React from "react";
+import useNavigation from "src/hooks/api/useNavigation";
 import useFaucet from "./hooks";
 import styles from "./PaymentFaucet.module.css";
 
@@ -7,6 +8,7 @@ const FAUCET_BASE_URL = "https://testnet.decred.org/explorer/tx";
 const getFaucetUrl = (txid) => `${FAUCET_BASE_URL}/${txid}`;
 
 const PaymentFaucet = ({ address, amount }) => {
+  const { user } = useNavigation();
   const {
     payWithFaucetError,
     payWithFaucet,
@@ -25,7 +27,7 @@ const PaymentFaucet = ({ address, amount }) => {
           <Button
             className="margin-top-s"
             loading={isApiRequestingPayWithFaucet}
-            onClick={() => payWithFaucet(address, amount)}>
+            onClick={() => payWithFaucet(address, amount, user.userid)}>
             Pay with Faucet
           </Button>
         )}

--- a/src/components/PaymentFaucet/hooks.js
+++ b/src/components/PaymentFaucet/hooks.js
@@ -1,21 +1,37 @@
+import { useMemo } from "react";
 import * as act from "src/actions";
 import { useSelector, useAction } from "src/redux";
 import * as sel from "src/selectors";
 
 export default function useFaucet() {
+  const currentUserID = useSelector(sel.currentUserID);
   const isTestnet = useSelector(sel.isTestNet);
   const isApiRequestingPayWithFaucet = useSelector(
     sel.isApiRequestingPayWithFaucet
   );
-  const payWithFaucetTxId = useSelector(sel.payWithFaucetTxId);
+  const proposalPaywallPaymentTxidSelector = useMemo(
+    () => sel.makeGetPaywallTxid(currentUserID),
+    [currentUserID]
+  );
+  const proposalPaywallPaymentTxid = useSelector(
+    proposalPaywallPaymentTxidSelector
+  );
+  const paywallFaucetTxidSelector = useMemo(
+    () => sel.makeGetPaywallFaucetTxid(currentUserID),
+    [currentUserID]
+  );
+  const paywallFaucetTxid = useSelector(paywallFaucetTxidSelector);
   const payWithFaucetError = useSelector(sel.payWithFaucetError);
 
   const payWithFaucet = useAction(act.payWithFaucet);
   const resetFaucet = useAction(act.resetPaywallPaymentWithFaucet);
+
+  const paymentTxid = paywallFaucetTxid || proposalPaywallPaymentTxid;
+
   return {
     isTestnet,
     isApiRequestingPayWithFaucet,
-    payWithFaucetTxId,
+    payWithFaucetTxId: paymentTxid,
     payWithFaucetError,
     payWithFaucet,
     resetFaucet

--- a/src/components/PaywallMessage.jsx
+++ b/src/components/PaywallMessage.jsx
@@ -9,7 +9,7 @@ import StaticMarkdown from "./StaticMarkdown";
 
 const PaywallMessage = ({ wrapper, ...props }) => {
   const { paywallContent } = useConfig();
-  const { isPaid } = usePaywall();
+  const { isPaid, currentUserEmail } = usePaywall();
   const WrapperComponent = wrapper;
   const [handleOpenModal, handleCloseModal] = useModalContext();
   const openPaywallModal = () =>
@@ -17,8 +17,9 @@ const PaywallMessage = ({ wrapper, ...props }) => {
       title: "Complete your registration",
       onClose: handleCloseModal
     });
+  const showMessage = !!currentUserEmail && !isPaid;
   return (
-    !isPaid && (
+    showMessage && (
       <>
         <WrapperComponent {...props}>
           <StaticMarkdown contentName={paywallContent} />

--- a/src/components/PaywallMessage.jsx
+++ b/src/components/PaywallMessage.jsx
@@ -9,8 +9,7 @@ import StaticMarkdown from "./StaticMarkdown";
 
 const PaywallMessage = ({ wrapper, ...props }) => {
   const { paywallContent } = useConfig();
-  const { userPaywallStatus, paywallAmount } = usePaywall();
-  const showMessage = userPaywallStatus < 2 && paywallAmount > 0;
+  const { isPaid } = usePaywall();
   const WrapperComponent = wrapper;
   const [handleOpenModal, handleCloseModal] = useModalContext();
   const openPaywallModal = () =>
@@ -19,7 +18,7 @@ const PaywallMessage = ({ wrapper, ...props }) => {
       onClose: handleCloseModal
     });
   return (
-    showMessage && (
+    !isPaid && (
       <>
         <WrapperComponent {...props}>
           <StaticMarkdown contentName={paywallContent} />

--- a/src/containers/User/Detail/Credits/AdminCredits.jsx
+++ b/src/containers/User/Detail/Credits/AdminCredits.jsx
@@ -16,10 +16,8 @@ const Credits = ({ user }) => {
     MANAGE_USER_CLEAR_USER_PAYWALL,
     userID
   );
-  const { isPaid } = usePaywall();
-
-  const { proposalCreditPrice } = useCredits(userID);
-
+  const { isPaid } = usePaywall(userID);
+  const { proposalCredits, proposalCreditPrice } = useCredits(userID);
   const {
     onRescanUserCredits,
     errorRescan,
@@ -50,7 +48,7 @@ const Credits = ({ user }) => {
         openMarkAsPaidModal={handleOpenMarkAsPaid}
       />
       <ProposalCreditsSection
-        proposalCredits={user.proposalcredits}
+        proposalCredits={proposalCredits}
         proposalCreditPrice={proposalCreditPrice}
       />
       <Button

--- a/src/containers/User/Detail/Credits/AdminUserCredits.jsx
+++ b/src/containers/User/Detail/Credits/AdminUserCredits.jsx
@@ -19,8 +19,7 @@ const Credits = ({ user }) => {
     MANAGE_USER_CLEAR_USER_PAYWALL,
     userID
   );
-  const { isPaid } = usePaywall();
-
+  const { isPaid } = usePaywall(userID);
   const {
     proposalCreditPrice,
     isApiRequestingUserProposalCredits,
@@ -42,12 +41,14 @@ const Credits = ({ user }) => {
   useEffect(() => {
     if (shouldPollPaywallPayment) {
       toggleCreditsPaymentPolling(true);
+      toggleProposalPaymentReceived(false);
       onPollProposalPaywallPayment(true);
     }
   }, [
     shouldPollPaywallPayment,
     onPollProposalPaywallPayment,
-    toggleCreditsPaymentPolling
+    toggleCreditsPaymentPolling,
+    toggleProposalPaymentReceived
   ]);
 
   const {
@@ -75,7 +76,6 @@ const Credits = ({ user }) => {
     }
   }, [
     proposalPaymentReceived,
-    toggleProposalPaymentReceived,
     toggleCreditsPaymentPolling,
     handleCloseModal
   ]);

--- a/src/containers/User/Detail/Credits/UserCredits.jsx
+++ b/src/containers/User/Detail/Credits/UserCredits.jsx
@@ -10,14 +10,14 @@ import { useUserPaymentModals } from "./hooks";
 
 const Credits = ({ user }) => {
   const userID = user && user.userid;
-  const { isPaid } = usePaywall();
+  const { isPaid } = usePaywall(userID);
   const {
     proposalCreditPrice,
     isApiRequestingUserProposalCredits,
     proposalCredits,
     toggleCreditsPaymentPolling,
-    proposalPaymentReceived,
     toggleProposalPaymentReceived,
+    proposalPaymentReceived,
     onPollProposalPaywallPayment,
     shouldPollPaywallPayment
   } = useCredits(userID);
@@ -31,12 +31,14 @@ const Credits = ({ user }) => {
   useEffect(() => {
     if (shouldPollPaywallPayment) {
       toggleCreditsPaymentPolling(true);
+      toggleProposalPaymentReceived(false);
       onPollProposalPaywallPayment(true);
     }
   }, [
     shouldPollPaywallPayment,
     onPollProposalPaywallPayment,
-    toggleCreditsPaymentPolling
+    toggleCreditsPaymentPolling,
+    toggleProposalPaymentReceived
   ]);
 
   useEffect(() => {
@@ -46,9 +48,8 @@ const Credits = ({ user }) => {
     }
   }, [
     proposalPaymentReceived,
-    toggleProposalPaymentReceived,
-    handleCloseModal,
-    toggleCreditsPaymentPolling
+    toggleCreditsPaymentPolling,
+    handleCloseModal
   ]);
 
   return isApiRequestingUserProposalCredits ? (

--- a/src/containers/User/Detail/Credits/hooks.js
+++ b/src/containers/User/Detail/Credits/hooks.js
@@ -136,7 +136,7 @@ export function useCredits(userID) {
   ]);
 
   useEffect(() => {
-    if (proposalPaywallPaymentTxid === undefined) {
+    if (!proposalPaywallPaymentTxid) {
       onFetchProposalPaywallPayment();
     }
   }, [proposalPaywallPaymentTxid, onFetchProposalPaywallPayment]);

--- a/src/containers/User/Detail/Credits/hooks.js
+++ b/src/containers/User/Detail/Credits/hooks.js
@@ -88,7 +88,7 @@ export function useCredits(userID) {
   const clearProposalPaymentPollingPointer = useAction(
     act.clearProposalPaymentPollingPointer
   );
-  const { isPaid } = usePaywall();
+  const { isPaid } = usePaywall(userID);
   const proposalCredits = proposalCreditsUnspent.length;
   const proposalCreditsFetched = proposalCredits !== null;
   const isUserPageOwner = currentUserID === userID;

--- a/src/containers/User/Detail/Credits/hooks.js
+++ b/src/containers/User/Detail/Credits/hooks.js
@@ -9,23 +9,58 @@ import ModalPayPaywall from "src/components/ModalPayPaywall";
 import { getProposalCreditsPaymentStatus } from "./helpers.js";
 
 export function useCredits(userID) {
-  const proposalPaywallAddress = useSelector(sel.proposalPaywallAddress);
-  const proposalCreditPrice = useSelector(sel.proposalCreditPrice);
   const isApiRequestingProposalPaywall = useSelector(
     sel.isApiRequestingProposalPaywall
   );
   const isApiRequestingUserProposalCredits = useSelector(
     sel.isApiRequestingUserProposalCredits
   );
+  const proposalPaywallAddressSelector = useMemo(
+    () => sel.makeGetPaywallAddress(userID),
+    [userID]
+  );
+  const proposalCreditPriceSelector = useMemo(
+    () => sel.makeGetPaywallCreditPrice(userID),
+    [userID]
+  );
+  const proposalPaywallPaymentTxidSelector = useMemo(
+    () => sel.makeGetPaywallTxid(userID),
+    [userID]
+  );
+  const proposalPaywallPaymentAmountSelector = useMemo(
+    () => sel.makeGetPaywallAmount(userID),
+    [userID]
+  );
+  const proposalPaywallPaymentConfirmationsSelector = useMemo(
+    () => sel.makeGetPaywallConfirmations(userID),
+    [userID]
+  );
+  const paywallFaucetTxidSelector = useMemo(
+    () => sel.makeGetPaywallFaucetTxid(userID),
+    [userID]
+  );
+  const creditsSelector = useMemo(() => sel.makeGetUnspentUserCredits(userID), [
+    userID
+  ]);
+  const creditsPurchasesSelector = useMemo(
+    () => sel.makeGetUserCreditsPurchasesByTx(userID),
+    [userID]
+  );
+  const proposalPaywallAddress = useSelector(proposalPaywallAddressSelector);
+  const proposalCreditPrice = useSelector(proposalCreditPriceSelector);
   const proposalPaywallPaymentTxid = useSelector(
-    sel.apiProposalPaywallPaymentTxid
+    proposalPaywallPaymentTxidSelector
   );
   const proposalPaywallPaymentAmount = useSelector(
-    sel.apiProposalPaywallPaymentAmount
+    proposalPaywallPaymentAmountSelector
   );
   const proposalPaywallPaymentConfirmations = useSelector(
-    sel.apiProposalPaywallPaymentConfirmations
+    proposalPaywallPaymentConfirmationsSelector
   );
+  const proposalCreditsUnspent = useSelector(creditsSelector);
+  const proposalCreditsPurchases = useSelector(creditsPurchasesSelector);
+  const paywallFaucetTxid = useSelector(paywallFaucetTxidSelector);
+
   const pollingCreditsPayment = useSelector(sel.pollingCreditsPayment);
   const reachedCreditsPaymentPollingLimit = useSelector(
     sel.reachedCreditsPaymentPollingLimit
@@ -35,20 +70,12 @@ export function useCredits(userID) {
   const currentUserID = useSelector(sel.currentUserID);
   const user = useSelector(sel.currentUser);
 
-  const creditsSelector = useMemo(() => sel.makeGetUnspentUserCredits(userID), [
-    userID
-  ]);
-  const creditsPurchasesSelector = useMemo(
-    () => sel.makeGetUserCreditsPurchasesByTx(userID),
-    [userID]
-  );
-
-  const proposalCreditsUnspent = useSelector(creditsSelector);
-  const proposalCreditsPurchases = useSelector(creditsPurchasesSelector);
-
   const onUserProposalCredits = useAction(act.onUserProposalCredits);
   const onPurchaseProposalCredits = useAction(
     act.onFetchProposalPaywallDetails
+  );
+  const onFetchProposalPaywallPayment = useAction(
+    act.onFetchProposalPaywallPayment
   );
   const onPollProposalPaywallPayment = useAction(
     act.onPollProposalPaywallPayment
@@ -62,23 +89,25 @@ export function useCredits(userID) {
   const clearProposalPaymentPollingPointer = useAction(
     act.clearProposalPaymentPollingPointer
   );
-
-  const proposalCredits = proposalCreditsUnspent.length;
   const { isPaid } = usePaywall();
+  const proposalCredits = proposalCreditsUnspent.length;
   const proposalCreditsFetched = proposalCredits !== null;
   const isUserPageOwner = user && currentUserID === user.userid;
   const shouldFetchPurchaseProposalCredits =
     isPaid &&
+    !!userID &&
     isUserPageOwner &&
     !proposalCreditPrice &&
     !isApiRequestingProposalPaywall;
   const shouldPollPaywallPayment =
     isPaid &&
     isUserPageOwner &&
+    proposalPaywallPaymentTxid !== "" &&
     !pollingCreditsPayment &&
     !reachedCreditsPaymentPollingLimit;
   const shouldFetchProposalCredits =
     isPaid &&
+    userID &&
     isUserPageOwner &&
     !isApiRequestingUserProposalCredits &&
     !proposalCreditsFetched;
@@ -98,12 +127,20 @@ export function useCredits(userID) {
   useEffect(() => {
     if (!pollingCreditsPayment && proposalPaywallPaymentTxid) {
       toggleCreditsPaymentPolling(true);
+      onPollProposalPaywallPayment(false);
     }
   }, [
     pollingCreditsPayment,
+    proposalPaywallPaymentTxid,
     toggleCreditsPaymentPolling,
-    proposalPaywallPaymentTxid
+    onPollProposalPaywallPayment
   ]);
+
+  useEffect(() => {
+    if (proposalPaywallPaymentTxid === undefined) {
+      onFetchProposalPaywallPayment();
+    }
+  }, [proposalPaywallPaymentTxid, onFetchProposalPaywallPayment]);
 
   return {
     proposalCreditPrice,
@@ -123,16 +160,24 @@ export function useCredits(userID) {
     toggleProposalPaymentReceived,
     onPollProposalPaywallPayment,
     shouldPollPaywallPayment,
-    clearProposalPaymentPollingPointer
+    clearProposalPaymentPollingPointer,
+    paywallFaucetTxid
   };
 }
 
 export function usePollProposalCreditsPayment() {
+  const currentUserID = useSelector(sel.currentUserID);
+  const proposalPaywallPaymentTxidSelector = useMemo(
+    () => sel.makeGetPaywallTxid(currentUserID),
+    [currentUserID]
+  );
   const proposalPaywallPaymentTxid = useSelector(
-    sel.apiProposalPaywallPaymentTxid
+    proposalPaywallPaymentTxidSelector
+  );
+  const onFetchProposalPaywallDetails = useAction(
+    act.onFetchProposalPaywallDetails
   );
   const pollingCreditsPayment = useSelector(sel.pollingCreditsPayment);
-
   const onUserProposalCredits = useAction(act.onUserProposalCredits);
   const toggleCreditsPaymentPolling = useAction(
     act.toggleCreditsPaymentPolling
@@ -152,14 +197,16 @@ export function usePollProposalCreditsPayment() {
       toggleProposalPaymentReceived(true);
       toggleCreditsPaymentPolling(false);
       onUserProposalCredits();
+      onFetchProposalPaywallDetails();
     }
     prevProposalPaywallPaymentTxid.current = proposalPaywallPaymentTxid;
   }, [
-    proposalPaywallPaymentTxid,
     pollingCreditsPayment,
-    onUserProposalCredits,
+    proposalPaywallPaymentTxid,
     toggleProposalPaymentReceived,
-    toggleCreditsPaymentPolling
+    toggleCreditsPaymentPolling,
+    onUserProposalCredits,
+    onFetchProposalPaywallDetails
   ]);
 
   return {};

--- a/src/containers/User/Detail/Credits/hooks.js
+++ b/src/containers/User/Detail/Credits/hooks.js
@@ -68,7 +68,6 @@ export function useCredits(userID) {
   const proposalPaymentReceived = useSelector(sel.proposalPaymentReceived);
   const isAdmin = useSelector(sel.currentUserIsAdmin);
   const currentUserID = useSelector(sel.currentUserID);
-  const user = useSelector(sel.currentUser);
 
   const onUserProposalCredits = useAction(act.onUserProposalCredits);
   const onPurchaseProposalCredits = useAction(
@@ -92,7 +91,7 @@ export function useCredits(userID) {
   const { isPaid } = usePaywall();
   const proposalCredits = proposalCreditsUnspent.length;
   const proposalCreditsFetched = proposalCredits !== null;
-  const isUserPageOwner = user && currentUserID === user.userid;
+  const isUserPageOwner = currentUserID === userID;
   const shouldFetchPurchaseProposalCredits =
     isPaid &&
     !!userID &&
@@ -145,7 +144,6 @@ export function useCredits(userID) {
   return {
     proposalCreditPrice,
     isAdmin,
-    user,
     isApiRequestingUserProposalCredits,
     proposalCredits,
     proposalCreditsPurchases,

--- a/src/hooks/api/usePaywall.js
+++ b/src/hooks/api/usePaywall.js
@@ -1,18 +1,25 @@
+import { useMemo } from "react";
 import * as act from "src/actions";
-import { useAction, useSelector } from "src/redux";
 import * as sel from "src/selectors";
-import { PAYWALL_STATUS_PAID } from "src/constants";
-import { useConfig } from "src/containers/Config";
+import { useAction, useSelector } from "src/redux";
+import { useConfig } from "src/Config";
 
 function usePaywall() {
   const currentUserEmail = useSelector(sel.currentUserEmail);
+  const currentUserID = useSelector(sel.currentUserID);
   const paywallAddress = useSelector(sel.currentUserPaywallAddress);
   const paywallAmount = useSelector(sel.currentUserPaywallAmount);
   const paywallTxNotBefore = useSelector(sel.currentUserPaywallTxNotBefore);
-  const userPaywallStatus = useSelector(sel.getUserPaywallStatus);
-  const userPaywallConfirmations = useSelector(sel.getUserPaywallConfirmations);
-  const userPaywallTxid = useSelector(sel.getUserPaywallTxid);
-  const userAlreadyPaid = useSelector(sel.getUserAlreadyPaid);
+  const userIsPaidSelector = useMemo(
+    () => sel.makeGetUserIsPaid(currentUserID),
+    [currentUserID]
+  );
+  const userPaywallStatusSelector = useMemo(
+    () => sel.makeGetPaywallAddress(currentUserID),
+    [currentUserID]
+  );
+  const userIsPaid = useSelector(userIsPaidSelector);
+  const userPaywallStatus = useSelector(userPaywallStatusSelector);
   const verificationToken = useSelector(sel.verificationToken);
   const isTestnet = useSelector(sel.isTestNet);
 
@@ -26,13 +33,10 @@ function usePaywall() {
     paywallAmount,
     paywallTxNotBefore,
     userPaywallStatus,
-    userPaywallConfirmations,
-    userPaywallTxid,
-    userAlreadyPaid,
     verificationToken,
     isTestnet,
     onResetAppPaywallInfo,
-    isPaid: userPaywallStatus === PAYWALL_STATUS_PAID,
+    isPaid: userIsPaid,
     paywallEnabled: enablePaywall
   };
 }

--- a/src/hooks/api/usePaywall.js
+++ b/src/hooks/api/usePaywall.js
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import * as act from "src/actions";
 import * as sel from "src/selectors";
 import { useAction, useSelector } from "src/redux";
-import { useConfig } from "src/Config";
+import { useConfig } from "src/containers/Config";
 
 function usePaywall() {
   const currentUserEmail = useSelector(sel.currentUserEmail);

--- a/src/hooks/api/usePaywall.js
+++ b/src/hooks/api/usePaywall.js
@@ -4,19 +4,17 @@ import * as sel from "src/selectors";
 import { useAction, useSelector } from "src/redux";
 import { useConfig } from "src/containers/Config";
 
-function usePaywall() {
-  const currentUserEmail = useSelector(sel.currentUserEmail);
+function usePaywall(userID) {
   const currentUserID = useSelector(sel.currentUserID);
+  const uuid = userID || currentUserID;
+  const currentUserEmail = useSelector(sel.currentUserEmail);
   const paywallAddress = useSelector(sel.currentUserPaywallAddress);
   const paywallAmount = useSelector(sel.currentUserPaywallAmount);
   const paywallTxNotBefore = useSelector(sel.currentUserPaywallTxNotBefore);
-  const userIsPaidSelector = useMemo(
-    () => sel.makeGetUserIsPaid(currentUserID),
-    [currentUserID]
-  );
+  const userIsPaidSelector = useMemo(() => sel.makeGetUserIsPaid(uuid), [uuid]);
   const userPaywallStatusSelector = useMemo(
-    () => sel.makeGetPaywallAddress(currentUserID),
-    [currentUserID]
+    () => sel.makeGetPaywallAddress(uuid),
+    [uuid]
   );
   const userIsPaid = useSelector(userIsPaidSelector);
   const userPaywallStatus = useSelector(userPaywallStatusSelector);

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -8,7 +8,8 @@ import {
   proposals,
   proposalVotes,
   invoices,
-  dccs
+  dccs,
+  paywall
 } from "./models";
 import external_api from "./external_api";
 
@@ -22,7 +23,8 @@ const rootReducer = combineReducers({
   proposals,
   proposalVotes,
   invoices,
-  dccs
+  dccs,
+  paywall
 });
 
 export default rootReducer;

--- a/src/reducers/models/credits.js
+++ b/src/reducers/models/credits.js
@@ -20,7 +20,8 @@ const credits = (state = DEFAULT_STATE, action) =>
             update(
               ["byUserID", action.payload.userid, "unspent"],
               (unspent = []) => [...unspent, ...action.payload.newcredits]
-            )(state)
+            )(state),
+          [act.RECEIVE_LOGOUT]: () => DEFAULT_STATE
         }[action.type] || (() => state)
       )();
 

--- a/src/reducers/models/index.js
+++ b/src/reducers/models/index.js
@@ -5,3 +5,4 @@ export { default as proposals } from "./proposals";
 export { default as proposalVotes } from "./proposalVotes";
 export { default as invoices } from "./invoices";
 export { default as dccs } from "./dccs";
+export { default as paywall } from "./paywall";

--- a/src/reducers/models/paywall.js
+++ b/src/reducers/models/paywall.js
@@ -1,0 +1,60 @@
+import * as act from "src/actions/types";
+import { update } from "lodash/fp";
+import { PAYWALL_STATUS_PAID } from "src/constants";
+
+const DEFAULT_STATE = {
+  byUserID: {}
+};
+
+const paywall = (state = DEFAULT_STATE, action) =>
+  action.error
+    ? state
+    : (
+        {
+          [act.RECEIVE_ME || act.RECEIVE_LOGIN]: () => {
+            const { userid, paywalladdress } = action.payload;
+
+            return update(["byUserID", userid], (paywall) => ({
+              ...paywall,
+              isPaid: paywalladdress === ""
+            }))(state);
+          },
+          [act.RECEIVE_PROPOSAL_PAYWALL_DETAILS]: () => {
+            const userid = action.payload.userid;
+            delete action.payload.userid;
+
+            return update(["byUserID", userid], (paywall) => ({
+              ...paywall,
+              ...action.payload
+            }))(state);
+          },
+          [act.RECEIVE_PROPOSAL_PAYWALL_PAYMENT]: () => {
+            const userid = action.payload.userid;
+            delete action.payload.userid;
+
+            return update(["byUserID", userid], (paywall) => ({
+              ...paywall,
+              ...action.payload
+            }))(state);
+          },
+          [act.UPDATE_USER_PAYWALL_STATUS]: () => {
+            const { userid, status } = action.payload;
+
+            return update(["byUserID", userid], (paywall) => ({
+              ...paywall,
+              status: status,
+              isPaid: status === PAYWALL_STATUS_PAID
+            }))(state);
+          },
+          [act.RECEIVE_PAYWALL_PAYMENT_WITH_FAUCET]: () => {
+            const { userid, txid } = action.payload;
+
+            return update(["byUserID", userid], (paywall) => ({
+              ...paywall,
+              faucetTxid: txid
+            }))(state);
+          }
+        }[action.type] || (() => state)
+      )();
+
+export default paywall;

--- a/src/reducers/models/paywall.js
+++ b/src/reducers/models/paywall.js
@@ -19,6 +19,15 @@ const paywall = (state = DEFAULT_STATE, action) =>
               isPaid: paywalladdress === ""
             }))(state);
           },
+          [act.RECEIVE_USER]: () => {
+            const { userid, newuserpaywalltx } = action.payload.user;
+            const paywall = state.byUserID[userid];
+            const isPaid = paywall ? paywall.isPaid : false;
+            return update(["byUserID", userid], (paywall) => ({
+              ...paywall,
+              isPaid: isPaid || newuserpaywalltx !== ""
+            }))(state);
+          },
           [act.RECEIVE_PROPOSAL_PAYWALL_DETAILS]: () => {
             const userid = action.payload.userid;
             delete action.payload.userid;
@@ -53,7 +62,8 @@ const paywall = (state = DEFAULT_STATE, action) =>
               ...paywall,
               faucetTxid: txid
             }))(state);
-          }
+          },
+          [act.RECEIVE_LOGOUT]: () => DEFAULT_STATE
         }[action.type] || (() => state)
       )();
 

--- a/src/redux/configureStore.js
+++ b/src/redux/configureStore.js
@@ -21,8 +21,8 @@ const getComposer = () => {
 const getMiddlewares = () => {
   const loggerMiddleware = createLogger();
   const isProductionEnv = process.env.NODE_ENV === "production";
-  const reduxLoggerIsOn = process.env.REACT_APP_USE_REDUX_LOGGER;
-  // const reduxLoggerIsOn = true;
+  // const reduxLoggerIsOn = process.env.REACT_APP_USE_REDUX_LOGGER;
+  const reduxLoggerIsOn = true;
   const middlewares = [
     thunkMiddleware,
     !isProductionEnv && reduxLoggerIsOn && loggerMiddleware

--- a/src/redux/configureStore.js
+++ b/src/redux/configureStore.js
@@ -21,8 +21,8 @@ const getComposer = () => {
 const getMiddlewares = () => {
   const loggerMiddleware = createLogger();
   const isProductionEnv = process.env.NODE_ENV === "production";
-  // const reduxLoggerIsOn = process.env.REACT_APP_USE_REDUX_LOGGER;
-  const reduxLoggerIsOn = true;
+  const reduxLoggerIsOn = process.env.REACT_APP_USE_REDUX_LOGGER;
+  // const reduxLoggerIsOn = true;
   const middlewares = [
     thunkMiddleware,
     !isProductionEnv && reduxLoggerIsOn && loggerMiddleware

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -8,6 +8,7 @@ export * from "./models/proposals";
 export * from "./models/proposalVotes";
 export * from "./models/invoices";
 export * from "./models/dccs";
+export * from "./models/paywall";
 
 export const selectorMap = (fns) => (...args) =>
   Object.keys(fns).reduce(

--- a/src/selectors/models/paywall.js
+++ b/src/selectors/models/paywall.js
@@ -5,9 +5,7 @@ import { PAYWALL_STATUS_PAID, PAYWALL_STATUS_WAITING } from "src/constants";
 export const paywallByUserID = get(["paywall", "byUserID"]);
 
 export const makeGetPaywallByUserID = (userID) =>
-  createSelector(paywallByUserID, (paywall) =>
-    paywall[userID] ? paywall[userID] : null
-  );
+  createSelector(paywallByUserID, get(userID));
 
 export const makeGetUserPaywallStatus = (userID) =>
   createSelector(makeGetPaywallByUserID(userID), (paywall) =>

--- a/src/selectors/models/paywall.js
+++ b/src/selectors/models/paywall.js
@@ -1,0 +1,53 @@
+import { createSelector } from "reselect";
+import get from "lodash/fp/get";
+import { PAYWALL_STATUS_PAID, PAYWALL_STATUS_WAITING } from "src/constants";
+
+export const paywallByUserID = get(["paywall", "byUserID"]);
+
+export const makeGetPaywallByUserID = (userID) =>
+  createSelector(paywallByUserID, (paywall) =>
+    paywall[userID] ? paywall[userID] : null
+  );
+
+export const makeGetUserPaywallStatus = (userID) =>
+  createSelector(makeGetPaywallByUserID(userID), (paywall) =>
+    paywall ? getUserPaywallStatus(paywall) : null
+  );
+
+export const makeGetPaywallCreditPrice = (userID) =>
+  createSelector(makeGetPaywallByUserID(userID), (paywall) =>
+    paywall ? paywall.creditprice / 100000000 : null
+  );
+
+const getUserPaywallStatus = (paywall) => {
+  if (paywall.isPaid) {
+    return PAYWALL_STATUS_PAID;
+  }
+  return paywall.status || PAYWALL_STATUS_WAITING;
+};
+
+const createPaywallSelector = (userID, key) =>
+  createSelector(makeGetPaywallByUserID(userID), (paywall) =>
+    paywall ? paywall[key] : null
+  );
+
+export const makeGetUserIsPaid = (userID) =>
+  createPaywallSelector(userID, "isPaid");
+
+export const makeGetPaywallAddress = (userID) =>
+  createPaywallSelector(userID, "paywalladdress");
+
+export const makeGetPaywallTxNotBefore = (userID) =>
+  createPaywallSelector(userID, "creditprice");
+
+export const makeGetPaywallTxid = (userID) =>
+  createPaywallSelector(userID, "txid");
+
+export const makeGetPaywallAmount = (userID) =>
+  createPaywallSelector(userID, "amount");
+
+export const makeGetPaywallConfirmations = (userID) =>
+  createPaywallSelector(userID, "confirmations");
+
+export const makeGetPaywallFaucetTxid = (userID) =>
+  createPaywallSelector(userID, "faucetTxid");


### PR DESCRIPTION
This is the last PR of the effort to normalize our state data in its own branch, separated by models. It normalizes and caches paywall data by users.

Besides normalizing the state, this PR fixes a infinite loop that crashed the app when trying to open the credit payment modal for the second time, after a first buy was confirmed. It also adds minor improvements to the flow of the payment process.

closes #1490 