### PR TITLE
fix: unvetted proposals empty files error

### DIFF
--- a/src/containers/Proposal/helpers.js
+++ b/src/containers/Proposal/helpers.js
@@ -211,7 +211,7 @@ export const getVoteEndTimestamp = (voteSummary, chainHeight, isTestnet) => {
  */
 export const getMarkdownContent = (files) => {
   const markdownFile = files.find((f) => f.name === "index.md");
-  return getTextFromIndexMd(markdownFile);
+  return markdownFile ? getTextFromIndexMd(markdownFile) : "";
 };
 
 /**

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -51,10 +51,17 @@ export const atou = (str) => decodeURIComponent(escape(window.atob(str)));
 //  <proposal name>\n
 //  <proposal description>
 //
-export const getTextFromIndexMd = (file) => {
+export const getTextFromIndexMd = (file = {}) => {
+  if (!file.payload) return "";
   const text = atou(file.payload);
   return text.substring(text.indexOf("\n\n") + 1).trim();
 };
+
+export const getIndexMdFromText = (text = "") => ({
+  name: "index.md",
+  mime: "text/plain; charset=utf-8",
+  payload: utoa(text)
+});
 
 export const getTextFromJsonToCsv = (file) => {
   const json = JSON.parse(atou(file.payload));

--- a/src/tests/helpers.test.js
+++ b/src/tests/helpers.test.js
@@ -5,6 +5,15 @@ const FILE = {
   mime: "image/jpeg",
   payload: "VGVzdCBwcm9wCiMgVGhpcyBpcyBhIHRlc3QgcHJvcG9zYWw="
 };
+
+const MD_FILE = {
+  mime: "text/plain; charset=utf-8",
+  name: "index.md",
+  payload: "cHJvcG9zYWwgbmFtZQoKcHJvcG9zYWwgZGVzY3JpcHRpb24="
+};
+
+const PROPOSAL_TEXT = "proposal name\n\nproposal description";
+
 const FILE_DIGESTED_PAYLOAD =
   "3973715772c4e0d41fc98fb67e97ad2436dca47961ac78a0757be43053d5af8c";
 
@@ -29,6 +38,16 @@ describe("test helpers functions", () => {
     expect(help.digest("password")).toEqual(
       "c0067d4af4e87f00dbac63b6156828237059172d1bbeac67427345d6a9fda484"
     );
+  });
+
+  test("it should return the proposal description from a md file", () => {
+    expect(help.getTextFromIndexMd(MD_FILE)).toEqual("proposal description");
+    expect(help.getTextFromIndexMd()).toEqual("");
+  });
+
+  test("it correctly encodes text into md files", () => {
+    expect(help.getIndexMdFromText(PROPOSAL_TEXT)).toEqual(MD_FILE);
+    expect(help.getIndexMdFromText()).toEqual({ ...MD_FILE, payload: "" });
   });
 });
 


### PR DESCRIPTION
This diff fixes an error reported by issue #1976 which consisted in trying to fetch an empty index.md file.

Closes #1976 

### Solution description

- adds new `getIndexMdFromText` function to `src/helpers`
- helpers test for `getIndexMdFromText` and `getTextFromIndexMd`
- index.md file addition on `RECEIVE_NEW_PROPOSAL` reducer


