### PR TITLE
[cms] Fix invoice datasheet columns width on Firefox

### DIFF
--- a/src/components/InvoiceDatasheet/InvoiceDatasheet.jsx
+++ b/src/components/InvoiceDatasheet/InvoiceDatasheet.jsx
@@ -72,7 +72,15 @@ const InvoiceDatasheet = React.memo(function InvoiceDatasheet({
       );
       setGrid(grid);
     },
-    [value, readOnly, errors, currentRate, policy, proposalsTokens, subContractors]
+    [
+      value,
+      readOnly,
+      errors,
+      currentRate,
+      policy,
+      proposalsTokens,
+      subContractors
+    ]
   );
 
   const handleRemoveLastRow = useCallback(
@@ -101,7 +109,10 @@ const InvoiceDatasheet = React.memo(function InvoiceDatasheet({
           <thead>
             <tr className={styles.tableHead}>
               {headers.map((col, idx) => (
-                <th key={`header-${idx}`} className={styles.tableHeadCell} width={col.width}>
+                <th
+                  key={`header-${idx}`}
+                  className={styles.tableHeadCell}
+                  style={{ minWidth: col.width, width: col.width }}>
                   {col.value}
                 </th>
               ))}

--- a/src/components/InvoiceDatasheet/helpers.js
+++ b/src/components/InvoiceDatasheet/helpers.js
@@ -240,17 +240,17 @@ export const convertGridToLineItems = (grid) => {
 };
 
 export const createTableHeaders = () => [
-  { readOnly: true, value: "", width: 20 },
-  { value: "Type", readOnly: true, width: 40 },
-  { value: "Domain", readOnly: true, width: 120 },
-  { value: "Subdomain", readOnly: true, width: 140 },
-  { value: "Description", readOnly: true, width: 300 },
-  { value: "Proposal Token", readOnly: true, width: 100 },
-  { value: "Subcontr. ID", readOnly: true, width: 100 },
-  { value: "Subcontr. Rate (USD)", readOnly: true, width: 80 },
-  { value: "Labor (hours)", readOnly: true, width: 70 },
-  { value: "Expense (USD)", readOnly: true, width: 75 },
-  { value: "Subtotal (USD)", readOnly: true, width: 75 }
+  { readOnly: true, value: "", width: "2rem" },
+  { value: "Type", readOnly: true, width: "4rem" },
+  { value: "Domain", readOnly: true, width: "12rem" },
+  { value: "Subdomain", readOnly: true, width: "14rem" },
+  { value: "Description", readOnly: true, width: "30rem" },
+  { value: "Proposal Token", readOnly: true, width: "10rem" },
+  { value: "Subcontr. ID", readOnly: true, width: "10rem" },
+  { value: "Subcontr. Rate (USD)", readOnly: true, width: "8rem" },
+  { value: "Labor (hours)", readOnly: true, width: "7rem" },
+  { value: "Expense (USD)", readOnly: true, width: "7.5rem" },
+  { value: "Subtotal (USD)", readOnly: true, width: "7.5rem" }
 ];
 
 export const updateGridCell = (grid, row, col, values) => {


### PR DESCRIPTION
### Bug (or issue) description

This PR fixes the issue reported by @alexlyp on https://matrix.to/#/!VFRvyndKpzcLrVslQD:decred.org/$158826507722600nsDEf:decred.org?via=decred.org&via=matrix.org&via=zettaport.com about invoice datasheet columns width being on the same size.

### Solution description

Firefox no longer allow `width` prop for `<th>` (see: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th). The solution was to pass correct inline CSS styles instead of passing the width prop.

### UI Changes Screenshot

Old:
<img width="1752" alt="Captura de Tela 2020-04-30 às 15 03 23" src="https://user-images.githubusercontent.com/22639213/80743706-cda43c00-8af3-11ea-8c62-b9ee9130f9fc.png">

New:
<img width="1759" alt="Captura de Tela 2020-04-30 às 15 03 15" src="https://user-images.githubusercontent.com/22639213/80743702-caa94b80-8af3-11ea-9cb5-201989907741.png">

