### PR TITLE
Proposal metadata

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -52,7 +52,6 @@ export const makeProposal = (
   rfpLink,
   attachments = []
 ) => ({
-  // TODO: add RFPs info as metadata
   files: [
     convertMarkdownToFile(name + "\n\n" + markdown),
     ...(attachments || [])

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -3,20 +3,19 @@ import * as pki from "./pki";
 import qs from "query-string";
 import get from "lodash/fp/get";
 import MerkleTree from "./merkle";
-import { convertObjectToUnixTimestamp } from "src/utils";
 import {
   PROPOSAL_STATUS_UNREVIEWED,
   INVOICE_STATUS_UNREVIEWED,
-  DCC_STATUS_ACTIVE,
-  PROPOSAL_TYPE_RFP,
-  PROPOSAL_TYPE_RFP_SUBMISSION
+  DCC_STATUS_ACTIVE
 } from "../constants";
 import {
   getHumanReadableError,
   digestPayload,
   digest,
   objectToSHA256,
-  utoa
+  utoa,
+  objectToBuffer,
+  bufferToBase64String
 } from "../helpers";
 
 export const TOP_LEVEL_COMMENT_PARENTID = "0";
@@ -53,25 +52,29 @@ export const makeProposal = (
   rfpLink,
   attachments = []
 ) => ({
+  // TODO: add RFPs info as metadata
   files: [
     convertMarkdownToFile(name + "\n\n" + markdown),
-    convertJsonToFile(
-      {
-        linkby:
-          type === PROPOSAL_TYPE_RFP
-            ? convertObjectToUnixTimestamp(rfpDeadline)
-            : undefined,
-        linkto: type === PROPOSAL_TYPE_RFP_SUBMISSION ? rfpLink : undefined
-      },
-      "data.json"
-    ),
     ...(attachments || [])
   ].map(({ name, mime, payload }) => ({
     name,
     mime,
     payload,
     digest: digestPayload(payload)
-  }))
+  })),
+  metadata: [
+    {
+      hint: "proposalmetadata",
+      payload: bufferToBase64String(
+        objectToBuffer({
+          name
+        })
+      ),
+      digest: objectToSHA256({
+        name
+      })
+    }
+  ]
 });
 
 export const makeInvoice = (
@@ -176,7 +179,7 @@ export const makeDCCVote = (token, vote) => ({ token, vote });
 
 export const signRegister = (email, proposal) => {
   return pki.myPubKeyHex(email).then((publickey) => {
-    const digests = proposal.files
+    const digests = [...proposal.files, ...proposal.metadata]
       .map((x) => Buffer.from(get("digest", x), "hex"))
       .sort(Buffer.compare);
     const tree = new MerkleTree(digests);

--- a/src/lib/tests/api.test.js
+++ b/src/lib/tests/api.test.js
@@ -63,12 +63,6 @@ describe("api integration modules (lib/api.js)", () => {
     const fileFromMarkdown = api.convertMarkdownToFile(
       PROPOSAL_NAME + "\n\n" + MARKDOWN
     );
-    const dataJsonFile = api.convertJsonToFile(
-      {
-        linkby: undefined
-      },
-      "data.json"
-    );
     expect(proposal).toEqual({
       files: [
         {
@@ -76,12 +70,21 @@ describe("api integration modules (lib/api.js)", () => {
           digest: help.digestPayload(fileFromMarkdown.payload)
         },
         {
-          ...dataJsonFile,
-          digest: help.digestPayload(dataJsonFile.payload)
-        },
-        {
           ...FILE,
           digest: FILE_DIGESTED_PAYLOAD
+        }
+      ],
+      metadata: [
+        {
+          hint: "proposalmetadata",
+          payload: help.bufferToBase64String(
+            help.objectToBuffer({
+              name: PROPOSAL_NAME
+            })
+          ),
+          digest: help.objectToSHA256({
+            name: PROPOSAL_NAME
+          })
         }
       ]
     });
@@ -98,10 +101,19 @@ describe("api integration modules (lib/api.js)", () => {
         {
           ...fileFromMarkdown,
           digest: help.digestPayload(fileFromMarkdown.payload)
-        },
+        }
+      ],
+      metadata: [
         {
-          ...dataJsonFile,
-          digest: help.digestPayload(dataJsonFile.payload)
+          hint: "proposalmetadata",
+          payload: help.bufferToBase64String(
+            help.objectToBuffer({
+              name: PROPOSAL_NAME
+            })
+          ),
+          digest: help.objectToSHA256({
+            name: PROPOSAL_NAME
+          })
         }
       ]
     });
@@ -120,10 +132,19 @@ describe("api integration modules (lib/api.js)", () => {
         {
           ...fileFromMarkdown,
           digest: help.digestPayload(fileFromMarkdown.payload)
-        },
+        }
+      ],
+      metadata: [
         {
-          ...dataJsonFile,
-          digest: help.digestPayload(dataJsonFile.payload)
+          hint: "proposalmetadata",
+          payload: help.bufferToBase64String(
+            help.objectToBuffer({
+              name: PROPOSAL_NAME
+            })
+          ),
+          digest: help.objectToSHA256({
+            name: PROPOSAL_NAME
+          })
         }
       ]
     });


### PR DESCRIPTION
### Bug (or issue) description

This diff adds metadata prop to the posted payload for both `new proposal` & `edit proposal` routes as specified here: https://github.com/decred/politeia/pull/1175

### Solution description

adjusted `makeproposal` function to add metadata prop besides the files property and deleted `data.json` files which was added lately to support creating RFPs

#### Use Cases (if needed)

 1. Create new proposal 
 2. Edit proposal

Depends on: https://github.com/decred/politeia/pull/1175
