### PR TITLE
[cms] Fix Invoice cancel button

### DIFF
--- a/src/components/InvoiceForm/InvoiceForm.jsx
+++ b/src/components/InvoiceForm/InvoiceForm.jsx
@@ -41,7 +41,8 @@ const InvoiceForm = React.memo(function InvoiceForm({
   setSessionStorageInvoice,
   approvedProposalsTokens,
   validateFiles,
-  requireGitHubName
+  requireGitHubName,
+  isEditing
 }) {
   const files = values.files;
   useScrollFormOnError(errors && errors.global);
@@ -58,12 +59,13 @@ const InvoiceForm = React.memo(function InvoiceForm({
   const handleChangeInvoiceDatasheet = useCallback(
     (value) => {
       setFieldValue("lineitems", value);
-      setSessionStorageInvoice({
-        ...values,
-        lineitems: value
-      });
+      !isEditing &&
+        setSessionStorageInvoice({
+          ...values,
+          lineitems: value
+        });
     },
-    [setFieldValue, values, setSessionStorageInvoice]
+    [setFieldValue, values, setSessionStorageInvoice, isEditing]
   );
 
   const handleFilesChange = useCallback(
@@ -93,10 +95,11 @@ const InvoiceForm = React.memo(function InvoiceForm({
 
   const handleChangeWithTouched = (field) => (e) => {
     setFieldTouched(field, true);
-    setSessionStorageInvoice({
-      ...values,
-      [field]: e.target.value
-    });
+    !isEditing &&
+      setSessionStorageInvoice({
+        ...values,
+        [field]: e.target.value
+      });
     handleChange(e);
   };
 
@@ -190,7 +193,8 @@ const InvoiceFormWrapper = ({
   initialValues,
   onSubmit,
   history,
-  approvedProposalsTokens
+  approvedProposalsTokens,
+  editMode
 }) => {
   const { policy } = usePolicy();
   const [submitSuccess, setSubmitSuccess] = useState(false);
@@ -282,7 +286,8 @@ const InvoiceFormWrapper = ({
             setSessionStorageInvoice,
             approvedProposalsTokens,
             validateFiles,
-            requireGitHubName
+            requireGitHubName,
+            isEditing: editMode
           }}
         />
       )}
@@ -295,7 +300,8 @@ InvoiceFormWrapper.propTypes = {
   initialValues: PropTypes.object,
   onSubmit: PropTypes.func,
   setSessionStorageInvoice: PropTypes.func,
-  history: PropTypes.object
+  history: PropTypes.object,
+  editMode: PropTypes.bool
 };
 
 export default withRouter(InvoiceFormWrapper);

--- a/src/containers/Invoice/Edit/Edit.jsx
+++ b/src/containers/Invoice/Edit/Edit.jsx
@@ -44,6 +44,7 @@ const EditInvoice = ({ match }) => {
           initialValues={initialValues}
           onSubmit={onEditInvoice}
           approvedProposalsTokens={approvedTokens}
+          editMode
         />
       ) : (
         <InvoiceLoader extended />


### PR DESCRIPTION
This PR Closes #1978 issue which described an unexpected behavior of "Cancel" button on Invoice Edit page. With this behavior, invoice editions could not be undone unless user erases his/her localStorage manually. Also, when user canceled the invoice edition, all data from the edit mode were inserted on "New Invoice" form.

### Solution description

Add a `editMode` prop to control sessionStorage savings.

### UI Changes Screenshot

Before:
![invoice-edit-cancel](https://user-images.githubusercontent.com/22639213/83932541-886dcc80-a779-11ea-873c-add91cdcf7b3.gif)

After:
![invoice-edit-cancel-fix](https://user-images.githubusercontent.com/22639213/83932544-8b68bd00-a779-11ea-837c-b68808b89eaa.gif)
