### PR TITLE
Add copy to clipboard to proposal token

### DIFF
--- a/src/components/Proposal/Proposal.jsx
+++ b/src/components/Proposal/Proposal.jsx
@@ -173,8 +173,7 @@ const Proposal = React.memo(function Proposal({
           Header,
           Subtitle,
           Edit,
-          Status,
-          RecordToken
+          Status
         }) => (
           <>
             <Header
@@ -266,7 +265,15 @@ const Proposal = React.memo(function Proposal({
             />
             {extended && (
               <Row topMarginSize="s">
-                <RecordToken token={proposalToken} />
+                <Text id={`proposal-token-${proposalToken}`} truncate>
+                  {proposalToken}
+                </Text>
+                <CopyLink
+                  className={classNames(
+                    isPublicAccessible && styles.copyLink && "margin-left-s"
+                  )}
+                  url={proposalToken}
+                />
               </Row>
             )}
             {hasvoteSummary && (


### PR DESCRIPTION
This diff closes #1936 - Add copy to clipboard button to the token in the proposal details page.

### Solution description

This diff add the possibility to copy to clipboard the proposal token in the proposal details page. 
To remove the pencil icon, I stopped to use `RecordToken`. I didn't change `RecordToken` as is used in other places.

### UI Changes Screenshot

Before diff:
<img width="623" alt="Screenshot 2020-06-01 at 00 12 35" src="https://user-images.githubusercontent.com/3491087/83363809-af548900-a39c-11ea-9fd9-c84d2dd758fa.png">

After diff:
<img width="610" alt="Screenshot 2020-06-01 at 00 12 04" src="https://user-images.githubusercontent.com/3491087/83363811-b2e81000-a39c-11ea-8a7a-af7f70bd8e35.png">
