### PR TITLE
[CMS] fix: remove Tooltip and add global errors to datasheet

### DIFF
--- a/src/components/InvoiceDatasheet/InvoiceDatasheet.jsx
+++ b/src/components/InvoiceDatasheet/InvoiceDatasheet.jsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect, useCallback, useMemo } from "react";
-import { classNames } from "pi-ui";
+import { classNames, H2, P } from "pi-ui";
 import PropTypes from "prop-types";
 import ReactDataSheet from "react-datasheet";
 import dropRight from "lodash/dropRight";
+import flowRight from "lodash/flowRight";
+import uniq from "lodash/uniq";
 import "react-datasheet/lib/react-datasheet.css";
 import styles from "./InvoiceDatasheet.module.css";
 import CellRenderer from "./components/CellRenderer";
@@ -153,8 +155,26 @@ const InvoiceDatasheet = React.memo(function InvoiceDatasheet({
 
   const removeRowsIsDisabled = grid && grid.length <= 2;
 
+  const renderErrors = () => {
+    // Get all unique normalized errors
+    const uniqueErrArr = flowRight([
+      uniq,
+      () => errors.flatMap((error) => Object.values(error))
+    ])();
+    return uniqueErrArr && uniqueErrArr.length ? (
+      <div>
+        <H2 className={styles.invoiceError}>Errors</H2>
+        {uniqueErrArr.map((err, i) => (
+          <P key={i} className={styles.invoiceError}>
+            {err.charAt(0).toUpperCase() + err.slice(1)}
+          </P>
+        ))}
+      </div>
+    ) : null;
+  };
   return (
     <div className={styles.wrapper}>
+      {renderErrors()}
       {!readOnly && (
         <div className="justify-right margin-top-s margin-bottom-s">
           <TableButton onClick={handleAddNewRow}>Add item</TableButton>

--- a/src/components/InvoiceDatasheet/InvoiceDatasheet.module.css
+++ b/src/components/InvoiceDatasheet/InvoiceDatasheet.module.css
@@ -102,3 +102,8 @@ pre {
   display: flex;
   align-items: center;
 }
+
+.invoiceError {
+  color: var(--color-orange) !important;
+  margin-bottom: 0 !important;
+}

--- a/src/components/InvoiceDatasheet/components/CellRenderer/CellRenderer.jsx
+++ b/src/components/InvoiceDatasheet/components/CellRenderer/CellRenderer.jsx
@@ -1,7 +1,6 @@
 import React, { useCallback } from "react";
-import { Tooltip, classNames } from "pi-ui";
+import { classNames } from "pi-ui";
 import styles from "./CellRenderer.module.css";
-import useAsyncState from "src/hooks/utils/useAsyncState";
 
 const CellRenderer = ({
   cell: { error, readOnly },
@@ -13,26 +12,20 @@ const CellRenderer = ({
   className,
   children
 }) => {
-  const [showTooltip, setShowTooltip] = useAsyncState();
-
   const handleOnMouseOver = useCallback(
-    async (e) => {
-      if (editing) {
-        await setShowTooltip(false);
-      }
+    (e) => {
       onMouseOver(e);
     },
-    [editing, onMouseOver, setShowTooltip]
+    [onMouseOver]
   );
 
   const handleOnMouseDown = useCallback(
-    async (e) => {
+    (e) => {
       if (!editing) {
-        await setShowTooltip(!!error);
         onMouseDown(e);
       }
     },
-    [onMouseDown, setShowTooltip, editing, error]
+    [onMouseDown, editing]
   );
 
   return (
@@ -46,14 +39,6 @@ const CellRenderer = ({
       onDoubleClick={onDoubleClick}
       onContextMenu={onContextMenu}>
       {children}
-      {showTooltip && (
-        <Tooltip
-          className={styles.errorTooltip}
-          contentClassName={styles.errorTooltipContent}
-          placement="top"
-          content={error}
-        />
-      )}
     </td>
   );
 };

--- a/src/components/InvoiceDatasheet/helpers.js
+++ b/src/components/InvoiceDatasheet/helpers.js
@@ -106,7 +106,7 @@ export const convertLineItemsToGrid = (
         {
           readOnly,
           value: line.domain,
-          error: false,
+          error: rowErrors && rowErrors.domain,
           dataEditor: selectWrapper(
             policyDomains.map((op) => ({
               value: capitalizeFirstLetter(op.description),


### PR DESCRIPTION
This PR is the last one for https://github.com/decred/politeiagui/issues/1924.
Closes https://github.com/decred/politeiagui/issues/1924
 
### Solution description

I am removing the error Tooltip and showing unique normalized global errors on top. The cells with errors are still highlighted.

### UI Changes Screenshot

![Screen Shot 2020-06-22 at 11 07 58](https://user-images.githubusercontent.com/13955303/85297078-b2f99e00-b478-11ea-8def-d60e63e9f207.png)

