### PR TITLE
fix: markdown editor commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react-file-reader-input": "https://github.com/ngokevin/react-file-reader-input.git",
     "react-infinite-scroller": "^1.2.4",
     "react-markdown": "^4.2.2",
-    "react-mde": "^2.1.2",
+    "react-mde": "8.0.2",
     "react-mde-newest": "npm:react-mde",
     "react-redux": "^7.1.3",
     "react-router-dom": "^4.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4303,7 +4303,6 @@ electron-to-chromium@^1.3.378, electron-to-chromium@^1.3.413:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.465.tgz#d692e5c383317570c2bd82092a24a0308c6ccf29"
   integrity sha512-K/lUeT3NLAsJ5SHRDhK3/zd0tw7OUllYD8w+fTOXm6ljCPsp2qq+vMzxpLo8u1M27ZjZAjRbsA6rirvne2nAMQ==
 
-
 elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
@@ -10379,14 +10378,14 @@ react-markdown@^4.2.2:
     xtend "^4.0.1"
 
 "react-mde-newest@npm:react-mde":
-  version "10.0.3"
-  resolved "https://registry.yarnpkg.com/react-mde/-/react-mde-10.0.3.tgz#0dea122ee8ba8741eec929d7cabf53b1c27d16ca"
-  integrity sha512-t8c1h6jkXHoCQpHcZ3Ex2cq/sGmsonS+tsoQ/YGUrijO4CL6wnwdIUpcApn2qeFZnkyqr7tyLwZ5GMOfiy8L/w==
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/react-mde/-/react-mde-8.2.0.tgz#4e5bc2f8365efd471b5bf69f544bd62860902cc1"
+  integrity sha512-itcbS94iN+4R7uxHTyfB4sSXivDxKo+WocqoJ5RZ5qqLfMI93Dj9XzmL3yh4nIcUyH2lWhfQ7c4HpKoT9WDFHw==
 
-react-mde@^2.1.2:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/react-mde/-/react-mde-2.3.4.tgz#cd8243facb1f5d68ae841a3b6b9cad6db280f958"
-  integrity sha512-UZ9JtBiZ3ALlPhYErLPtvYfSC2CdqVjUubB/ZfNtlVIC1LwsqfTCCE+cI4ZgZPs5mPsgQZlb/gSLGls7U9sLMQ==
+react-mde@8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/react-mde/-/react-mde-8.0.2.tgz#900dca65f0dc0d45e75dce8a08ac6f648a09dc31"
+  integrity sha512-Uu1nq3L7kS//Ylp33g97WEeYMCT9CmR5OMIrd0HeeJU06geT2dWW/LN+EfEI0rf2B3Swj1iixZqzqMBNxKuqdw==
 
 react-redux@^7.1.3:
   version "7.2.0"


### PR DESCRIPTION
This issue fixes the commands updates for `react-mde` package. The `commands` approach has changed on newer versions. 

Package commit that changed the approach: https://github.com/andrerpena/react-mde/commit/f65513448639fd2300546f61eb5a13647c9b66b5

### Solution description

Rollback to the previous version, 8.0.2.

New version issue: #1993 
