### PR TITLE
Allow Dark Mode switch for not logged in users

### DIFF
--- a/src/components/HeaderNav/HeaderNav.jsx
+++ b/src/components/HeaderNav/HeaderNav.jsx
@@ -105,6 +105,16 @@ const HeaderNav = ({ history }) => {
     </div>
   ) : (
     <nav className={styles.navContainer}>
+      <div
+        className={classNames(styles.themeToggleWrapper, styles.publicWrapper)}>
+        <Toggle
+          onToggle={onThemeToggleHandler}
+          toggled={themeName === "dark"}
+        />
+        <div onClick={onThemeToggleHandler} className={styles.themeToggleLabel}>
+          Dark Mode
+        </div>
+      </div>
       <NavLink
         className={styles.navLink}
         activeClassName={styles.activeNavLink}

--- a/src/components/HeaderNav/HeaderNav.module.css
+++ b/src/components/HeaderNav/HeaderNav.module.css
@@ -48,6 +48,11 @@ ul.dropdownList {
   justify-content: space-between;
 }
 
+.publicWrapper {
+  padding: 0 2rem;
+  border-bottom: 2px solid transparent;
+}
+
 .themeToggleLabel {
   margin-left: 1rem;
   margin-top: 0.1rem;

--- a/src/components/HeaderNav/HeaderNav.module.css
+++ b/src/components/HeaderNav/HeaderNav.module.css
@@ -18,7 +18,7 @@
   composes: navContainer;
   text-decoration: none !important;
   color: var(--tab-text-color) !important;
-  border-bottom: 2px solid transparent;
+  border-bottom: 0.2rem solid transparent;
 }
 
 .navLink:hover {
@@ -30,12 +30,12 @@
 }
 
 .rightGreyBorder {
-  border-right: 1px solid var(--separator-color);
+  border-right: 0.1rem solid var(--separator-color);
 }
 
 .activeNavLink {
   color: var(--color-primary-dark);
-  border-bottom: 4px solid var(--active-nav-border-color);
+  border-bottom: 0.4rem solid var(--active-nav-border-color);
 }
 
 ul.dropdownList {
@@ -50,7 +50,7 @@ ul.dropdownList {
 
 .publicWrapper {
   padding: 0 2rem;
-  border-bottom: 2px solid transparent;
+  border-bottom: 0.2rem solid transparent;
 }
 
 .themeToggleLabel {


### PR DESCRIPTION
This PR Closes #1960 issue, which describes an odd behaviour regarding the **Dark Mode** switch not being available for not logged in users.

### Solution description

The Dark Mode tree was already used in the same component, this diff only adds the switch for the public interface.

### UI Changes Screenshot

Before:
<img width="1157" alt="Captura de Tela 2020-05-29 às 16 49 25" src="https://user-images.githubusercontent.com/22639213/83301181-8cc14500-a1cf-11ea-9934-59a007c9b90b.png">


After:
<img width="1250" alt="Captura de Tela 2020-05-29 às 17 11 27" src="https://user-images.githubusercontent.com/22639213/83301166-859a3700-a1cf-11ea-857f-9b941b781ae9.png">

