### PR TITLE
[CMS] fix: allow to copy chunks of text inside a cell

### DIFF
--- a/src/components/InvoiceDatasheet/InvoiceDatasheet.jsx
+++ b/src/components/InvoiceDatasheet/InvoiceDatasheet.jsx
@@ -94,13 +94,15 @@ const InvoiceDatasheet = React.memo(function InvoiceDatasheet({
     }
     e.preventDefault();
     /**
-     *  The next line is necessary to not run the callback for the event listener attached to the document by react-spreadsheet
+     *  The next line is necessary to not run the callback for the event
+     * listener attached to the document by react-spreadsheet
      */
     e.stopPropagation();
   };
 
   /**
-   * This hook adds a listener to a copy action in the document.body. Adding it to the document.body allow us to overwrite the one added by react-spreadsheet to the document.
+   * This hook adds a listener to a copy action in the document.body.
+   * Adding it to the document.body allow us to overwrite the one added by react-spreadsheet to the document.
    */
   useEffect(
     function customCopy() {

--- a/src/components/InvoiceDatasheet/InvoiceDatasheet.jsx
+++ b/src/components/InvoiceDatasheet/InvoiceDatasheet.jsx
@@ -1,10 +1,4 @@
-import React, {
-  useState,
-  useEffect,
-  useLayoutEffect,
-  useCallback,
-  useMemo
-} from "react";
+import React, { useState, useEffect, useCallback, useMemo } from "react";
 import { classNames } from "pi-ui";
 import PropTypes from "prop-types";
 import ReactDataSheet from "react-datasheet";
@@ -108,13 +102,18 @@ const InvoiceDatasheet = React.memo(function InvoiceDatasheet({
   /**
    * This hook adds a listener to a copy action in the document.body. Adding it to the document.body allow us to overwrite the one added by react-spreadsheet to the document.
    */
-  useEffect(function customCopy() {
-    document.body.addEventListener("copy", handleCopy);
+  useEffect(
+    function customCopy() {
+      if (readOnly) {
+        document.body.addEventListener("copy", handleCopy);
 
-    return function removeCopyListener() {
-      document.body.removeEventListener("copy", handleCopy);
-    };
-  }, []);
+        return function removeCopyListener() {
+          document.body.removeEventListener("copy", handleCopy);
+        };
+      }
+    },
+    [readOnly]
+  );
 
   const handleRemoveLastRow = useCallback(
     (e) => {

--- a/src/components/InvoiceDatasheet/InvoiceDatasheet.module.css
+++ b/src/components/InvoiceDatasheet/InvoiceDatasheet.module.css
@@ -48,6 +48,8 @@ pre {
 }
 
 .multilineCellValue {
+  user-select: text;
+  cursor: text;
   word-break: break-word;
   white-space: pre-line !important;
   padding: 0 0.5rem;


### PR DESCRIPTION
This PR fixes part of #1924

### Solution description

I am overwriting the `react-datasheet` copy event listener so now the user can copy chunks of text inside a cell on readOnly mode.

### UI Changes Screenshot

![coolcopy](https://user-images.githubusercontent.com/13955303/85214831-b987f880-b346-11ea-8eef-7fe2b5d21a0d.gif)

