### PR TITLE
[rfp] Improve proposal form for mobile

### DIFF
--- a/src/components/ProposalForm/ProposalForm.jsx
+++ b/src/components/ProposalForm/ProposalForm.jsx
@@ -120,6 +120,7 @@ const ProposalForm = React.memo(function ProposalForm({
       )}
       <Row
         noMargin
+        wrap={smallTablet}
         className={classNames(
           styles.typeRow,
           isRfpSubmission && styles.typeRowNoMargin
@@ -142,6 +143,7 @@ const ProposalForm = React.memo(function ProposalForm({
             />
             <Tooltip
               contentClassName={styles.deadlineTooltip}
+              className={styles.tooltipWrapper}
               placement={smallTablet ? "left" : "bottom"}
               content="The deadline for the RFP submissions,
               it can be edited at any point before the voting has been started and should be at least two weeks from now.">
@@ -153,14 +155,16 @@ const ProposalForm = React.memo(function ProposalForm({
         )}
         {isRfpSubmission && (
           <>
-            <div className={styles.iconWrapper}>
-              <Icon
-                type={"horizontalLink"}
-                viewBox="0 0 24 16"
-                width={24}
-                height={16}
-              />
-            </div>
+            {!smallTablet && (
+              <div className={styles.iconWrapper}>
+                <Icon
+                  type={"horizontalLink"}
+                  viewBox="0 0 24 16"
+                  width={24}
+                  height={16}
+                />
+              </div>
+            )}
             <BoxTextInput
               placeholder="RFP token"
               name="rfpLink"
@@ -168,7 +172,10 @@ const ProposalForm = React.memo(function ProposalForm({
               value={values.rfpLink}
               disabled={isPublic}
               onChange={handleChangeWithTouched("rfpLink")}
-              className={styles.rfpLinkToken}
+              className={classNames(
+                styles.rfpLinkToken,
+                smallTablet && styles.topMargin
+              )}
               error={touched.rfpLink && errors.rfpLink}
             />
           </>

--- a/src/components/ProposalForm/ProposalForm.module.css
+++ b/src/components/ProposalForm/ProposalForm.module.css
@@ -46,8 +46,7 @@
   display: flex;
   align-items: center;
   height: 4.4rem;
-  margin-left: var(--spacing-small);
-  margin-right: var(--spacing-small);
+  justify-content: center;
 }
 
 .deadlineTooltip {
@@ -99,7 +98,7 @@
 
   .tooltipWrapper {
     margin-top: 2rem;
-    flex-basis: 5%;
+    flex-basis: 10%;
   }
 
   .formatHelpButton {

--- a/src/components/ProposalForm/ProposalForm.module.css
+++ b/src/components/ProposalForm/ProposalForm.module.css
@@ -81,6 +81,10 @@
   text-decoration: none !important;
 }
 
+.tooltipWrapper {
+  flex-basis: 4rem;
+}
+
 .topMargin {
   margin-top: 2rem;
 }

--- a/src/components/ProposalForm/ProposalForm.module.css
+++ b/src/components/ProposalForm/ProposalForm.module.css
@@ -88,7 +88,7 @@
 
 @media screen and (max-width: 685px) {
   .datePicker {
-    composes: topMargin;
+    margin-top: 2rem;
     margin-left: 0;
     flex-basis: 90%;
   }
@@ -98,7 +98,7 @@
   }
 
   .tooltipWrapper {
-    composes: topMargin;
+    margin-top: 2rem;
     flex-basis: 5%;
   }
 

--- a/src/components/ProposalForm/ProposalForm.module.css
+++ b/src/components/ProposalForm/ProposalForm.module.css
@@ -38,7 +38,7 @@
 
 .datePicker {
   margin-left: 2rem;
-  width: 20rem;
+  flex-basis: 20rem;
   height: 4.4rem;
 }
 
@@ -56,7 +56,7 @@
 }
 
 .rfpLinkToken {
-  width: 50rem;
+  flex-basis: 50rem;
 }
 
 .rfpLinkToken > input {
@@ -82,9 +82,24 @@
   text-decoration: none !important;
 }
 
+.topMargin {
+  margin-top: 2rem;
+}
+
 @media screen and (max-width: 685px) {
+  .datePicker {
+    composes: topMargin;
+    margin-left: 0;
+    flex-basis: 90%;
+  }
+
   .rfpLinkToken {
-    width: auto;
+    flex-basis: 100%;
+  }
+
+  .tooltipWrapper {
+    composes: topMargin;
+    flex-basis: 5%;
   }
 
   .formatHelpButton {

--- a/src/components/layout/helpers/Row.jsx
+++ b/src/components/layout/helpers/Row.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import styles from "../layouts.module.css";
 import { classNames } from "pi-ui";
 
 export const Row = ({
@@ -10,6 +11,7 @@ export const Row = ({
   noMargin,
   className,
   hide,
+  wrap,
   onClick
 }) =>
   !hide && (
@@ -18,6 +20,7 @@ export const Row = ({
         !noMargin && `margin-top-${topMarginSize}`,
         `justify-${justify}`,
         `align-${align}`,
+        wrap && styles.wrap,
         className
       )}
       onClick={onClick}>
@@ -32,6 +35,7 @@ Row.propTypes = {
   align: PropTypes.oneOf(["start", "end", "center", "stretch"]),
   hide: PropTypes.bool,
   noMargin: PropTypes.bool,
+  wrap: PropTypes.bool,
   onClick: PropTypes.func
 };
 
@@ -39,6 +43,7 @@ Row.defaultProps = {
   topMarginSize: "m",
   justify: "left",
   align: "stretch",
+  wrap: false,
   hide: false,
   noMargin: false
 };

--- a/src/components/layout/layouts.module.css
+++ b/src/components/layout/layouts.module.css
@@ -76,6 +76,10 @@ div.customPageDetails {
   grid-column: 4 / 12 !important;
 }
 
+.wrap {
+  flex-wrap: wrap;
+}
+
 /* HUGE SCREENS */
 @media screen and (min-width: 1400px) {
   .narrow {


### PR DESCRIPTION
This diff improves the new proposal form for mobile screens - see before/after screenshot below.
Mentioned here: https://github.com/decred/politeiagui/issues/1951#issuecomment-635585549

### Solution description

Improved *flex* styling for mobile screen which included extending the `Row` component to accept `wrap` prop to make each item span to full row on mobile/when `wrap` boolean is true.

### UI Changes Screenshot

After:
<img width="432" alt="Screenshot 2020-05-29 at 02 14 06" src="https://user-images.githubusercontent.com/10324528/83207136-be47fb00-a152-11ea-9c6e-4d472e264274.png">
<img width="422" alt="Screenshot 2020-05-29 at 02 19 29" src="https://user-images.githubusercontent.com/10324528/83207247-fd764c00-a152-11ea-849b-d09ec7e2b597.png">


Before:
![image](https://user-images.githubusercontent.com/10324528/83206815-fac72700-a151-11ea-8290-95e2f12a7563.png)

