### PR TITLE
Set pihostname from docker env [nojs]

### DIFF
--- a/nojavascript/Nginx/Dockerfile
+++ b/nojavascript/Nginx/Dockerfile
@@ -4,5 +4,6 @@ LABEL description="rendertron nginx server"
 LABEL version="1.0"
 LABEL maintainer "jholdstock@decred.org"
 
-COPY ./nginx.conf /etc/nginx/conf.d/default.conf
 COPY ./headers.conf /etc/nginx/conf.d/headers.conf
+COPY ./nginx.conf.template /etc/nginx/conf.d/default.conf.template
+CMD /bin/bash -c "envsubst '\$PIHOSTNAME' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf && exec nginx -g 'daemon off;'"

--- a/nojavascript/Nginx/nginx.conf.template
+++ b/nojavascript/Nginx/nginx.conf.template
@@ -1,0 +1,38 @@
+proxy_cache_path  /var/cache/nginx  levels=1:2    keys_zone=STATIC:10m
+    inactive=10m  max_size=1g;
+
+
+server {
+	set $host_name ${PIHOSTNAME};
+	listen 80;
+    server_name localhost;
+    server_tokens off;
+	include "conf.d/headers.conf";
+	proxy_set_header       Host $host;
+	proxy_buffering        on;
+	proxy_cache            STATIC;
+	proxy_cache_valid      200  10m;
+	proxy_cache_valid      400 1m;
+	proxy_cache_use_stale  error timeout invalid_header updating
+								http_500 http_502 http_503 http_504;
+	set $pretoken "";
+	set $posttoken "%3F";
+	if ($is_args) {
+		set $pretoken "%3F";
+		set $posttoken "%26";
+	}
+	set $args "${pretoken}${args}${posttoken}nojavascript%3Dtrue"; 
+	location ~* ^/user/(login|signup|request-reset-password|verify) {
+		return 403;
+	}
+	location  = / {
+		proxy_pass http://$host_name:6060/render/https://$host_name$uri$args;
+	}
+	location ~ ^/(proposals/|user/) {
+		proxy_pass http://$host_name:6060/render/https://$host_name$uri$args;
+	}
+
+	location / {
+        return 403;
+    }
+}

--- a/nojavascript/README.md
+++ b/nojavascript/README.md
@@ -17,10 +17,10 @@ location /nojavascript/ {
 
 
 
-### Build the docker images using the command `./build.sh` it will ask for an input for the hostname. It is very important that the host is accessible from inside the docker images. This is usually example.com.
+### Build the docker images using the command `./build.sh`. 
 
 
-#### If this is not possible start the docker images with the ["--add-host"](https://docs.docker.com/engine/reference/run/#managing-etchosts) command. You might also need to setup a docker [internal network](https://docs.docker.com/engine/reference/commandline/network_create/). When properly setup you should be able to `curl 'https://example.com'` from inside docker and it should return the contents of `https://example.com`.
+#### It is very important that the host is accessible from inside the docker images. This is usually example.com. If this is not possible start the docker images with the ["--add-host"](https://docs.docker.com/engine/reference/run/#managing-etchosts) command. You might also need to setup a docker [internal network](https://docs.docker.com/engine/reference/commandline/network_create/). When properly setup you should be able to `curl 'https://example.com'` from inside docker and it should return the contents of `https://example.com`.
 
 ## Start rendertronmain 
 
@@ -32,11 +32,11 @@ Docker command:
 
 ## Start rentertronnginx
 
-If you use the below command the location `$HOME/.nginx/longcache/cache `is used to store the cache.  Because the contents of the politeia site keeps changing cache only lasts 10 minutes. This can be edited in the file `build.sh`. Delete the contents of this folder if you are having cache issues.
+If you use the below command the location `$HOME/.nginx/longcache/cache `is used to store the cache.  Because the contents of the politeia site keeps changing cache only lasts 10 minutes. This can be edited in the file `/Nginx/nginx.conf.template`. Delete the contents of this folder if you are having cache issues.
 
 Docker command:
 
-`docker run -v $HOME/.nginx/longcache/cache:/var/cache/nginx -d --rm -p 9090:80 decred/rendertronnginx:latest`
+`docker run  -e PIHOSTNAME={HOSTNAMEHERE} -v $HOME/.nginx/longcache/cache:/var/cache/nginx -d --rm -p 9090:80 decred/rendertronnginx:latest`
 
 ## Final checks. 
 

--- a/nojavascript/build.sh
+++ b/nojavascript/build.sh
@@ -1,45 +1,5 @@
 #!/bin/bash
 
-read -p 'HostName (should resolve from inside docker): ' HostName
-echo 'proxy_cache_path  /var/cache/nginx  levels=1:2    keys_zone=STATIC:10m
-    inactive=10m  max_size=1g;
-
-
-server {
-	set $host_name '$HostName';
-	listen 80;
-    server_name localhost;
-    server_tokens off;
-	include "conf.d/headers.conf";
-	proxy_set_header       Host $host;
-	proxy_buffering        on;
-	proxy_cache            STATIC;
-	proxy_cache_valid      200  10m;
-	proxy_cache_valid      400 1m;
-	proxy_cache_use_stale  error timeout invalid_header updating
-								http_500 http_502 http_503 http_504;
-	set $pretoken "";
-	set $posttoken "%3F";
-	if ($is_args) {
-		set $pretoken "%3F";
-		set $posttoken "%26";
-	}
-	set $args "${pretoken}${args}${posttoken}nojavascript%3Dtrue"; 
-	location ~* ^/user/(login|signup|request-reset-password|verify) {
-		return 403;
-	}
-	location  = / {
-		proxy_pass http://$host_name:6060/render/https://$host_name$uri$args;
-	}
-	location ~ ^/(proposals/|user/) {
-		proxy_pass http://$host_name:6060/render/https://$host_name$uri$args;
-	}
-
-	location / {
-        return 403;
-    }
-}' > Nginx/nginx.conf
-
 echo "
 =====================================
 Building rendertronnginx docker image  
@@ -56,12 +16,11 @@ Building rendertronmain docker image
 
 docker build -t decred/rendertronmain RenderTron/
 
-
 echo "
 =====================================
 Build complete the programs can be run using 
 
-docker run -v \$HOME/.nginx/longcache/cache:/var/cache/nginx -d --rm -p 9090:80 decred/rendertronnginx:latest
+docker run -e PIHOSTNAME={HOSTNAMEHERE} -v \$HOME/.nginx/longcache/cache:/var/cache/nginx -d --rm -p 9090:80 decred/rendertronnginx:latest
 
 docker run -d --rm -p 6060:6060 decred/rendertronmain:latest
 =====================================


### PR DESCRIPTION
Building the docker file required the user to input the politeia hostname and the hostname was hard-coded into the docker image. 

This is not ideal when politeia could have multiple hostnames. 

eg: test-proposals.decred.org and proposals.decred.org

Now the hostname is set an as environment variable when starting the docker image. 

eg:

`docker run -e PIHOSTNAME=172.17.0.1 -v $HOME/.nginx/longcache/cache:/var/cache/nginx -d --rm -p 9090:80 decred/rendertronnginx:latest`

