### PR TITLE
Fix too big buttons in invoice/dcc forms on FF

### DIFF
--- a/src/components/DccForm/DraftSaver.jsx
+++ b/src/components/DccForm/DraftSaver.jsx
@@ -52,8 +52,7 @@ const DraftSaver = ({ values, setValues, submitSuccess }) => {
 
   useEffect(
     function handleInitializeFormFromDraft() {
-      const foundDraftDcc =
-        draftDccs && draftId && draftDccs[draftId];
+      const foundDraftDcc = draftDccs && draftId && draftDccs[draftId];
       if (foundDraftDcc) {
         setValues(foundDraftDcc);
       }
@@ -63,7 +62,6 @@ const DraftSaver = ({ values, setValues, submitSuccess }) => {
   return (
     <Button
       type="button"
-      width={150}
       kind={saving || !canSaveDraft ? "disabled" : "secondary"}
       loading={saving}
       onClick={handleSave}>

--- a/src/components/InvoiceForm/DraftSaver.jsx
+++ b/src/components/InvoiceForm/DraftSaver.jsx
@@ -90,7 +90,6 @@ const DraftSaver = ({ values, setValues, submitSuccess }) => {
   return (
     <Button
       type="button"
-      width={150}
       kind={saving || !canSaveDraft ? "disabled" : "secondary"}
       loading={saving}
       onClick={handleSave}>


### PR DESCRIPTION
### Issue description
This PR refers to issue #1889, which reports that form button look *fat* on FF.

### Solution description
Deleted explicit width prop from draft button

### UI Changes Screenshot
After - check #1889  out for before screenshot:
![image](https://user-images.githubusercontent.com/10324528/80798028-a4db7f80-8ba3-11ea-8550-fc843858402d.png)

Fixes #1889 