### PR TITLE
fix: use RecordToken on proposal details

### DIFF
--- a/src/components/Proposal/Proposal.jsx
+++ b/src/components/Proposal/Proposal.jsx
@@ -5,7 +5,6 @@ import {
   Text,
   useMediaQuery,
   useTheme,
-  CopyableText,
   Tooltip
 } from "pi-ui";
 import React, { useEffect, useState } from "react";
@@ -177,7 +176,8 @@ const Proposal = React.memo(function Proposal({
           Header,
           Subtitle,
           Edit,
-          Status
+          Status,
+          RecordToken
         }) => (
           <>
             <Header
@@ -284,13 +284,7 @@ const Proposal = React.memo(function Proposal({
             />
             {extended && (
               <Row topMarginSize="s">
-                <CopyableText
-                  className={styles.copyableText}
-                  id={`proposal-token-${proposalToken}`}
-                  truncate
-                  tooltipPlacement={"bottom"}>
-                  {proposalToken}
-                </CopyableText>
+                <RecordToken token={proposalToken} isCopyable />
               </Row>
             )}
             {hasvoteSummary && (

--- a/src/components/RecordWrapper/RecordWrapper.jsx
+++ b/src/components/RecordWrapper/RecordWrapper.jsx
@@ -13,7 +13,8 @@ import {
   useHover,
   useTheme,
   getThemeProperty,
-  Tooltip
+  Tooltip,
+  CopyableText
 } from "pi-ui";
 import { Row } from "../layout";
 import Link from "../Link";
@@ -37,12 +38,24 @@ export const Event = ({ event, timestamp, className, size }) => (
   </DateTooltip>
 );
 
-export const RecordToken = ({ token }) => (
-  <div className="align-center overflow-hidden">
-    <Icon type="sign" className="margin-right-xs" />
-    <Text id={`proposal-token-${token}`} truncate>
-      {token}
-    </Text>
+export const RecordToken = ({ token, isCopyable }) => (
+  <div className={styles.recordToken}>
+    {isCopyable && (
+      <CopyableText
+        id={`proposal-token-${token}`}
+        truncate
+        tooltipPlacement={"bottom"}>
+        {token}
+      </CopyableText>
+    )}
+    {!isCopyable && (
+      <>
+        <Icon type="sign" className="margin-right-xs" />
+        <Text id={`proposal-token-${token}`} truncate>
+          {token}
+        </Text>
+      </>
+    )}
   </div>
 );
 
@@ -298,6 +311,14 @@ Event.propTypes = {
 
 Event.defaultProps = {
   show: true
+};
+
+RecordToken.propTypes = {
+  token: PropTypes.string.isRequired,
+  isCopyable: PropTypes.bool
+};
+RecordToken.defaultProps = {
+  isCopyable: false
 };
 
 export default RecordWrapper;

--- a/src/components/RecordWrapper/RecordWrapper.module.css
+++ b/src/components/RecordWrapper/RecordWrapper.module.css
@@ -110,6 +110,12 @@ div.darkSeeOnGithubTooltip {
   color: var(--text-color);
 }
 
+.recordToken {
+  display: flex;
+  align-items: center;
+  max-width: 100%;
+}
+
 @media screen and (max-width: 560px) {
   .status:not(.disableMobileView) {
     position: initial;


### PR DESCRIPTION
This PR fixes the `CopyableText` usage on `Proposal.jsx` for proposal tokens. We should use RecordToken instead and pass a `isCopyable` prop to it when necessary.

### Solution description

Move the CopyableText component to RecordToken

