### PR TITLE
Add husky.hooks to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "build-staging": "REACT_APP_STAGING=true react-app-rewired build",
     "test": "react-app-rewired test --env=jsdom",
     "eject": "react-app-rewired eject",
-    "prettify": "prettier --write 'src/**/*.{js,css,json}'",
+    "prettify": "prettier --write 'src/**/*.{js,jsx,css,json}'",
     "lint": "./node_modules/.bin/eslint src --ext .js --ext .jsx"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,11 @@
     "lint": "./node_modules/.bin/eslint src --ext .js --ext .jsx",
     "precommit": "lint-staged"
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
   "lint-staged": {
     "*.{js, jsx}": [
       "yarn prettify",

--- a/package.json
+++ b/package.json
@@ -62,8 +62,7 @@
     "test": "react-app-rewired test --env=jsdom",
     "eject": "react-app-rewired eject",
     "prettify": "prettier --write 'src/**/*.{js,css,json}'",
-    "lint": "./node_modules/.bin/eslint src --ext .js --ext .jsx",
-    "precommit": "lint-staged"
+    "lint": "./node_modules/.bin/eslint src --ext .js --ext .jsx"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
This diff resolves the warning regarding `husky` pre-commit hook - see #1891 

### Solution description
Added `husky.hooks` to `package.json` as suggested in the same warning message!

Fixes #1891 
