### PR TITLE
Fix duplicate RFP submissions requests

### DIFF
--- a/src/components/Proposal/Proposal.jsx
+++ b/src/components/Proposal/Proposal.jsx
@@ -59,7 +59,8 @@ const ProposalWrapper = (props) => {
   const isRFP = !!linkedfrom;
   const batchTokens = isSubmission ? [linkto] : isRFP ? linkedfrom : null;
   const {
-    data: [proposals, voteSummaries]
+    data: [proposals, voteSummaries],
+    resetData: resetRfpSubmissionsData
   } = useProposalBatchWithoutRedux(batchTokens, true, isRFP);
   useEffect(() => {
     if (isSubmission && proposals && proposals[0]) {
@@ -83,7 +84,8 @@ const ProposalWrapper = (props) => {
         rfpSubmissions: isRFP && {
           proposals,
           voteSummaries
-        }
+        },
+        resetRfpSubmissionsData
       }}
     />
   );
@@ -100,7 +102,8 @@ const Proposal = React.memo(function Proposal({
   currentUser,
   history,
   proposedFor,
-  rfpSubmissions
+  rfpSubmissions,
+  resetRfpSubmissionsData
 }) {
   const {
     censorshiprecord,
@@ -378,7 +381,14 @@ const Proposal = React.memo(function Proposal({
               </Row>
             )}
             <LoggedInContent>
-              <ProposalActions proposal={proposal} voteSummary={voteSummary} />
+              <ProposalActions
+                proposal={proposal}
+                voteSummary={voteSummary}
+                resetRfpSubmissionsData={resetRfpSubmissionsData}
+                rfpSubmissionsVoteSummaries={
+                  isRfp && rfpSubmissions.voteSummaries
+                }
+              />
             </LoggedInContent>
           </>
         )}

--- a/src/components/Proposal/ProposalActions.jsx
+++ b/src/components/Proposal/ProposalActions.jsx
@@ -14,7 +14,6 @@ import {
   useUnvettedProposalActions,
   usePublicProposalActions
 } from "src/containers/Proposal/Actions";
-import useProposalBatchWithoutRedux from "src/hooks/api/useProposalBatchWithoutRedux";
 import AdminContent from "src/components/AdminContent";
 import { useLoaderContext } from "src/containers/Loader";
 import styles from "./ProposalActions.module.css";
@@ -50,7 +49,12 @@ const UnvettedActions = ({ proposal }) => {
   );
 };
 
-const PublicActions = ({ proposal, voteSummary }) => {
+const PublicActions = ({
+  proposal,
+  voteSummary,
+  rfpSubmissionsVoteSummaries,
+  resetRfpSubmissionsData
+}) => {
   if (!usePublicProposalActions()) {
     throw Error(
       "PublicActions requires an PublicActionsProvider on a higher level of the component tree. "
@@ -80,14 +84,6 @@ const PublicActions = ({ proposal, voteSummary }) => {
 
   const rfpLinkedSubmissions = proposal.linkedfrom;
   const [submssionsDidntVote, setSubmissionDidntVote] = useState(false);
-  const {
-    data: [, rfpSubmissionsVoteSummaries],
-    resetData
-  } = useProposalBatchWithoutRedux(
-    rfpLinkedSubmissions ? rfpLinkedSubmissions : null,
-    false,
-    true
-  );
   useEffect(() => {
     // check if RFP submissions are already under vote => hide `start runoff vote` action
     if (rfpSubmissionsVoteSummaries) {
@@ -134,7 +130,8 @@ const PublicActions = ({ proposal, voteSummary }) => {
       )}
       {isRfpReadyToRunoff(proposal, voteSummary) && submssionsDidntVote && (
         <div className="justify-right margin-top-m">
-          <Button onClick={withProposal(onStartRunoffVote, resetData)}>
+          <Button
+            onClick={withProposal(onStartRunoffVote, resetRfpSubmissionsData)}>
             Start Runoff Vote
           </Button>
         </div>


### PR DESCRIPTION
This diff fixes the first issue reported on #1987 (we could keep the issue open because it includes another issue which isn't related to this fix - https://github.com/decred/politeiagui/issues/1987#issuecomment-640902764):
> Duplicate /proposals/batch and /proposals/batchvotesummary are being sent.
>
>https://test-proposals.decred.org/proposals/0de5bd8

### Solution description
I noticed that the duplicated calls originated from `Proposal.jsx` & `ProposalActions.jsx`, which both called `useProposalBatchWithoutRedux`.
Given the fact that  ProposalActions.jsx` is used inside `Proposal.jsx`, I deleted the hook call from the child and passed the needed data as props from the parent - as it already calls the hook to get RFP submissions info.

### UI Changes Screenshot

Before:
<img width="1513" alt="image" src="https://user-images.githubusercontent.com/10324528/84603222-04a89400-ae8d-11ea-9920-70bace5f6e02.png">

After:
<img width="1509" alt="image" src="https://user-images.githubusercontent.com/10324528/84603228-0eca9280-ae8d-11ea-8f0b-5c80a228d82f.png">
