### PR TITLE
cms: invoice datasheet minor fixes

### DIFF
--- a/src/components/InvoiceDatasheet/InvoiceDatasheet.jsx
+++ b/src/components/InvoiceDatasheet/InvoiceDatasheet.jsx
@@ -192,7 +192,7 @@ const InvoiceDatasheet = React.memo(function InvoiceDatasheet({
     // Get all unique normalized errors
     const uniqueErrArr = flowRight([
       uniq,
-      () => errors.flatMap((error) => Object.values(error))
+      () => errors && errors.flatMap((error) => Object.values(error))
     ])();
     return uniqueErrArr && uniqueErrArr.length ? (
       <div>

--- a/src/components/InvoiceDatasheet/helpers.js
+++ b/src/components/InvoiceDatasheet/helpers.js
@@ -55,7 +55,7 @@ export const generateBlankLineItem = (policy) => ({
   description: "",
   proposaltoken: "",
   labor: 0,
-  expenses: "",
+  expenses: 0,
   subtotal: "",
   subuserid: "",
   subrate: 0


### PR DESCRIPTION
This PR fixes some minor erros on invoice datasheet:
- `expenses` initial value was `""`, should be number;
- undefined `errors` not being handled