### PR TITLE
[cms] fix invoices list date ranges

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -174,5 +174,3 @@ export const MONTHS_LABELS = [
   "Nov",
   "Dec"
 ];
-
-export const INVALID_DATE = "Invalid Date. Please provide a Date Object.";

--- a/src/containers/Invoice/helpers.js
+++ b/src/containers/Invoice/helpers.js
@@ -2,7 +2,6 @@ import {
   getCurrentMonth,
   getCurrentYear,
   getCurrentDateValue,
-  getYearAndMonthFromDate,
   getCurrentDefaultMonthAndYear
 } from "src/helpers";
 import { INVOICE_STATUS_NEW, INVOICE_STATUS_UPDATED } from "./constants";
@@ -109,13 +108,19 @@ export const getInvoiceTotalAmount = (invoice) => {
  */
 export const getPreviousMonthsRange = (range) => {
   const minDate = new Date();
-  const currentMonth = minDate.getMonth();
-  const currentYear = minDate.getFullYear();
-  if (currentMonth > range - 1) {
-    minDate.setMonth(currentMonth - range + 1);
+  let minMonth = minDate.getMonth() + 1;
+  let minYear = minDate.getFullYear();
+  if (minMonth > range) {
+    minMonth = minMonth - range;
   } else {
-    minDate.setMonth(12 - (range - currentMonth - 1));
-    minDate.setFullYear(currentYear - 1);
+    minMonth = 12 - (range - minMonth);
+    minYear = minYear - 1;
   }
-  return [getYearAndMonthFromDate(minDate), getCurrentDefaultMonthAndYear()];
+  return [
+    {
+      month: minMonth,
+      year: minYear
+    },
+    getCurrentDefaultMonthAndYear()
+  ];
 };

--- a/src/containers/Invoice/helpers.js
+++ b/src/containers/Invoice/helpers.js
@@ -102,11 +102,20 @@ export const getInvoiceTotalAmount = (invoice) => {
   return rate * totalHours + totalExpenses;
 };
 
+/**
+ * Returns min, max of a date range as array of two items.
+ * the first item is the beginning and second is current date obj
+ * @param {Number} range - number of months included in range
+ */
 export const getPreviousMonthsRange = (range) => {
-  // Tweak from Date API. If month is negative, it returns the last month of the
-  //   previous year. See: https://www.w3schools.com/jsref/jsref_setmonth.asp
-  const previous = new Date();
-  previous.setMonth(previous.getMonth() - range + 1);
-
-  return [getYearAndMonthFromDate(previous), getCurrentDefaultMonthAndYear()];
+  const minDate = new Date();
+  const currentMonth = minDate.getMonth();
+  const currentYear = minDate.getFullYear();
+  if (currentMonth > range - 1) {
+    minDate.setMonth(currentMonth - range + 1);
+  } else {
+    minDate.setMonth(12 - (range - currentMonth - 1));
+    minDate.setFullYear(currentYear - 1);
+  }
+  return [getYearAndMonthFromDate(minDate), getCurrentDefaultMonthAndYear()];
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -446,7 +446,10 @@ export const isValidDate = (date) => date instanceof Date && !isNaN(date);
 
 export const getYearAndMonthFromDate = (date) => {
   if (!isValidDate(date)) throw new Error(INVALID_DATE);
-  return { year: date.getFullYear(), month: date.getMonth() };
+  return {
+    year: date.getFullYear(),
+    month: date.getMonth() === 0 ? 12 : date.getMonth()
+  };
 };
 
 export const getCurrentDefaultMonthAndYear = () => ({

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -7,7 +7,7 @@ import range from "lodash/fp/range";
 import * as pki from "./lib/pki";
 import { sha3_256 } from "js-sha3";
 
-import { INVALID_FILE, INVALID_DATE } from "./constants";
+import { INVALID_FILE } from "./constants";
 import {
   INVOICE_STATUS_APPROVED,
   INVOICE_STATUS_DISPUTED,
@@ -441,16 +441,6 @@ export const getCurrentDateValue = () => {
 
 export const getDateFromYearAndMonth = ({ year, month }) =>
   new Date(year, month);
-
-export const isValidDate = (date) => date instanceof Date && !isNaN(date);
-
-export const getYearAndMonthFromDate = (date) => {
-  if (!isValidDate(date)) throw new Error(INVALID_DATE);
-  return {
-    year: date.getFullYear(),
-    month: date.getMonth() === 0 ? 12 : date.getMonth()
-  };
-};
 
 export const getCurrentDefaultMonthAndYear = () => ({
   month: getCurrentMonth() - 1,

--- a/src/utils.js
+++ b/src/utils.js
@@ -58,7 +58,6 @@ export const formatUnixTimestampToObj = (unixtimestamp) => {
  * @param {number} unixtimestamp - unix seconds timestamp
  * @return {string} date - date formated in dd mmm yyyy
  */
-
 export const formatShortUnixTimestamp = (unixtimestamp) => {
   const currentdate = new Date(unixtimestamp * 1000);
   return `${currentdate.getUTCDate()} ${


### PR DESCRIPTION
This diff closes #2003 by fixing `getPreviousMonthsRange` function, which didn't work properly when range started somewhere in previous year.

### Solution description
Adjusted `getPreviousMonthsRange` to work with ranges starting in previous year.
Also, discarded `getYearAndMonthFromDate` which was called in `getPreviousMonthsRange`, as we needed to convert from zero to one based months indexes when working with JS's Date API and DatePicker date values, now we return DatePikcer friendly values directly from `getPreviousMonthsRange`.


### UI Changes Screenshot
![image](https://user-images.githubusercontent.com/10324528/84665951-bfce3d00-af20-11ea-8f5b-53d6ac33fa6e.png)

