### PR TITLE
fix: Show start runoff vote button only to admins

### DIFF
--- a/src/components/Proposal/ProposalActions.jsx
+++ b/src/components/Proposal/ProposalActions.jsx
@@ -129,20 +129,25 @@ const PublicActions = ({
         </div>
       )}
       {isRfpReadyToRunoff(proposal, voteSummary) && submssionsDidntVote && (
-        <div className="justify-right margin-top-m">
-          <Button
-            onClick={withProposal(onStartRunoffVote, resetRfpSubmissionsData)}>
-            Start Runoff Vote
-          </Button>
-        </div>
+        <AdminContent>
+          <div className="justify-right margin-top-m">
+            <Button
+              onClick={withProposal(
+                onStartRunoffVote,
+                resetRfpSubmissionsData
+              )}>
+              Start Runoff Vote
+            </Button>
+          </div>
+        </AdminContent>
       )}
     </>
   );
 };
 
-const ProposalActions = ({ proposal, voteSummary }) => {
+const ProposalActions = ({ proposal, ...props }) => {
   return isPublicProposal(proposal) || isAbandonedProposal(proposal) ? (
-    <PublicActions proposal={proposal} voteSummary={voteSummary} />
+    <PublicActions {...{ ...props, proposal }} />
   ) : (
     <UnvettedActions proposal={proposal} />
   );


### PR DESCRIPTION
This diff closes #2026, and ensures that `start runoff vote` button is displayed only for admins.

### Solution description

Wrapped the content with `<AdminContent>` and fixed missing rfp data because of wrapper components props swallow.  


