### PR TITLE
Add Tooltip to edit icon if the vote is authorized

### DIFF
--- a/src/components/Proposal/Proposal.jsx
+++ b/src/components/Proposal/Proposal.jsx
@@ -4,7 +4,8 @@ import {
   StatusTag,
   Text,
   useMediaQuery,
-  useTheme
+  useTheme,
+  Tooltip
 } from "pi-ui";
 import React, { useEffect, useState } from "react";
 import Markdown from "../Markdown";
@@ -23,6 +24,7 @@ import {
   getQuorumInVotes,
   isVotingFinishedProposal,
   getProposalToken,
+  isVotingNotAuthorizedProposal,
   goToFullProposal
 } from "src/containers/Proposal/helpers";
 import {
@@ -130,6 +132,7 @@ const Proposal = React.memo(function Proposal({
   const isAbandoned = isAbandonedProposal(proposal);
   const isPublicAccessible = isPublic || isAbandoned;
   const isAuthor = currentUser && currentUser.userid === userid;
+  const isVotingAuthorized = !isVotingNotAuthorizedProposal(voteSummary);
   const isEditable = isAuthor && isEditableProposal(proposal, voteSummary);
   const mobile = useMediaQuery("(max-width: 560px)");
   const showEditedDate =
@@ -188,8 +191,23 @@ const Proposal = React.memo(function Proposal({
                   {name}
                 </Title>
               }
+              /**
+               * if the proposal is editable: show Edit icon
+               * if the proposal is not editable and the voting is authorized: show Edit icon wrapped by tooltip
+               * otherwise: do not show Edit icon
+               * */
               edit={
-                isEditable && <Edit url={`/proposals/${proposalToken}/edit`} />
+                isEditable ? (
+                  <Edit url={`/proposals/${proposalToken}/edit`} />
+                ) : isVotingAuthorized ? (
+                  <Tooltip
+                    placement={mobile ? "left" : "right"}
+                    content="You have to revoke the voting authorization to edit the proposal"
+                    className={classNames(styles.disabled)}
+                    contentClassName={styles.authorizeTooltip}>
+                    <Edit tabIndex={-1} />
+                  </Tooltip>
+                ) : null
               }
               isRfp={isRfp}
               isRfpSubmission={isRfpSubmission}

--- a/src/components/Proposal/Proposal.jsx
+++ b/src/components/Proposal/Proposal.jsx
@@ -203,7 +203,7 @@ const Proposal = React.memo(function Proposal({
                   <Tooltip
                     placement={mobile ? "left" : "right"}
                     content="You have to revoke the voting authorization to edit the proposal"
-                    className={classNames(styles.disabled)}
+                    className={styles.disabled}
                     contentClassName={styles.authorizeTooltip}>
                     <Edit tabIndex={-1} />
                   </Tooltip>

--- a/src/components/Proposal/Proposal.module.css
+++ b/src/components/Proposal/Proposal.module.css
@@ -2,6 +2,14 @@
   margin-top: var(--spacing-small);
 }
 
+.authorizeTooltip {
+  width: 22rem;
+}
+
+.disabled > * {
+  pointer-events: none;
+}
+
 .filesRow {
   display: flex;
   flex-flow: row wrap;

--- a/src/components/RecordWrapper/RecordWrapper.jsx
+++ b/src/components/RecordWrapper/RecordWrapper.jsx
@@ -75,8 +75,8 @@ export const Subtitle = ({ children }) => (
   </Join>
 );
 
-export const Edit = ({ url }) => (
-  <Link to={url}>
+export const Edit = ({ url, tabIndex }) => (
+  <Link to={url || ""} tabIndex={tabIndex}>
     <Icon type="edit" className={styles.editButton} />
   </Link>
 );


### PR DESCRIPTION
Closes https://github.com/decred/politeiagui/issues/1975

### Solution description

I added a Tooltip to the edit icon for when the voting is authorized

### UI Changes Screenshot

After:
<img width="400" alt="Screen Shot 2020-06-04 at 13 43 42" src="https://user-images.githubusercontent.com/13955303/83786969-7a308b00-a669-11ea-95c3-b7b95a87033e.png">

* Obs: we have to improve our Tooltip for firefox mobile. We have an issue for this here: https://github.com/decred/pi-ui/issues/259.