### PR TITLE
[cms] Add user invoices tab on account page

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -279,10 +279,10 @@ export const onChangePassword = (password, newPassword) =>
       });
   });
 
-export const onFetchUserInvoices = (userid, token) => (dispatch) => {
+export const onFetchUserInvoices = () => (dispatch) => {
   dispatch(act.REQUEST_USER_INVOICES());
   return api
-    .userInvoices(userid, token)
+    .userInvoices()
     .then((response) => dispatch(act.RECEIVE_USER_INVOICES(response)))
     .catch((error) => {
       dispatch(act.RECEIVE_USER_INVOICES(null, error));

--- a/src/containers/Invoice/Admin/Admin.jsx
+++ b/src/containers/Invoice/Admin/Admin.jsx
@@ -1,0 +1,53 @@
+import React, { useCallback } from "react";
+import { Spinner } from "pi-ui";
+import { AdminInvoiceActionsProvider } from "src/containers/Invoice/Actions";
+import Invoice from "src/components/Invoice";
+import { useAdminInvoices } from "./hooks";
+import HelpMessage from "src/components/HelpMessage";
+import styles from "./Admin.module.css";
+
+const InvoicesAdmin = ({ userID }) => {
+  const { loading, invoices } = useAdminInvoices();
+  const userInovices = invoices.filter((inv) => 
+    inv.userid === userID
+  );
+  const renderInvoice = useCallback(
+    (invoice) => (
+      <Invoice
+        key={`invoice-${invoice.censorshiprecord.token}`}
+        invoice={invoice}
+      />
+    ),
+    []
+  );
+  const renderInvoices = useCallback(
+    (invoices) => invoices.map(renderInvoice),
+    [renderInvoice]
+  );
+  const renderEmptyMessage = useCallback(
+    (invoices) =>
+      !invoices.length && (
+        <HelpMessage>
+          {"There are no invoices submitted by this user."}
+        </HelpMessage>
+      ),
+    []
+  );
+  return (
+    <AdminInvoiceActionsProvider>
+      {loading && (
+        <div className={styles.spinnerWrapper}>
+          <Spinner invert />
+        </div>
+      )}
+      {!loading && (
+        <>
+          {renderEmptyMessage(userInovices)}
+          {renderInvoices(userInovices)}
+        </>
+      )}
+    </AdminInvoiceActionsProvider>
+  );
+};
+
+export default InvoicesAdmin;

--- a/src/containers/Invoice/Admin/Admin.jsx
+++ b/src/containers/Invoice/Admin/Admin.jsx
@@ -8,7 +8,7 @@ import styles from "./Admin.module.css";
 
 const InvoicesAdmin = ({ userID }) => {
   const { loading, invoices } = useAdminInvoices();
-  const userInovices = invoices.filter((inv) => 
+  const userInovices = invoices.filter((inv) =>
     inv.userid === userID
   );
   const renderInvoice = useCallback(

--- a/src/containers/Invoice/Admin/Admin.module.css
+++ b/src/containers/Invoice/Admin/Admin.module.css
@@ -1,0 +1,6 @@
+.spinnerWrapper {
+  display: flex;
+  height: 50%;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/containers/Invoice/Admin/index.js
+++ b/src/containers/Invoice/Admin/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Admin";

--- a/src/containers/Invoice/User/hooks.js
+++ b/src/containers/Invoice/User/hooks.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import * as sel from "src/selectors";
 import * as act from "src/actions";
 import { useAction, useSelector, useStoreSubscribe } from "src/redux";
@@ -6,8 +6,13 @@ import useAPIAction from "src/hooks/utils/useAPIAction";
 import useThrowError from "src/hooks/utils/useThrowError";
 import { handleSaveAppDraftInvoices } from "src/lib/local_storage";
 
-export function useUserInvoices() {
-  const invoices = useSelector(sel.getCurrentUserInvoices);
+export function useUserInvoices(userid) {
+  const currentUserID = useSelector(sel.currentUserID);
+  const userID = userid || currentUserID;
+  const invoicesSelector = useMemo(() => sel.makeGetInvoicesByUserID(userID), [
+    userID
+  ]);
+  const invoices = useSelector(invoicesSelector);
   const onFetchUserInvoices = useAction(act.onFetchUserInvoices);
 
   const [loading, error] = useAPIAction(onFetchUserInvoices);

--- a/src/containers/User/Detail/Detail.jsx
+++ b/src/containers/User/Detail/Detail.jsx
@@ -4,6 +4,7 @@ import { withRouter } from "react-router-dom";
 import ModalChangeUsername from "src/components/ModalChangeUsername";
 import { PUB_KEY_STATUS_LOADED, PUB_KEY_STATUS_LOADING } from "src/constants";
 import UserProposals from "src/containers/Proposal/User";
+import AdminInvoices from "src/containers/Invoice/Admin";
 import useUserIdentity from "src/hooks/api/useUserIdentity";
 import useQueryStringWithIndexValue from "src/hooks/utils/useQueryStringWithIndexValue";
 import useUserDetail from "src/hooks/api/useUserDetail";
@@ -35,6 +36,7 @@ const getTabComponents = ({ user, ...rest }) => {
         withDrafts={rest.isUserPageOwner}
       />
     ),
+    [tabValues.INVOICES]: <AdminInvoices userID={user.userid} />,
     [tabValues.DRAFTS]: <Drafts key="tab-invoices" />,
     [tabValues.MANAGE_DCC]: <ManageContractor userID={user.userid} {...rest} />
   };
@@ -71,6 +73,7 @@ const UserDetail = ({
       if (tabLabel === tabValues.PREFERENCES && !isUserPageOwner) return true;
       if (tabLabel === tabValues.CREDITS && !isAdminOrTheUser) return true;
       if (tabLabel === tabValues.MANAGE_DCC && !isAdminOrTheUser) return true;
+      if (tabLabel === tabValues.INVOICES && !isAdmin) return true;
 
       return false;
     };
@@ -84,7 +87,9 @@ const UserDetail = ({
       }
       if (recordType === RECORD_TYPE_PROPOSAL) {
         return (
-          tabLabel !== tabValues.MANAGE_DCC && tabLabel !== tabValues.DRAFTS
+          tabLabel !== tabValues.MANAGE_DCC &&
+          tabLabel !== tabValues.DRAFTS &&
+          tabLabel !== tabValues.INVOICES
         );
       }
       return true;
@@ -95,12 +100,14 @@ const UserDetail = ({
       tabValues.PREFERENCES,
       tabValues.CREDITS,
       tabValues.PROPOSALS,
+      tabValues.INVOICES,
       tabValues.DRAFTS,
       tabValues.MANAGE_DCC
     ].filter((tab) => !isTabDisabled(tab) && filterByRecordType(tab));
   }, [
     isUserPageOwner,
     isAdminOrTheUser,
+    isAdmin,
     RECORD_TYPE_INVOICE,
     RECORD_TYPE_PROPOSAL,
     recordType

--- a/src/containers/User/Detail/helpers.js
+++ b/src/containers/User/Detail/helpers.js
@@ -4,6 +4,7 @@ export const tabValues = {
   PREFERENCES: "Preferences",
   CREDITS: "Credits",
   PROPOSALS: "Proposals",
+  INVOICES: "Invoices",
   DRAFTS: "Drafts",
   MANAGE_DCC: "Manage Contractor"
 };


### PR DESCRIPTION
### Bug (or issue) description

We need a user invoice tab on the account page to ease reviews for the admins.

Closes #1905 

### Solution description

User invoice tab on the user's account page. This tab is only available for admins, since the dashboard of cms is already dedicated to the user's invoices. This is meant to facilitate the review process.

### UI Changes Screenshot

![Screenshot from 2020-05-12 19-38-56](https://user-images.githubusercontent.com/2729122/81752653-48703e00-9488-11ea-8614-2ad62dde49bb.png)