### PR TITLE
Proposal details responsive header fixes

### DIFF
--- a/src/components/RecordWrapper/RecordWrapper.jsx
+++ b/src/components/RecordWrapper/RecordWrapper.jsx
@@ -128,7 +128,11 @@ export const Header = React.memo(function Header({
     <div className={styles.header}>
       {!mobile || disableMobileView ? (
         <div className={styles.titleWrapper}>
-          <div className={styles.titleEditWrapper}>
+          <div
+            className={classNames(
+              styles.titleEditWrapper,
+              isRfp && styles.rfpTitleWrapper
+            )}>
             {isRfp && <RfpTag />}
             {title}
             {edit}

--- a/src/components/RecordWrapper/RecordWrapper.module.css
+++ b/src/components/RecordWrapper/RecordWrapper.module.css
@@ -25,6 +25,7 @@
 }
 
 .subtitleWrapper {
+  max-width: calc(100% - 15rem);
   flex-wrap: wrap;
 }
 
@@ -67,6 +68,10 @@
   max-width: calc(100% - 28rem);
   display: flex;
   align-items: center;
+}
+
+.rfpTitleWrapper {
+  max-width: calc(100% - 32rem);
 }
 
 .mobileRfpTag {
@@ -120,6 +125,7 @@ div.darkSeeOnGithubTooltip {
   .titleEditWrapper {
     flex-wrap: wrap;
     max-width: 100%;
+    margin-top: 1rem;
   }
 
   .titleStatusWrapper {
@@ -129,6 +135,5 @@ div.darkSeeOnGithubTooltip {
 
   .title {
     max-width: 100%;
-    margin-top: 0.5rem;
   }
 }


### PR DESCRIPTION
This diff closes issue #1971 which reported minor issues regarding proposal styles and responsiveness.

### Solution description

Just some css fixes, such as adding margins and reducing the width size of record subtitle.

### UI Changes Screenshot

Before:
![](https://user-images.githubusercontent.com/13955303/83676458-13e83180-a5b1-11ea-9847-77b45a8e2787.png)

After:
<img width="636" alt="Screen Shot 2020-06-03 at 7 37 03 PM" src="https://user-images.githubusercontent.com/22639213/83695964-9da7f700-a5d1-11ea-8318-99d6115de4ef.png">
