### PR TITLE
fix error feedback

### DIFF
--- a/src/components/ModalConfirm.jsx
+++ b/src/components/ModalConfirm.jsx
@@ -13,7 +13,6 @@ const ModalConfirm = ({
   successMessage
 }) => {
   const [success, setSuccess] = useState(false);
-  const [isSubmitting, setSubmitting] = useState(false);
 
   const { theme } = useTheme();
   const successIconBgColor = getThemeProperty(
@@ -25,16 +24,17 @@ const ModalConfirm = ({
     "success-icon-checkmark-color"
   );
 
-  const onSubmitForm = async (_, { resetForm, setFieldError }) => {
-    setSubmitting(true);
+  const onSubmitForm = async (
+    _,
+    { resetForm, setFieldError, setSubmitting }
+  ) => {
     try {
       await onSubmit();
       resetForm();
-      setSubmitting(false);
       setSuccess(true);
     } catch (e) {
-      setSubmitting(false);
       setFieldError("global", e);
+      setSubmitting(false);
     }
   };
   useEffect(
@@ -49,7 +49,6 @@ const ModalConfirm = ({
   return (
     <Modal
       style={{ width: "600px" }}
-      disableClose={isSubmitting}
       title={(success && successTitle) || title}
       show={show}
       onClose={onClose}
@@ -67,19 +66,28 @@ const ModalConfirm = ({
       }>
       {!success && (
         <FormWrapper initialValues={{}} onSubmit={onSubmitForm}>
-          {({ Form, Actions, ErrorMessage, handleSubmit, errors }) => (
-            <Form onSubmit={handleSubmit}>
-              {errors && errors.global && (
-                <ErrorMessage>{errors.global.toString()}</ErrorMessage>
-              )}
-              <Text>{message}</Text>
-              <Actions className="no-padding-bottom">
-                <Button loading={isSubmitting} type="submit">
-                  Confirm
-                </Button>
-              </Actions>
-            </Form>
-          )}
+          {({
+            Form,
+            Actions,
+            ErrorMessage,
+            handleSubmit,
+            errors,
+            isSubmitting
+          }) => {
+            return (
+              <Form onSubmit={handleSubmit}>
+                {errors && errors.global && (
+                  <ErrorMessage>{errors.global.toString()}</ErrorMessage>
+                )}
+                <Text>{message}</Text>
+                <Actions className="no-padding-bottom">
+                  <Button loading={isSubmitting} type="submit">
+                    Confirm
+                  </Button>
+                </Actions>
+              </Form>
+            );
+          }}
         </FormWrapper>
       )}
       {success && (

--- a/src/components/ModalConfirmWithReason.jsx
+++ b/src/components/ModalConfirmWithReason.jsx
@@ -23,14 +23,14 @@ const ModalConfirmWithReason = ({
   successTitle
 }) => {
   const [success, setSuccess] = useState(false);
-  const [isSubmitting, setSubmitting] = useState(false);
 
-  const onSubmitReason = async (values, { resetForm, setFieldError }) => {
-    setSubmitting(true);
+  const onSubmitReason = async (
+    values,
+    { resetForm, setFieldError, setSubmitting }
+  ) => {
     try {
       await onSubmit(values.reason);
       resetForm();
-      setSubmitting(false);
       setSuccess(true);
     } catch (e) {
       setSubmitting(false);
@@ -56,7 +56,6 @@ const ModalConfirmWithReason = ({
   return (
     <Modal
       style={{ width: "600px" }}
-      disableClose={isSubmitting}
       title={(success && successTitle) || title}
       show={show}
       onClose={onClose}
@@ -95,7 +94,8 @@ const ModalConfirmWithReason = ({
             handleBlur,
             handleSubmit,
             errors,
-            touched
+            touched,
+            isSubmitting
           }) => (
             <Form onSubmit={handleSubmit}>
               {errors && errors.global && (

--- a/src/components/ModalStartVote/ModalStartVote.jsx
+++ b/src/components/ModalStartVote/ModalStartVote.jsx
@@ -36,7 +36,6 @@ const ModalStartVote = ({
   voteType
 }) => {
   const [success, setSuccess] = useState(false);
-  const [isSubmitting, setSubmitting] = useState(false);
   const { apiInfo } = useLoaderContext();
   const { theme } = useTheme();
   const {
@@ -50,8 +49,10 @@ const ModalStartVote = ({
     theme,
     "success-icon-checkmark-color"
   );
-  const onSubmitStartVote = async (values, { resetForm, setFieldError }) => {
-    setSubmitting(true);
+  const onSubmitStartVote = async (
+    values,
+    { resetForm, setFieldError, setSubmitting }
+  ) => {
     try {
       const { linkby } = proposal;
       const isRfp = !!linkby;
@@ -66,7 +67,6 @@ const ModalStartVote = ({
       }
       await onSubmit(values);
       resetForm();
-      setSubmitting(false);
       setSuccess(true);
     } catch (e) {
       setSubmitting(false);
@@ -92,7 +92,6 @@ const ModalStartVote = ({
   return (
     <Modal
       style={{ width: "600px" }}
-      disableClose={isSubmitting}
       title={(success && successTitle) || title}
       show={show}
       onClose={onClose}
@@ -125,6 +124,7 @@ const ModalStartVote = ({
             handleSubmit,
             setFieldValue,
             errors,
+            isSubmitting,
             touched
           }) => {
             const handleChangeDuration = (v) =>

--- a/src/containers/User/Invite/ModalnviteContractor.jsx
+++ b/src/containers/User/Invite/ModalnviteContractor.jsx
@@ -8,15 +8,15 @@ import { useInviteContractor } from "./hooks";
 
 const ModalInviteContractor = ({ show, onClose }) => {
   const [success, setSuccess] = useState(false);
-  const [isSubmitting, setSubmitting] = useState(false);
   const { onInviteContractor } = useInviteContractor();
 
-  const onInvite = async (values, { resetForm, setFieldError }) => {
-    setSubmitting(true);
+  const onInvite = async (
+    values,
+    { resetForm, setFieldError, setSubmitting }
+  ) => {
     try {
       await onInviteContractor(values);
       resetForm();
-      setSubmitting(false);
       setSuccess(true);
     } catch (e) {
       setSubmitting(false);
@@ -42,7 +42,6 @@ const ModalInviteContractor = ({ show, onClose }) => {
   return (
     <Modal
       style={{ width: "600px" }}
-      disableClose={isSubmitting}
       title={success ? "Invite sent!" : "Invite Contractor"}
       show={show}
       onClose={onClose}
@@ -72,6 +71,7 @@ const ModalInviteContractor = ({ show, onClose }) => {
             handleBlur,
             handleSubmit,
             errors,
+            isSubmitting,
             touched
           }) => (
             <Form onSubmit={handleSubmit}>


### PR DESCRIPTION
### Bug (or issue) description

This PR closes https://github.com/decred/politeiagui/issues/1913

### Solution description

I decided to use the Formik `setSubmitting` action and `isSubmitting` flag instead of doing it inside the custom modal component. Notice that we only have to call the `setSubmitting` imperatively if the promise rejects (see https://github.com/jaredpalmer/formik/issues/739).
 
**Before**

![no_error_feedback](https://user-images.githubusercontent.com/13955303/81591662-2943b480-9393-11ea-9f67-fe89ebba08c6.gif)


**After**

![fix](https://user-images.githubusercontent.com/13955303/81591689-3496e000-9393-11ea-9bbf-efa9c74d21b0.gif)

