### PR TITLE
[pi-ui] Use ThemeProvider's new fonts array prop

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -16,18 +16,38 @@ import SourceSansProLight from "src/assets/fonts/source-sans-pro/SourceSansPro-L
 import SourceSansProRegular from "src/assets/fonts/source-sans-pro/SourceSansPro-Regular.ttf";
 import SourceSansProSemiBold from "src/assets/fonts/source-sans-pro/SourceSansPro-SemiBold.ttf";
 
-const fontConfig = {
-  fontFamilyText: "Source Sans Pro",
-  regularUrl: SourceSansProRegular,
-  semiBoldUrl: SourceSansProSemiBold,
-  lightUrl: SourceSansProLight,
-  format: "truetype"
+const themeCustomVariables = {
+  "font-family-text": "Source Sans Pro"
 };
 
 const themes = {
-  light: defaultLightTheme,
-  dark: defaultDarkTheme
+  light: { ...defaultLightTheme, ...themeCustomVariables },
+  dark: { ...defaultDarkTheme, ...themeCustomVariables }
 };
+
+const fonts = [
+  {
+    "font-family": "Source Sans Pro",
+    src: `url(${SourceSansProLight}) format("truetype")`,
+    "font-weight": defaultLightTheme["font-weight-light"],
+    "font-style": "normal",
+    "font-display": "swap"
+  },
+  {
+    "font-family": "Source Sans Pro",
+    src: `url(${SourceSansProRegular}) format("truetype")`,
+    "font-weight": defaultLightTheme["font-weight-regular"],
+    "font-style": "normal",
+    "font-display": "swap"
+  },
+  {
+    "font-family": "Source Sans Pro",
+    src: `url(${SourceSansProSemiBold}) format("truetype")`,
+    "font-weight": defaultLightTheme["font-weight-semi-bold"],
+    "font-style": "normal",
+    "font-display": "swap"
+  }
+];
 
 const App = () => {
   // This is a temporary fix to avoid an issue during the tests
@@ -36,10 +56,7 @@ const App = () => {
   }
 
   return (
-    <ThemeProvider
-      themes={themes}
-      defaultThemeName="light"
-      fontConfig={fontConfig}>
+    <ThemeProvider themes={themes} defaultThemeName="light" fonts={fonts}>
       <Config>
         <ReduxProvider>
           <Loader>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8937,7 +8937,7 @@ performance-now@^2.1.0:
 
 "pi-ui@https://github.com/decred/pi-ui":
   version "1.0.0"
-  resolved "https://github.com/decred/pi-ui#45830c9e2fa94658cf958775be70aa2302213d5d"
+  resolved "https://github.com/decred/pi-ui#0b390b5a574a6c05368256e12abb50dcd280eddc"
   dependencies:
     clamp-js-main "^0.11.5"
     react-select "2.4.4"


### PR DESCRIPTION
### Use ThemeProvider's new fonts array prop

Lately we started with integrating pi-ui into decrediton and we are using `ThemeProvider` to provide it's themes variables and we would like to provide the fonts using `ThemeProvider`.

Before this diff we used to provider fontConfig from `pigui` using the following object:
```
const fontConfig = {
  fontFamilyText: "Source Sans Pro",
  regularUrl: SourceSansProRegular,
  semiBoldUrl: SourceSansProSemiBold,
  lightUrl: SourceSansProLight,
  format: "truetype"
};
```
The above object is pretty limiting in case we have multiple fonts which is the case in decrediton. 
In order to make it as generic as possible I've replaced `fontConfig` object with `fonts` array which should look something similar to:
```
const fonts = [
  {
    "font-family": "Source Sans Pro",
    src: `url(${SourceSansProLight}) format("truetype")`,
    "font-weight": defaultLightTheme["font-weight-light"],
    "font-style": "normal",
    "font-display": "swap"
  },
  {
    "font-family": "Source Sans Pro",
    src: `url(${SourceSansProRegular}) format("truetype")`,
    "font-weight": defaultLightTheme["font-weight-regular"],
    "font-style": "normal",
    "font-display": "swap"
  },
  {
    "font-family": "Source Sans Pro",
    src: `url(${SourceSansProSemiBold}) format("truetype")`,
    "font-weight": defaultLightTheme["font-weight-semi-bold"],
    "font-style": "normal",
    "font-display": "swap"
  }
];
```

With that we would be able to provide fonts arrays in `pigui` & `decrediton` without limiting the font configuration to some font-weight, or font-style!

### Solution description
Replaced old `fontConfig` with new `fonts` array prop.

### Dependencies
Depends on: https://github.com/decred/pi-ui/pull/254
