### PR TITLE
Add husky.hooks to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,11 @@
     "lint": "./node_modules/.bin/eslint src --ext .js --ext .jsx",
     "precommit": "lint-staged"
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
   "lint-staged": {
     "*.{js, jsx}": [
       "yarn prettify",

--- a/src/lib/tests/api.test.js
+++ b/src/lib/tests/api.test.js
@@ -63,12 +63,6 @@ describe("api integration modules (lib/api.js)", () => {
     const fileFromMarkdown = api.convertMarkdownToFile(
       PROPOSAL_NAME + "\n\n" + MARKDOWN
     );
-    const dataJsonFile = api.convertJsonToFile(
-      {
-        linkby: undefined
-      },
-      "data.json"
-    );
     expect(proposal).toEqual({
       files: [
         {
@@ -76,12 +70,21 @@ describe("api integration modules (lib/api.js)", () => {
           digest: help.digestPayload(fileFromMarkdown.payload)
         },
         {
-          ...dataJsonFile,
-          digest: help.digestPayload(dataJsonFile.payload)
-        },
-        {
           ...FILE,
           digest: FILE_DIGESTED_PAYLOAD
+        }
+      ],
+      metadata: [
+        {
+          hint: "proposalmetadata",
+          payload: help.bufferToBase64String(
+            help.objectToBuffer({
+              name: PROPOSAL_NAME
+            })
+          ),
+          digest: help.objectToSHA256({
+            name: PROPOSAL_NAME
+          })
         }
       ]
     });
@@ -98,10 +101,19 @@ describe("api integration modules (lib/api.js)", () => {
         {
           ...fileFromMarkdown,
           digest: help.digestPayload(fileFromMarkdown.payload)
-        },
+        }
+      ],
+      metadata: [
         {
-          ...dataJsonFile,
-          digest: help.digestPayload(dataJsonFile.payload)
+          hint: "proposalmetadata",
+          payload: help.bufferToBase64String(
+            help.objectToBuffer({
+              name: PROPOSAL_NAME
+            })
+          ),
+          digest: help.objectToSHA256({
+            name: PROPOSAL_NAME
+          })
         }
       ]
     });
@@ -120,10 +132,19 @@ describe("api integration modules (lib/api.js)", () => {
         {
           ...fileFromMarkdown,
           digest: help.digestPayload(fileFromMarkdown.payload)
-        },
+        }
+      ],
+      metadata: [
         {
-          ...dataJsonFile,
-          digest: help.digestPayload(dataJsonFile.payload)
+          hint: "proposalmetadata",
+          payload: help.bufferToBase64String(
+            help.objectToBuffer({
+              name: PROPOSAL_NAME
+            })
+          ),
+          digest: help.objectToSHA256({
+            name: PROPOSAL_NAME
+          })
         }
       ]
     });


### PR DESCRIPTION
This diff resolves the warning regarding `husky` pre-commit hook - see #1891 

### Solution description
Added `husky.hooks` to `package.json` as suggested in the same warning message!

Fixes #1891 
