### PR TITLE
Proposal form: Add spacing around rfp submission icon

### DIFF
--- a/src/components/ProposalForm/ProposalForm.module.css
+++ b/src/components/ProposalForm/ProposalForm.module.css
@@ -47,6 +47,7 @@
   align-items: center;
   height: 4.4rem;
   justify-content: center;
+  padding: 0.8rem;
 }
 
 .deadlineTooltip {

--- a/src/components/ProposalForm/ProposalForm.module.css
+++ b/src/components/ProposalForm/ProposalForm.module.css
@@ -69,7 +69,7 @@
   color: var(--color-gray);
   font-weight: 400;
   cursor: pointer;
-  padding-top: 10px;
+  padding-top: 1rem;
   padding-right: var(--spacing-4);
 }
 


### PR DESCRIPTION
Small improvement for RFP submission token's icon.

### UI Changes Screenshot

Before:
![image](https://user-images.githubusercontent.com/10324528/84594765-c7281480-ae54-11ea-8d90-b2d3cb352924.png)


After:
![image](https://user-images.githubusercontent.com/10324528/84594767-cabb9b80-ae54-11ea-8f1a-0eeead77fd1f.png)

