### PR TITLE
fix: submitted proposals RFP responsivity

### DIFF
--- a/src/components/ProposalsList/ProposalItem.jsx
+++ b/src/components/ProposalsList/ProposalItem.jsx
@@ -1,6 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { StatusBar, StatusTag, Text, classNames, Icon } from "pi-ui";
+import {
+  StatusBar,
+  StatusTag,
+  Text,
+  classNames,
+  Icon,
+  useMediaQuery
+} from "pi-ui";
 import VotesCount from "../Proposal/VotesCount";
 import { Row } from "../layout";
 import {
@@ -44,6 +51,8 @@ const ProposalItem = ({
   );
   const { voteEndTimestamp } = useProposalVoteTimeInfo(voteSummary);
 
+  const mobile = useMediaQuery("(max-width: 760px)");
+
   return (
     proposal &&
     voteSummary && (
@@ -84,7 +93,7 @@ const ProposalItem = ({
             />
           </Row>
         )}
-        {(isVoteActive || isVotingFinished) && (
+        {(isVoteActive || isVotingFinished) && !mobile && (
           <Row
             className={styles.timeLeftPassed}
             justify="center"

--- a/src/components/ProposalsList/ProposalsList.module.css
+++ b/src/components/ProposalsList/ProposalsList.module.css
@@ -30,6 +30,7 @@ span.statusTag > span {
 }
 
 .itemWrapper {
+  padding: 0.5rem;
   height: 6.1rem;
   border-bottom: 1px solid var(--separator-color);
   cursor: pointer;
@@ -43,4 +44,18 @@ span.statusTag > span {
 
 .voteEvent {
   color: var(--color-primary-dark) !important;
+}
+
+/* EXTRA SMALL SCREENS*/
+@media screen and (max-width: 560px) {
+  .itemWrapper {
+    height: 100%;
+    margin: var(--spacing-1) auto;
+    flex-direction: column;
+    align-items: space-between;
+    padding: 0.5rem;
+  }
+  .itemWrapper > * {
+    margin: 0.5rem;
+  }
 }


### PR DESCRIPTION
This PR closes https://github.com/decred/politeiagui/issues/1989

### Solution description

Added some custom CSS for screens smaller than 560px and hid the time since voting ended from the list (can still be found on proposal details, of course) on screens smaller than 760px so now the readability is improved. We might get design improvements on this in the future.

### UI Changes Screenshot

### Before:
![localhost_3000_proposals_3e3540e9d773abe931dc3a6c9d868cd80af318a59124baa3b7dc51c1d7119884 (1)](https://user-images.githubusercontent.com/13955303/84163164-8ccf0980-aa47-11ea-8db3-7f78c08f92b7.png)

### After:

**<= 560px**
![localhost_3000_proposals_3e3540e9d773abe931dc3a6c9d868cd80af318a59124baa3b7dc51c1d7119884 (2)](https://user-images.githubusercontent.com/13955303/84163182-92c4ea80-aa47-11ea-9a30-c1b67513f314.png)

**<= 760px**
![localhost_3000_proposals_3e3540e9d773abe931dc3a6c9d868cd80af318a59124baa3b7dc51c1d7119884 (3)](https://user-images.githubusercontent.com/13955303/84163192-95274480-aa47-11ea-8236-1c3e3f744b05.png)
