### PR TITLE
[wip] Allow short token URLs

### DIFF
--- a/src/containers/Proposal/Detail/hooks.js
+++ b/src/containers/Proposal/Detail/hooks.js
@@ -55,9 +55,21 @@ export function useProposal(token, threadParentID) {
         return;
       }
       onFetchProposal(token);
-      onFetchProposalsVoteSummary([token]);
     },
     [proposal, token, onFetchProposal, onFetchProposalsVoteSummary]
+  );
+  useEffect(
+    // fetch vote summary only when proposal details loaded => full token is avaliable in redux store
+    // thus can be used to fetch vote summary
+    function fetchVoteSummary() {
+      if (proposalFromState) {
+        const {
+          censorshiprecord: { token }
+        } = proposalFromState;
+        onFetchProposalsVoteSummary([token]);
+      }
+    },
+    [proposalFromState, onFetchProposalsVoteSummary]
   );
 
   useEffect(

--- a/src/containers/Proposal/hooks/useProposalVote.js
+++ b/src/containers/Proposal/hooks/useProposalVote.js
@@ -1,7 +1,6 @@
 import { useMemo } from "react";
 import * as sel from "src/selectors";
-import * as act from "src/actions";
-import { useSelector, useAction } from "src/redux";
+import { useSelector } from "src/redux";
 import { isVoteActiveProposal } from "../helpers";
 import useProposalVoteTimeInfo from "./useProposalVoteTimeInfo";
 
@@ -11,7 +10,6 @@ export default function useProposalVote(token) {
     [token]
   );
   const voteSummary = useSelector(voteSummarySelector);
-  const onFetchProposalsBatch = useAction(act.onFetchProposalsBatch);
   const voteActive = isVoteActiveProposal(voteSummary);
   const { voteEndTimestamp, voteBlocksLeft } = useProposalVoteTimeInfo(
     voteSummary
@@ -20,7 +18,6 @@ export default function useProposalVote(token) {
     voteSummary,
     voteBlocksLeft,
     voteActive,
-    voteEndTimestamp,
-    onFetchProposalsBatch
+    voteEndTimestamp
   };
 }

--- a/src/selectors/models/proposals.js
+++ b/src/selectors/models/proposals.js
@@ -20,7 +20,16 @@ export const tokenInventory = createDeepEqualSelector(
 export const newProposalToken = get(["proposals", "newProposalToken"]);
 
 export const makeGetProposalByToken = (token) =>
-  createSelector(proposalsByToken, get(token));
+  createSelector(proposalsByToken, (propsByToken) => {
+    const proposal = propsByToken[token];
+    if (proposal) return proposal;
+    const proposalsTokens = Object.keys(propsByToken);
+    // check if the provided token is prefix of original token
+    const matchedTokenByPrefix = proposalsTokens.find(
+      (key) => key.substring(0, 7) === token
+    );
+    return propsByToken[matchedTokenByPrefix];
+  });
 
 export const makeGetNumOfProposalsByUserId = (userId) =>
   createSelector(numOfProposalsByUserId, get(userId));


### PR DESCRIPTION
This diff allows users to use short proposal's token in URLs - first 7 chars of original 64 chars hex.

### Solution description
- Adjusted `useProposal` hook to fetch voteSummary only when full token is fetched and stored in redux store.
- Updated `makeGetProposalByToken` selector to try find the stored proposal by using the 7 chars prefix instead of full length token.

### Dependencies
Closes #1939 

