### PR TITLE
[CMS] fix: improve paste on datasheet

### DIFF
--- a/src/components/InvoiceDatasheet/InvoiceDatasheet.jsx
+++ b/src/components/InvoiceDatasheet/InvoiceDatasheet.jsx
@@ -33,7 +33,6 @@ const InvoiceDatasheet = React.memo(function InvoiceDatasheet({
 
   const handleCellsChange = useCallback(
     (changes) => {
-      console.log(changes);
       const { grid: newGrid } = processCellsChange(grid, changes, userRate);
       const lineItems = convertGridToLineItems(newGrid);
       onChange(lineItems);

--- a/src/components/InvoiceDatasheet/InvoiceDatasheet.jsx
+++ b/src/components/InvoiceDatasheet/InvoiceDatasheet.jsx
@@ -33,6 +33,7 @@ const InvoiceDatasheet = React.memo(function InvoiceDatasheet({
 
   const handleCellsChange = useCallback(
     (changes) => {
+      console.log(changes);
       const { grid: newGrid } = processCellsChange(grid, changes, userRate);
       const lineItems = convertGridToLineItems(newGrid);
       onChange(lineItems);
@@ -52,7 +53,7 @@ const InvoiceDatasheet = React.memo(function InvoiceDatasheet({
 
   const handleAddNewRow = useCallback(
     (e) => {
-      e.preventDefault();
+      e && e.preventDefault();
       const newValue = value.concat([generateBlankLineItem(policy)]);
       onChange(newValue);
     },
@@ -82,6 +83,27 @@ const InvoiceDatasheet = React.memo(function InvoiceDatasheet({
       subContractors
     ]
   );
+
+  const handlePaste = (str) => {
+    // Track number of lines pasted
+    let rowCount = 0;
+
+    // Parse pasted comma-separated values
+    const grid = str.split(/\r\n|\n|\r/).map(function (row) {
+      rowCount++;
+      return row.split("\t");
+    });
+
+    // Add new rows programtically in case the user wants to paste more lines than the number currently available
+    let newValue = value;
+    for (let i = value.length; i < rowCount; i++) {
+      newValue = newValue.concat([generateBlankLineItem(policy)]);
+    }
+    // Update state
+    onChange(newValue);
+
+    return grid;
+  };
 
   const handleRemoveLastRow = useCallback(
     (e) => {
@@ -147,6 +169,7 @@ const InvoiceDatasheet = React.memo(function InvoiceDatasheet({
       <div className={styles.datasheetWrapper}>
         <ReactDataSheet
           data={grid}
+          parsePaste={handlePaste}
           valueRenderer={valueRenderer}
           onContextMenu={onContextMenu}
           onCellsChanged={handleCellsChange}


### PR DESCRIPTION
This PR fixes part of https://github.com/decred/politeiagui/issues/1924

### Solution description

I'm passing a custom parser to `react-datasheet`'s `pasteParser` prop and while I paste the csv string I count the rows and add new ones programatically.

### UI Changes Screenshot

**After**
![improved paste](https://user-images.githubusercontent.com/13955303/85207329-69854380-b2fe-11ea-9c68-f6bf3841c3c2.gif)
