### PR TITLE
fix: show dark loaders on darkmode

### DIFF
--- a/src/components/CommentForm/CommentFormLoader.jsx
+++ b/src/components/CommentForm/CommentFormLoader.jsx
@@ -1,16 +1,22 @@
 import React from "react";
 import ContentLoader from "react-content-loader";
+import { useTheme, getThemeProperty } from "pi-ui";
 
-const ProposalFormLoader = () => (
-  <ContentLoader
-    height={420}
-    width={800}
-    speed={2}
-    primaryColor="#f3f3f3"
-    secondaryColor="#ecebeb">
-    <rect x="0" y="30" width="800" height="200" />
-    <rect x="630" y="250" width="170" height="50" />
-  </ContentLoader>
-);
+const ProposalFormLoader = () => {
+  const { theme } = useTheme();
+  const primaryColor = getThemeProperty(theme, "card-background");
+  const secondaryColor = getThemeProperty(theme, "dimmed-card-background");
+  return (
+    <ContentLoader
+      height={420}
+      width={800}
+      speed={2}
+      primaryColor={primaryColor}
+      secondaryColor={secondaryColor}>
+      <rect x="0" y="30" width="800" height="200" />
+      <rect x="630" y="250" width="170" height="50" />
+    </ContentLoader>
+  );
+};
 
 export default ProposalFormLoader;

--- a/src/components/Invoice/InvoiceLoader.jsx
+++ b/src/components/Invoice/InvoiceLoader.jsx
@@ -1,72 +1,93 @@
 import React from "react";
 import RecordWrapper from "../RecordWrapper";
-import { useMediaQuery } from "pi-ui";
+import { useMediaQuery, useTheme, getThemeProperty } from "pi-ui";
 
 import ContentLoader from "react-content-loader";
 
