### PR TITLE
[cms] Add formatting helper for cents to USD

### DIFF
--- a/src/containers/Invoice/Payouts/PayoutsList.jsx
+++ b/src/containers/Invoice/Payouts/PayoutsList.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link, Button, Spinner, Table, CopyableText, classNames } from "pi-ui";
 import PropTypes from "prop-types";
-import { convertAtomsToDcr, formatShortUnixTimestamp } from "src/utils";
+import { convertAtomsToDcr, formatShortUnixTimestamp, formatCentsToUSD } from "src/utils";
 import { useAdminPayouts } from "./hooks";
 import ExportToCsv from "src/components/ExportToCsv";
 import HelpMessage from "src/components/HelpMessage";
@@ -55,12 +55,12 @@ const PayoutsList = ({ TopBanner, PageDetails, Main }) => {
                     approvedtime: formatShortUnixTimestamp(approvedtime),
                     month: `${month}/${year}`,
                     contractorname,
-                    contractorrate: contractorrate / 100,
-                    labortotal: labortotal / 100,
-                    expensetotal: expensetotal / 100,
-                    total: total / 100,
-                    exchangerate: exchangerate / 100,
-                    dcrtotal: convertAtomsToDcr(dcrtotal),
+                    contractorrate: formatCentsToUSD(contractorrate),
+                    labortotal: formatCentsToUSD(labortotal),
+                    expensetotal: formatCentsToUSD(expensetotal),
+                    total: formatCentsToUSD(total),
+                    exchangerate: formatCentsToUSD(exchangerate),
+                    dcrtotal: convertAtomsToDcr(dcrtotal) + " DCR",
                     address: (
                       <CopyableText
                         truncate
@@ -87,7 +87,35 @@ const PayoutsList = ({ TopBanner, PageDetails, Main }) => {
               ]}></Table>
             <Row noMargin justify="right">
               <ExportToCsv
-                data={payouts}
+                data={payouts.map(
+                  ({
+                    approvedtime,
+                    year,
+                    month,
+                    contractorname,
+                    contractorrate,
+                    labortotal,
+                    expensetotal,
+                    total,
+                    exchangerate,
+                    address,
+                    dcrtotal
+                  }) => {
+                    return {
+                      approvedtime: formatShortUnixTimestamp(approvedtime),
+                      month: `${month}/${year}`,
+                      contractorname,
+                      contractorrate: formatCentsToUSD(contractorrate),
+                      labortotal: formatCentsToUSD(labortotal),
+                      expensetotal: formatCentsToUSD(expensetotal),
+                      total: formatCentsToUSD(total),
+                      exchangerate: formatCentsToUSD(exchangerate),
+                      address: address,
+                      dcrtotal: convertAtomsToDcr(dcrtotal) + " DCR"
+                    };
+                  }
+                )
+                }
                 fields={[
                   "approvedtime",
                   "year",
@@ -98,8 +126,8 @@ const PayoutsList = ({ TopBanner, PageDetails, Main }) => {
                   "expensetotal",
                   "total",
                   "exchangerate",
-                  "dcrtotal",
-                  "address"
+                  "address",
+                  "dcrtotal"
                 ]}
                 filename="payouts">
                 <Link className="cursor-pointer">Export To Csv</Link>

--- a/src/containers/Invoice/Payouts/PayoutsList.jsx
+++ b/src/containers/Invoice/Payouts/PayoutsList.jsx
@@ -1,7 +1,11 @@
 import React from "react";
 import { Link, Button, Spinner, Table, CopyableText, classNames } from "pi-ui";
 import PropTypes from "prop-types";
-import { convertAtomsToDcr, formatShortUnixTimestamp, formatCentsToUSD } from "src/utils";
+import {
+  convertAtomsToDcr,
+  formatShortUnixTimestamp,
+  formatCentsToUSD
+} from "src/utils";
 import { useAdminPayouts } from "./hooks";
 import ExportToCsv from "src/components/ExportToCsv";
 import HelpMessage from "src/components/HelpMessage";
@@ -114,8 +118,7 @@ const PayoutsList = ({ TopBanner, PageDetails, Main }) => {
                       dcrtotal: convertAtomsToDcr(dcrtotal) + " DCR"
                     };
                   }
-                )
-                }
+                )}
                 fields={[
                   "approvedtime",
                   "year",

--- a/src/utils.js
+++ b/src/utils.js
@@ -77,3 +77,9 @@ export const currencyFormatter = (currency) =>
 
 /** exports an usdFormatter */
 export const usdFormatter = currencyFormatter("USD");
+
+/** Exports a simple formatter that takes cents and returns in dollars and label */
+export const formatCentsToUSD = (centsInput) => {
+  const dollars = centsInput / 100;
+  return dollars.toFixed(2) + " USD";
+};


### PR DESCRIPTION


This PR makes sure that all values displayed on the payouts page and exported csv are consistently shown as XXX.XX USD and XXX.XX DCR.

### Solution Description

Add a formatting helper to utils `formatCentsToUSD` that takes cents as the argument and returns a string with XXX.XX USD.

