### PR TITLE
[cms] Fix DCC support/oppose buttons overflow

### DIFF
--- a/src/components/DCC/DCC.module.css
+++ b/src/components/DCC/DCC.module.css
@@ -23,7 +23,6 @@ span.statusTag > span {
 }
 
 .supportOpposeButtons {
-  float: right;
   padding-bottom: 1rem;
 }
 


### PR DESCRIPTION
### Bug (or issue) description
DCC Support/oppose buttons were displayed on a weird way, as described on #1904 .

### Solution description

Removed the `float` property on support/oppose buttons styles

### UI Changes Screenshot

Old:
![](https://user-images.githubusercontent.com/14864439/81259302-f36f9a80-9037-11ea-9003-18c4e548da4e.png)

New:
<img width="1398" alt="Captura de Tela 2020-05-07 às 21 31 21" src="https://user-images.githubusercontent.com/22639213/81357478-1f2b6880-90aa-11ea-8cb3-eae1ee32ecf8.png">

Closes #1904 