### PR TITLE
Fix paywallpayment calls overkill

### DIFF
--- a/src/containers/User/Detail/Credits/hooks.js
+++ b/src/containers/User/Detail/Credits/hooks.js
@@ -73,9 +73,6 @@ export function useCredits(userID) {
   const onPurchaseProposalCredits = useAction(
     act.onFetchProposalPaywallDetails
   );
-  const onFetchProposalPaywallPayment = useAction(
-    act.onFetchProposalPaywallPayment
-  );
   const onPollProposalPaywallPayment = useAction(
     act.onPollProposalPaywallPayment
   );
@@ -122,24 +119,6 @@ export function useCredits(userID) {
       onUserProposalCredits();
     }
   }, [shouldFetchProposalCredits, onUserProposalCredits]);
-
-  useEffect(() => {
-    if (!pollingCreditsPayment && proposalPaywallPaymentTxid) {
-      toggleCreditsPaymentPolling(true);
-      onPollProposalPaywallPayment(false);
-    }
-  }, [
-    pollingCreditsPayment,
-    proposalPaywallPaymentTxid,
-    toggleCreditsPaymentPolling,
-    onPollProposalPaywallPayment
-  ]);
-
-  useEffect(() => {
-    if (!proposalPaywallPaymentTxid) {
-      onFetchProposalPaywallPayment();
-    }
-  }, [proposalPaywallPaymentTxid, onFetchProposalPaywallPayment]);
 
   return {
     proposalCreditPrice,


### PR DESCRIPTION
This diff fixes the bug reported in #1875 & https://github.com/decred/politeiagui/pull/1910#pullrequestreview-410550124 - paywallpayment route calls overkill even in new proposal page.

### Solution description
I've compared #1483 with #1844 and have found an extra call in `useCredits` to start paywallpayment polling, this is already handled in the components and should be called again inside the custom hook.

#### Use Cases (if needed)
I've tested the following:
 - No calls are triggered in any page only when user navigate to credits page we start polling
 - After 6 calls if no txid isn't provided we stop polling
 - When `Purchase more` button is clicked we start poll tell we get 2 confirmations.


### Dependencies
Closes #1875 
