### PR TITLE
Fix signRegister function for records with no metadata/invoices

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -177,6 +177,9 @@ export const makeDCC = (
 export const makeDCCVote = (token, vote) => ({ token, vote });
 
 export const signRegister = (email, record) => {
+  if (typeof email !== "string" || typeof record !== "object") {
+    throw Error("signRegister: Invalid params");
+  }
   return pki.myPubKeyHex(email).then((publickey) => {
     const digests = [...record.files, ...(record.metadata || [])]
       .map((x) => Buffer.from(get("digest", x), "hex"))

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -176,16 +176,16 @@ export const makeDCC = (
 
 export const makeDCCVote = (token, vote) => ({ token, vote });
 
-export const signRegister = (email, proposal) => {
+export const signRegister = (email, record) => {
   return pki.myPubKeyHex(email).then((publickey) => {
-    const digests = [...proposal.files, ...proposal.metadata]
+    const digests = [...record.files, ...(record.metadata || [])]
       .map((x) => Buffer.from(get("digest", x), "hex"))
       .sort(Buffer.compare);
     const tree = new MerkleTree(digests);
     const root = tree.getRoot().toString("hex");
     return pki
       .signStringHex(email, root)
-      .then((signature) => ({ ...proposal, publickey, signature }));
+      .then((signature) => ({ ...record, publickey, signature }));
   });
 };
 


### PR DESCRIPTION
### Bug description
This diff fixes a bug that blocked invoices from being submitted because of missing `metadata` prop which was added lately for proposals

### Solution description
*conditionally* append `record.metadata` property to `digests` array & better function signature, 