### PR TITLE
[cms] Replace BoxTextInput by TextArea on DCC Statement

### DIFF
--- a/src/components/DCC/DCC.jsx
+++ b/src/components/DCC/DCC.jsx
@@ -19,7 +19,6 @@ import {
   isDccApproved
 } from "src/containers/DCC/helpers";
 import { SupportOppose, DccActions } from "src/containers/DCC/Actions";
-import Markdown from "src/components/Markdown";
 
 const Dcc = ({ dcc, extended }) => {
   const {
@@ -114,7 +113,7 @@ const Dcc = ({ dcc, extended }) => {
                 <Row justify="space-between" className={styles.topDetails}>
                   <div className={styles.field}>
                     <Text size="small">Statement</Text>
-                    <Markdown body={presentationalStatement(dccStatement)}/>
+                    <Text className={styles.statement}>{presentationalStatement(dccStatement)}</Text>
                   </div>
                 </Row>
                 {!isActive &&

--- a/src/components/DCC/DCC.jsx
+++ b/src/components/DCC/DCC.jsx
@@ -19,6 +19,7 @@ import {
   isDccApproved
 } from "src/containers/DCC/helpers";
 import { SupportOppose, DccActions } from "src/containers/DCC/Actions";
+import Markdown from "src/components/Markdown";
 
 const Dcc = ({ dcc, extended }) => {
   const {
@@ -113,7 +114,7 @@ const Dcc = ({ dcc, extended }) => {
                 <Row justify="space-between" className={styles.topDetails}>
                   <div className={styles.field}>
                     <Text size="small">Statement</Text>
-                    <Text>{presentationalStatement(dccStatement)}</Text>
+                    <Markdown body={presentationalStatement(dccStatement)}/>
                   </div>
                 </Row>
                 {!isActive &&

--- a/src/components/DCC/DCC.module.css
+++ b/src/components/DCC/DCC.module.css
@@ -17,6 +17,11 @@ span.statusTag > span {
   color: var(--color-gray-blueish);
 }
 
+.statement {
+  white-space: pre-line;
+  padding-top: 0.5rem;
+}
+
 .supportOpposeButtons {
   float: right;
   padding-bottom: 1rem;

--- a/src/components/DccForm/DccForm.jsx
+++ b/src/components/DccForm/DccForm.jsx
@@ -4,9 +4,10 @@ import {
   Button,
   Message,
   RadioButtonGroup,
-  classNames
+  classNames,
+  TextArea
 } from "pi-ui";
-import { Formik } from "formik";
+import { Formik, Field } from "formik";
 import SelectField from "src/components/Select/SelectField";
 import { withRouter } from "react-router-dom";
 import { dccValidationSchema } from "./validation";
@@ -22,7 +23,7 @@ import {
   DCC_TYPE_REVOCATION,
   CONTRACTOR_TYPE_REVOKED
 } from "src/containers/DCC";
-import MarkdownEditor from "src/components/MarkdownEditor";
+import usePolicy from "src/hooks/api/usePolicy";
 
 const Select = ({ error, ...props }) => (
   <div
@@ -84,13 +85,13 @@ const DccForm = React.memo(function DccForm({
     setFieldValue("nomineeid", "");
   };
 
-  const handleChangeStatement = (value) => {
+  const handleChangeStatement = (e) => {
     setSessionStorageDcc({
       ...values,
-      "statement": value
+      "statement": e.target.value
     });
     setFieldTouched("statement", true);
-    setFieldValue("statement", value);
+    setFieldValue("statement", e.target.value);
   };
 
   const handleChangeSelector = (field) => (e) => {
@@ -168,13 +169,13 @@ const DccForm = React.memo(function DccForm({
           isDisabled={!values.type}
         />
       )}
-      <MarkdownEditor
+      <Field
+        component={TextArea}
         name="statement"
         value={values.statement}
         onChange={handleChangeStatement}
         placeholder="Statement"
         error={touched.statement && errors.statement}
-        className={styles.statement}
       />
       <div className="justify-right">
         <DraftSaver {...{ submitSuccess }}/>
@@ -193,9 +194,10 @@ const DccFormWrapper = ({
   isUserValid
 }) => {
   const [submitSuccess, setSubmitSuccess] = useState(false);
+  const { policy } = usePolicy();
   const dccFormValidation = useMemo(
-    () => dccValidationSchema(),
-    []
+    () => dccValidationSchema(policy),
+    [policy]
   );
 
   const FORM_INITIAL_VALUES = {

--- a/src/components/DccForm/DccForm.jsx
+++ b/src/components/DccForm/DccForm.jsx
@@ -1,7 +1,6 @@
 import React, { useMemo, useState, useCallback, useEffect } from "react";
 import PropTypes from "prop-types";
 import {
-  BoxTextInput,
   Button,
   Message,
   RadioButtonGroup,
@@ -23,6 +22,7 @@ import {
   DCC_TYPE_REVOCATION,
   CONTRACTOR_TYPE_REVOKED
 } from "src/containers/DCC";
+import MarkdownEditor from "src/components/MarkdownEditor";
 
 const Select = ({ error, ...props }) => (
   <div
@@ -34,7 +34,6 @@ const Select = ({ error, ...props }) => (
 
 const DccForm = React.memo(function DccForm({
   values,
-  handleChange,
   handleSubmit,
   isSubmitting,
   setFieldValue,
@@ -75,15 +74,6 @@ const DccForm = React.memo(function DccForm({
     </Button>
   ), [isValid, isSubmitting, isUserValid]);
 
-  const handleChangeWithTouched = (field) => (e) => {
-    setFieldTouched(field, true);
-    setSessionStorageDcc({
-      ...values,
-      [field]: e.target.value
-    });
-    handleChange(e);
-  };
-
   const handleChangeDccType = (e) => {
     setFieldTouched("type", true);
     setSessionStorageDcc({
@@ -92,6 +82,15 @@ const DccForm = React.memo(function DccForm({
     });
     setFieldValue("type", e.value);
     setFieldValue("nomineeid", "");
+  };
+
+  const handleChangeStatement = (value) => {
+    setSessionStorageDcc({
+      ...values,
+      "statement": value
+    });
+    setFieldTouched("statement", true);
+    setFieldValue("statement", value);
   };
 
   const handleChangeSelector = (field) => (e) => {
@@ -169,13 +168,13 @@ const DccForm = React.memo(function DccForm({
           isDisabled={!values.type}
         />
       )}
-      <BoxTextInput
-        placeholder="Statement"
+      <MarkdownEditor
         name="statement"
-        tabIndex={1}
         value={values.statement}
+        onChange={handleChangeStatement}
+        placeholder="Statement"
         error={touched.statement && errors.statement}
-        onChange={handleChangeWithTouched("statement")}
+        className={styles.statement}
       />
       <div className="justify-right">
         <DraftSaver {...{ submitSuccess }}/>

--- a/src/components/DccForm/DccForm.module.css
+++ b/src/components/DccForm/DccForm.module.css
@@ -17,3 +17,7 @@
 .radioButton {
   padding-bottom: 1rem;
 }
+
+.statement {
+  margin-bottom: 2rem;
+}

--- a/src/components/DccForm/validation.js
+++ b/src/components/DccForm/validation.js
@@ -1,7 +1,8 @@
 import * as Yup from "yup";
 import { DCC_TYPE_ISSUANCE } from "src/containers/DCC";
+import { yupFieldMatcher } from "src/utils/validation";
 
-export const dccValidationSchema = () =>
+export const dccValidationSchema = ({ cmsstatementsupportedchars }) =>
   Yup.object().shape({
     nomineeid: Yup.string().required("required"),
     type: Yup.number()
@@ -10,7 +11,8 @@ export const dccValidationSchema = () =>
       .max(2),
     statement: Yup.string()
       .required("required")
-      .max(5000),
+      .max(5000)
+      .matches(...yupFieldMatcher("Statement", cmsstatementsupportedchars)),
     domain: Yup.number()
       .when("type", issuanceFieldValidator)
       .max(6),


### PR DESCRIPTION
This issue depends on https://github.com/decred/politeia/pull/1164.

It should improve the DCC usability, since it is a critical feature. Now the DCC sponsor can format her/his using the same Markdown formatting on proposals.