### PR TITLE
[cms] Fix Supervisor ID's list

### DIFF
--- a/src/containers/User/Detail/ManageContractor/helpers.js
+++ b/src/containers/User/Detail/ManageContractor/helpers.js
@@ -30,3 +30,13 @@ export const selectDomainOptions = domainOptions.map((op, idx) => ({
   value: idx,
   label: op
 }));
+
+export const getSupervisorsOptions = (supervisors, currentUserID) =>
+  supervisors &&
+  Array.isArray(supervisors) &&
+  supervisors
+    .filter(({ id }) => id !== currentUserID)
+    .map(({ username, id }) => ({
+      label: username,
+      value: id
+    }));

--- a/src/hooks/api/useSupervisors.js
+++ b/src/hooks/api/useSupervisors.js
@@ -1,0 +1,15 @@
+import * as sel from "src/selectors";
+import * as act from "src/actions";
+import { useAction, useSelector } from "src/redux";
+import { CONTRACTOR_TYPE_SUPERVISOR } from "src/containers/DCC";
+import useAPIAction from "src/hooks/utils/useAPIAction";
+
+export default function useSupervisors() {
+  const onFetchUsers = useAction(act.onFetchCmsUsers);
+  const supervisors = useSelector(
+    sel.makeGetUsersByContractorTypes(CONTRACTOR_TYPE_SUPERVISOR)
+  );
+  const [loading, error] = useAPIAction(onFetchUsers);
+
+  return { supervisors, loading, error };
+}


### PR DESCRIPTION
This diff closes #1937 issue, which reported a bug with the supervisor ids selector on Manage Contractor form. No options were being shown.

### Solution description

The list of supervisors options was empty because it was getting information from user's supervisor list, not the supervisors list available on the CMS platform. The solution is: create a `useSupervisors` hook to fetch all supervisors (since this can only be performed by admins) and populate the selector's options to display them.

#### Use Cases (if needed)

The `useSupervisors` hook can be used for fetching supervisors.

### UI Changes Screenshot

Before:
<img width="1022" alt="Captura de Tela 2020-05-26 às 00 21 02" src="https://user-images.githubusercontent.com/22639213/82857233-d3b8ed00-9ee6-11ea-88fb-47c0016172e7.png">

After:
<img width="1020" alt="Captura de Tela 2020-05-26 às 00 20 26" src="https://user-images.githubusercontent.com/22639213/82857247-dc112800-9ee6-11ea-90d7-c8d24c948894.png">

