### PR TITLE
[cms] Turn off admin-only for DCCs

### DIFF
--- a/src/apps/cms/config.json
+++ b/src/apps/cms/config.json
@@ -16,7 +16,7 @@
   "navMenuPaths": [
     { "label": "My invoices", "path": "/invoices/me", "admin": false },
     { "label": "Admin", "path": "/admin/invoices", "admin": true },
-    { "label": "DCCs", "path": "/dccs", "admin": true },
+    { "label": "DCCs", "path": "/dccs", "admin": false },
     { "label": "Search for users", "path": "/user/search", "admin": true }
   ]
 }


### PR DESCRIPTION
All users should be able to navigate to the DCCs page