+const ExtraSmallLoader = ({
+  primaryColor,
+  secondaryColor,
+  yOffset,
+  extended
+}) => (
+  <ContentLoader
+    height={extended ? 300 : 170}
+    width={400}
+    speed={2}
+    primaryColor={primaryColor}
+    secondaryColor={secondaryColor}>
+    <rect x="0" y="0" width="180" height="10" />
+    <rect x="0" y="20" width="360" height="20" />
+    <rect x="0" y="60" width="80" height="20" />
+    {extended && (
+      <>
+        <rect x="0" y="100" width="20" height="14" />
+        <rect x="30" y="100" width="400" height="14" />
+        <rect x="0" y="134" width="400" height="1" />
+        <rect x="0" y="154" width="200" height="12" />
+        <rect x="0" y="180" width="400" height="12" />
+        <rect x="0" y="212" width="400" height="1" />
+      </>
+    )}
+    <rect x="0" y={`${156 + yOffset}`} width="130" height="14" />
+    {extended && (
+      <>
+        <rect x="0" y="220" width="140" height="20" />
+        <rect x="150" y="220" width="140" height="20" />
+      </>
+    )}
+  </ContentLoader>
+);
+
+const RegularLoader = ({ extended, primaryColor, secondaryColor, yOffset }) => (
+  <ContentLoader
+    height={extended ? 240 : 100}
+    width={800}
+    speed={2}
+    primaryColor={primaryColor}
+    secondaryColor={secondaryColor}>
+    <rect x="0" y="0" width="600" height="20" />
+    <rect x="700" y="0" width="100" height="20" />
+    <rect x="0" y="40" width="100" height="10" />
+    <rect x="110" y="40" width="200" height="10" />
+    {extended && (
+      <>
+        <rect x="0" y="60" width="20" height="14" />
+        <rect x="30" y="60" width="500" height="14" />
+        <rect x="0" y="100" width="800" height="1" />
+        <rect x="0" y="120" width="600" height="12" />
+        <rect x="0" y="136" width="800" height="12" />
+        <rect x="0" y="164" width="800" height="1" />
+      </>
+    )}
+    <rect x="0" y={`${80 + yOffset}`} width="130" height="14" />
+    {extended && (
+      <>
+        <rect x="0" y="220" width="140" height="20" />
+        <rect x="150" y="220" width="140" height="20" />
+      </>
+    )}
+  </ContentLoader>
+);
+
 const InvoiceLoader = ({ extended }) => {
   const extraSmall = useMediaQuery("(max-width: 560px)");
+  const { theme } = useTheme();
+
+  const primaryColor = getThemeProperty(theme, "card-background");
+  const secondaryColor = getThemeProperty(theme, "dimmed-card-background");
   const yOffset = extended ? 100 : 0;
   return (
     <RecordWrapper>
       {() =>
         extraSmall ? (
-          <ContentLoader
-            height={extended ? 300 : 170}
-            width={400}
-            speed={2}
-            primaryColor="#f3f3f3"
-            secondaryColor="#ecebeb">
-            <rect x="0" y="0" width="180" height="10" />
-            <rect x="0" y="20" width="360" height="20" />
-            <rect x="0" y="60" width="80" height="20" />
-            {extended && (
-              <>
-                <rect x="0" y="100" width="20" height="14" />
-                <rect x="30" y="100" width="400" height="14" />
-                <rect x="0" y="134" width="400" height="1" />
-                <rect x="0" y="154" width="200" height="12" />
-                <rect x="0" y="180" width="400" height="12" />
-                <rect x="0" y="212" width="400" height="1" />
-              </>
-            )}
-            <rect x="0" y={`${156 + yOffset}`} width="130" height="14" />
-            {extended && (
-              <>
-                <rect x="0" y="220" width="140" height="20" />
-                <rect x="150" y="220" width="140" height="20" />
-              </>
-            )}
-          </ContentLoader>
+          <ExtraSmallLoader
+            {...{ primaryColor, secondaryColor, yOffset, extended }}
+          />
         ) : (
-          <ContentLoader
-            height={extended ? 240 : 100}
-            width={800}
-            speed={2}
-            primaryColor="#f3f3f3"
-            secondaryColor="#ecebeb">
-            <rect x="0" y="0" width="600" height="20" />
-            <rect x="700" y="0" width="100" height="20" />
-            <rect x="0" y="40" width="100" height="10" />
-            <rect x="110" y="40" width="200" height="10" />
-            {extended && (
-              <>
-                <rect x="0" y="60" width="20" height="14" />
-                <rect x="30" y="60" width="500" height="14" />
-                <rect x="0" y="100" width="800" height="1" />
-                <rect x="0" y="120" width="600" height="12" />
-                <rect x="0" y="136" width="800" height="12" />
-                <rect x="0" y="164" width="800" height="1" />
-              </>
-            )}
-            <rect x="0" y={`${80 + yOffset}`} width="130" height="14" />
-            {extended && (
-              <>
-                <rect x="0" y="220" width="140" height="20" />
-                <rect x="150" y="220" width="140" height="20" />
-              </>
-            )}
-          </ContentLoader>
+          <RegularLoader
+            {...{ primaryColor, secondaryColor, yOffset, extended }}
+          />
         )
       }
     </RecordWrapper>

--- a/src/components/InvoiceDatasheet/components/CellRenderer/CellRenderer.module.css
+++ b/src/components/InvoiceDatasheet/components/CellRenderer/CellRenderer.module.css
@@ -22,6 +22,10 @@
   background: var(--color-orange-light) !important;
 }
 
+.erroredCell > * {
+  color: var(--color-gray-dark);
+}
+
 .erroredCell > input {
-  color: #303030;
+  color: var(--color-gray-dark);
 }

--- a/src/components/Proposal/ProposalLoader.jsx
+++ b/src/components/Proposal/ProposalLoader.jsx
@@ -4,6 +4,72 @@ import { useMediaQuery, useTheme, getThemeProperty } from "pi-ui";
 
 import ContentLoader from "react-content-loader";
 
+const ExtraSmallLoader = ({
+  primaryColor,
+  secondaryColor,
+  extended,
+  yOffset
+}) => (
+  <ContentLoader
+    height={extended ? 300 : 170}
+    width={400}
+    speed={2}
+    primaryColor={primaryColor}
+    secondaryColor={secondaryColor}>
+    <rect x="0" y="0" width="180" height="10" />
+    <rect x="0" y="20" width="360" height="20" />
+    <rect x="0" y="60" width="80" height="20" />
+    {extended && (
+      <>
+        <rect x="0" y="100" width="20" height="14" />
+        <rect x="30" y="100" width="400" height="14" />
+        <rect x="0" y="134" width="400" height="1" />
+        <rect x="0" y="154" width="200" height="12" />
+        <rect x="0" y="180" width="400" height="12" />
+        <rect x="0" y="212" width="400" height="1" />
+      </>
+    )}
+    <rect x="0" y={`${156 + yOffset}`} width="130" height="14" />
+    {extended && (
+      <>
+        <rect x="0" y="220" width="140" height="20" />
+        <rect x="150" y="220" width="140" height="20" />
+      </>
+    )}
+  </ContentLoader>
+);
+
+const RegularLoader = ({ primaryColor, secondaryColor, extended, yOffset }) => (
+  <ContentLoader
+    height={extended ? 240 : 100}
+    width={800}
+    speed={2}
+    primaryColor={primaryColor}
+    secondaryColor={secondaryColor}>
+    <rect x="0" y="0" width="600" height="20" />
+    <rect x="700" y="0" width="100" height="20" />
+    <rect x="0" y="40" width="100" height="10" />
+    <rect x="110" y="40" width="200" height="10" />
+    {extended && (
+      <>
+        <rect x="0" y="60" width="20" height="14" />
+        <rect x="30" y="60" width="500" height="14" />
+        <rect x="0" y="100" width="800" height="1" />
+        <rect x="0" y="120" width="600" height="12" />
+        <rect x="0" y="136" width="800" height="12" />
+        <rect x="0" y="164" width="800" height="1" />
+      </>
+    )}
+    <rect x="0" y={`${80 + yOffset}`} width="130" height="14" />
+    {extended && (
+      <>
+        <rect x="0" y="220" width="140" height="20" />
+        <rect x="150" y="220" width="140" height="20" />
+      </>
+    )}
+  </ContentLoader>
+);
+
 const ProposalLoader = ({ extended }) => {
   const extraSmall = useMediaQuery("(max-width: 560px)");
   const yOffset = extended ? 100 : 0;
@@ -14,62 +80,13 @@ const ProposalLoader = ({ extended }) => {
     <RecordWrapper>
       {() =>
         extraSmall ? (
-          <ContentLoader
-            height={extended ? 300 : 170}
-            width={400}
-            speed={2}
-            primaryColor={primaryColor}
-            secondaryColor={secondaryColor}>
-            <rect x="0" y="0" width="180" height="10" />
-            <rect x="0" y="20" width="360" height="20" />
-            <rect x="0" y="60" width="80" height="20" />
-            {extended && (
-              <>
-                <rect x="0" y="100" width="20" height="14" />
-                <rect x="30" y="100" width="400" height="14" />
-                <rect x="0" y="134" width="400" height="1" />
-                <rect x="0" y="154" width="200" height="12" />
-                <rect x="0" y="180" width="400" height="12" />
-                <rect x="0" y="212" width="400" height="1" />
-              </>
-            )}
-            <rect x="0" y={`${156 + yOffset}`} width="130" height="14" />
-            {extended && (
-              <>
-                <rect x="0" y="220" width="140" height="20" />
-                <rect x="150" y="220" width="140" height="20" />
-              </>
-            )}
-          </ContentLoader>
+          <ExtraSmallLoader
+            {...{ primaryColor, secondaryColor, extended, yOffset }}
+          />
         ) : (
-          <ContentLoader
-            height={extended ? 240 : 100}
-            width={800}
-            speed={2}
-            primaryColor={primaryColor}
-            secondaryColor={secondaryColor}>
-            <rect x="0" y="0" width="600" height="20" />
-            <rect x="700" y="0" width="100" height="20" />
-            <rect x="0" y="40" width="100" height="10" />
-            <rect x="110" y="40" width="200" height="10" />
-            {extended && (
-              <>
-                <rect x="0" y="60" width="20" height="14" />
-                <rect x="30" y="60" width="500" height="14" />
-                <rect x="0" y="100" width="800" height="1" />
-                <rect x="0" y="120" width="600" height="12" />
-                <rect x="0" y="136" width="800" height="12" />
-                <rect x="0" y="164" width="800" height="1" />
-              </>
-            )}
-            <rect x="0" y={`${80 + yOffset}`} width="130" height="14" />
-            {extended && (
-              <>
-                <rect x="0" y="220" width="140" height="20" />
-                <rect x="150" y="220" width="140" height="20" />
-              </>
-            )}
-          </ContentLoader>
+          <RegularLoader
+            {...{ primaryColor, secondaryColor, extended, yOffset }}
+          />
         )
       }
     </RecordWrapper>

--- a/src/components/ProposalForm/ProposalFormLoader.jsx
+++ b/src/components/ProposalForm/ProposalFormLoader.jsx
@@ -1,25 +1,31 @@
 import React from "react";
 import ContentLoader from "react-content-loader";
+import { useTheme, getThemeProperty } from "pi-ui";
 
-const ProposalFormLoader = () => (
-  <ContentLoader
-    height={420}
-    width={800}
-    speed={2}
-    primaryColor="#f3f3f3"
-    secondaryColor="#ecebeb">
-    <rect x="0" y="10" width="800" height="40" />
+const ProposalFormLoader = () => {
+  const { theme } = useTheme();
+  const primaryColor = getThemeProperty(theme, "card-background");
+  const secondaryColor = getThemeProperty(theme, "dimmed-card-background");
+  return (
+    <ContentLoader
+      height={420}
+      width={800}
+      speed={2}
+      primaryColor={primaryColor}
+      secondaryColor={secondaryColor}>
+      <rect x="0" y="10" width="800" height="40" />
 
-    <rect x="0" y="75" width="800" height="1" />
+      <rect x="0" y="75" width="800" height="1" />
 
-    <rect x="0" y="100" width="800" height="150" />
+      <rect x="0" y="100" width="800" height="150" />
 
-    <rect x="0" y="280" width="800" height="1" />
-    <rect x="0" y="310" width="130" height="14" />
-    <rect x="150" y="310" width="130" height="14" />
-    <rect x="500" y="360" width="140" height="40" />
-    <rect x="650" y="360" width="140" height="40" />
-  </ContentLoader>
-);
+      <rect x="0" y="280" width="800" height="1" />
+      <rect x="0" y="310" width="130" height="14" />
+      <rect x="150" y="310" width="130" height="14" />
+      <rect x="500" y="360" width="140" height="40" />
+      <rect x="650" y="360" width="140" height="40" />
+    </ContentLoader>
+  );
+};
 
 export default ProposalFormLoader;

--- a/src/components/ProposalsList/ProposalsList.jsx
+++ b/src/components/ProposalsList/ProposalsList.jsx
@@ -8,11 +8,11 @@ import ContentLoader from "react-content-loader";
 
 const Placeholder = () => {
   const { theme } = useTheme();
-  const primaryColor = getThemeProperty(theme, "color-gray-lightest");
-  const secondaryColor = getThemeProperty(theme, "color-gray-lighter");
+  const primaryColor = getThemeProperty(theme, "card-background");
+  const secondaryColor = getThemeProperty(theme, "dimmed-card-background");
   return (
     <ContentLoader
-      height={420}
+      height={220}
       width={800}
       speed={2}
       primaryColor={primaryColor}
@@ -45,7 +45,7 @@ const ProposalsList = ({ data: { proposals, voteSummaries } }) => {
             />
           ))
       ) : (
-        <LoadingPlaceholders numberOfItems={2} placeholder={Placeholder} />
+        <LoadingPlaceholders numberOfItems={1} placeholder={Placeholder} />
       )}
     </div>
   );

--- a/src/containers/Comments/Comment/CommentLoader.jsx
+++ b/src/containers/Comments/Comment/CommentLoader.jsx
@@ -1,16 +1,20 @@
 import React from "react";
-import { useMediaQuery } from "pi-ui";
+import { useMediaQuery, useTheme, getThemeProperty } from "pi-ui";
 import ContentLoader from "react-content-loader";
 
 const CommentLoader = () => {
+  const { theme } = useTheme();
+
+  const primaryColor = getThemeProperty(theme, "card-background");
+  const secondaryColor = getThemeProperty(theme, "dimmed-card-background");
   const extraSmall = useMediaQuery("(max-width: 560px)");
   return (
     <ContentLoader
       height={100}
       width={extraSmall ? 400 : 600}
       speed={2}
-      primaryColor="#f3f3f3"
-      secondaryColor="#ecebeb">
+      primaryColor={primaryColor}
+      secondaryColor={secondaryColor}>
       <rect
         x="0"
         y="10"


### PR DESCRIPTION
This PR Closes #1995 issue which reported a light-themed view on some loaders on darkmode. This was caused by a hard-coded color hex string.

### Solution description

The solution was to use the `useTheme` hook to get the current theme, and then get its respective primary and secondary colors.

Also, this diff improves Invoice and Proposal loaders modularization by splitting the loader into 2 components, called `ExtraSmallLoader` and `RegularLoader`

### UI Changes Screenshot

Before:
<img width="1279" alt="Screen Shot 2020-06-15 at 6 09 31 PM" src="https://user-images.githubusercontent.com/22639213/84706534-80f5b280-af33-11ea-9baa-5aac45c46f32.png">

After:
<img width="1279" alt="Screen Shot 2020-06-15 at 6 10 03 PM" src="https://user-images.githubusercontent.com/22639213/84706542-8521d000-af33-11ea-9738-328e1338fe9f.png">
