### PR TITLE
Add Timeout for Comments Anchoring

### DIFF
--- a/src/containers/Comments/Comments.jsx
+++ b/src/containers/Comments/Comments.jsx
@@ -235,9 +235,7 @@ const Comments = ({
       if (isAnchoring) {
         timeout = setTimeout(handleToggleAnchoring, ANCHORING_TIMEOUT_MS);
       }
-      return () => {
-        if (timeout) clearTimeout(timeout);
-      };
+      return () => timeout && clearTimeout(timeout);
     },
     [isAnchoring, handleToggleAnchoring]
   );
@@ -247,9 +245,7 @@ const Comments = ({
       if (!isAnchoring) {
         timeout = setTimeout(handleToggleAnchoring, getTimeLeftToAnchor());
       }
-      return () => {
-        if (timeout) clearTimeout(timeout);
-      };
+      return () => timeout && clearTimeout(timeout);
     },
     [isAnchoring, handleToggleAnchoring]
   );


### PR DESCRIPTION
This diff Closes #1941 issue, which demands the addition of a 5 minutes timeout on minute 58 of every hour.

### Solution description

The solution is basically to check for the current browser time, and if its `minutes + seconds + milliseconds` are greater than 58 minutes. If so, block comments and display the following warning message:
> Commenting temporarily unavailable while an hourly censorship resistance routine is in progress. Sorry for the inconvenience. This will be fixed soon. Check back in 5 minutes.

One thing that is added by this diff is the real time handler for this warning, since users can comment while navigating on the screen. It shows up on minute 58, and disappears 5 minutes later.


### UI Changes Screenshot
When comments are blocked due to comments anchoring:

- Light Mode: <img width="1075" alt="Captura de Tela 2020-05-26 às 20 16 01" src="https://user-images.githubusercontent.com/22639213/82956352-00244600-9f87-11ea-9140-7672f16c5d91.png">

- Dark Mode: <img width="1074" alt="Captura de Tela 2020-05-26 às 20 16 10" src="https://user-images.githubusercontent.com/22639213/82956394-13371600-9f87-11ea-9939-60dbc2ba5f11.png">

