### PR TITLE
Remove extra colon in Account page

### DIFF
--- a/src/containers/User/Detail/Account/AdminAccount.jsx
+++ b/src/containers/User/Detail/Account/AdminAccount.jsx
@@ -190,7 +190,7 @@ const AdminAccount = ({
             Password
           </Text>
           <InfoSection
-            label="Reset password token:"
+            label="Reset password token"
             info={resetpasswordverificationtoken}
           />
           <InfoSection
@@ -221,7 +221,7 @@ const AdminAccount = ({
             Verification token
           </Text>
           <InfoSection
-            label="Verification token:"
+            label="Verification token"
             info={newuserverificationtoken}
           />
           <InfoSection
@@ -252,7 +252,7 @@ const AdminAccount = ({
             Update key
           </Text>
           <InfoSection
-            label="Update key token:"
+            label="Update key token"
             info={updatekeyverificationtoken}
           />
           <InfoSection

--- a/src/containers/User/Detail/Account/AdminAccount.jsx
+++ b/src/containers/User/Detail/Account/AdminAccount.jsx
@@ -161,10 +161,10 @@ const AdminAccount = ({
       <Text weight="semibold" className={styles.subtitle}>
         Security
       </Text>
-      <InfoSection label="Failed login attempts:" info={failedloginattempts} />
+      <InfoSection label="Failed login attempts" info={failedloginattempts} />
       <InfoSection
         noMargin
-        label="Locked:"
+        label="Locked"
         info={isUserLocked(islocked) ? "Yes" : "No"}
       />
       {!isUserDeactivated(isdeactivated) ? (

--- a/src/containers/User/Detail/Account/AdminAccount.jsx
+++ b/src/containers/User/Detail/Account/AdminAccount.jsx
@@ -195,7 +195,7 @@ const AdminAccount = ({
           />
           <InfoSection
             noMargin
-            label="Expires:"
+            label="Expires"
             info={
               isExpired(resetpasswordverificationexpiry) ? (
                 <span>Expired</span>
@@ -226,7 +226,7 @@ const AdminAccount = ({
           />
           <InfoSection
             noMargin
-            label="Expires:"
+            label="Expires"
             info={
               isExpired(newuserverificationexpiry) ? (
                 <span>Expired</span>
@@ -257,7 +257,7 @@ const AdminAccount = ({
           />
           <InfoSection
             noMargin
-            label="Expires:"
+            label="Expires"
             info={
               isExpired(updatekeyverificationexpiry) ? (
                 <span>Expired</span>

--- a/src/containers/User/Detail/Account/OtherAccount.jsx
+++ b/src/containers/User/Detail/Account/OtherAccount.jsx
@@ -10,7 +10,7 @@ const OtherAccount = ({
   <Card className={classNames("container", "margin-bottom-m")}>
     <InfoSection
       className="no-margin-top"
-      label="Admin:"
+      label="Admin"
       info={isUserAdmin(isadmin) ? "Yes" : "No"}
     />
   </Card>

--- a/src/containers/User/Detail/Account/components/AddressSection.jsx
+++ b/src/containers/User/Detail/Account/components/AddressSection.jsx
@@ -3,7 +3,7 @@ import InfoSection from "../../InfoSection.jsx";
 
 export default ({ address }) => (
   <InfoSection
-    label="Address:"
+    label="Address"
     info={<span style={{ wordBreak: "break-word" }}>{address}</span>}
   />
 );

--- a/src/containers/User/Detail/Account/components/AdminSection.jsx
+++ b/src/containers/User/Detail/Account/components/AdminSection.jsx
@@ -5,7 +5,7 @@ import InfoSection from "../../InfoSection.jsx";
 export default ({ isadmin }) => (
   <InfoSection
     className="no-margin-top"
-    label="Admin:"
+    label="Admin"
     info={isUserAdmin(isadmin) ? "Yes" : "No"}
   />
 );

--- a/src/containers/User/Detail/Account/components/EmailSection.jsx
+++ b/src/containers/User/Detail/Account/components/EmailSection.jsx
@@ -4,7 +4,7 @@ import InfoSection from "../../InfoSection.jsx";
 
 export default ({ token }) => (
   <InfoSection
-    label="Verified email:"
+    label="Verified email"
     info={isUserEmailVerified(token) ? "Yes" : "No"}
   />
 );

--- a/src/containers/User/Detail/Account/components/PasswordSection.jsx
+++ b/src/containers/User/Detail/Account/components/PasswordSection.jsx
@@ -4,7 +4,7 @@ import { Button } from "pi-ui";
 
 export default ({ onClick }) => (
   <InfoSection
-    label="Password:"
+    label="Password"
     alignLabelCenter
     info={
       <Button size="sm" onClick={onClick}>

--- a/src/containers/User/Detail/Account/components/PaywallSection.jsx
+++ b/src/containers/User/Detail/Account/components/PaywallSection.jsx
@@ -4,7 +4,7 @@ import InfoSection from "../../InfoSection.jsx";
 
 export default ({ amount, timestamp }) => (
   <>
-    <InfoSection label="Amount:" info={`${convertAtomsToDcr(amount)} DCR`} />
-    <InfoSection label="Pay after:" info={formatUnixTimestamp(timestamp)} />
+    <InfoSection label="Amount" info={`${convertAtomsToDcr(amount)} DCR`} />
+    <InfoSection label="Pay after" info={formatUnixTimestamp(timestamp)} />
   </>
 );


### PR DESCRIPTION
This diff closes #1911 - in the Account page, remove extra colon in all labels.

### Solution description

Remove extra colon to just leave one.

### UI Changes Screenshot

Before diff:
<img width="511" alt="before" src="https://user-images.githubusercontent.com/3491087/82612354-f84d5600-9bc2-11ea-8fa0-b8d2e828b31e.png">

After diff:
<img width="532" alt="after" src="https://user-images.githubusercontent.com/3491087/82612377-04391800-9bc3-11ea-9c6e-043706d05854.png">


