### PR TITLE
[cms] Add `domain` & `contractor type` filters to user search page

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -201,10 +201,10 @@ export const onVerifyNewUser = (email, verificationToken, username) => (
     });
 };
 
-export const onSearchUser = (query) => (dispatch) => {
+export const onSearchUser = (query, isCMS) => (dispatch) => {
   dispatch(act.REQUEST_USER_SEARCH());
-  return api
-    .searchUser(query)
+  const apiReq = !isCMS ? api.searchUser(query) : api.searchCmsUsers(query);
+  return apiReq
     .then((res) => dispatch(act.RECEIVE_USER_SEARCH({ ...res, query })))
     .catch((err) => {
       dispatch(act.RECEIVE_USER_SEARCH(null, err));

--- a/src/containers/User/Search/Search.jsx
+++ b/src/containers/User/Search/Search.jsx
@@ -34,20 +34,16 @@ const UserSearch = ({ TopBanner, PageDetails, Main, Title }) => {
   const [foundUsers, setFoundUsers] = useState([]);
 
   const searchOptions = useMemo(() => {
-    const options = [
+    if (isCMS) {
+      return [
+        { value: "domain", label: "Domain" },
+        { value: "contractortype", label: "Contractor type" }
+      ];
+    }
+    return [
       { value: "email", label: "Email" },
       { value: "username", label: "Username" }
     ];
-    // If CMS mode, add two more filter options
-    if (isCMS) {
-      options.push(
-        ...[
-          { value: "domain", label: "Domain" },
-          { value: "contractortype", label: "Contractor type" }
-        ]
-      );
-    }
-    return options;
   }, [isCMS]);
 
   async function onSubmit(values, { setSubmitting }) {
@@ -95,10 +91,12 @@ const UserSearch = ({ TopBanner, PageDetails, Main, Title }) => {
           <Formik
             initialValues={{
               searchTerm: "",
-              searchBy: "email"
+              searchBy: !isCMS ? "email" : "domain",
+              contractortype: undefined,
+              domain: undefined
             }}
             onSubmit={onSubmit}
-            validationSchema={searchSchema({ isCMS })}>
+            validationSchema={searchSchema}>
             {({
               values,
               handleChange,
@@ -114,8 +112,6 @@ const UserSearch = ({ TopBanner, PageDetails, Main, Title }) => {
               const isByDomain = values.searchBy === "domain";
               const isByType = values.searchBy === "contractortype";
               const isByEmail = values.searchBy === "email";
-              const isByUsername = values.searchBy === "username";
-              const showTextBox = isByUsername || isByEmail;
               return (
                 <form>
                   <RadioButtonGroup
@@ -127,7 +123,7 @@ const UserSearch = ({ TopBanner, PageDetails, Main, Title }) => {
                     onChange={handleChangeSearchBy}
                   />
                   <div className="justify-left margin-top-m">
-                    {showTextBox && (
+                    {!isCMS && (
                       <BoxTextInput
                         name="searchTerm"
                         className={styles.searchBox}
@@ -138,7 +134,7 @@ const UserSearch = ({ TopBanner, PageDetails, Main, Title }) => {
                     )}
                     {isByType && (
                       <SelectField
-                        name="type"
+                        name="contractortype"
                         className={styles.select}
                         options={selectTypeOptions}
                         value={values.contractortype}

--- a/src/containers/User/Search/Search.jsx
+++ b/src/containers/User/Search/Search.jsx
@@ -99,7 +99,9 @@ const UserSearch = ({ TopBanner, PageDetails, Main, Title }) => {
               };
               const isByDomain = values.searchBy === "domain";
               const isByType = values.searchBy === "contractortype";
-              const showTextBox = !isByDomain && !isByType;
+              const isByEmail = values.searchBy === "email";
+              const isByUsername = values.searchBy === "username";
+              const showTextBox = isByUsername || isByEmail;
               return (
                 <form>
                   <RadioButtonGroup
@@ -117,7 +119,7 @@ const UserSearch = ({ TopBanner, PageDetails, Main, Title }) => {
                         className={styles.searchBox}
                         value={values.searchTerm}
                         onChange={handleChange}
-                        placeholder="User email or username"
+                        placeholder={isByEmail ? "User email" : "Username"}
                       />
                     )}
                     {isByType && (
@@ -125,6 +127,7 @@ const UserSearch = ({ TopBanner, PageDetails, Main, Title }) => {
                         name="type"
                         className={styles.select}
                         options={selectTypeOptions}
+                        placeholder="Choose contractor type"
                       />
                     )}
                     {isByDomain && (
@@ -132,6 +135,7 @@ const UserSearch = ({ TopBanner, PageDetails, Main, Title }) => {
                         name="domain"
                         className={styles.select}
                         options={selectDomainOptions}
+                        placeholder="Choose a domain"
                       />
                     )}
                     <Button

--- a/src/containers/User/Search/Search.jsx
+++ b/src/containers/User/Search/Search.jsx
@@ -12,7 +12,9 @@ import {
 import React, { useEffect, useState } from "react";
 import {
   selectTypeOptions,
-  selectDomainOptions
+  selectDomainOptions,
+  domainOptions,
+  typeOptions
 } from "src/containers/User/Detail/ManageContractor/helpers";
 import HelpMessage from "src/components/HelpMessage";
 import SelectField from "src/components/Select/SelectField";
@@ -21,12 +23,20 @@ import styles from "./Search.module.css";
 import Link from "src/components/Link";
 import { searchSchema } from "./validation";
 
-const getFormattedSearchResults = (users = []) =>
-  users.map((u) => ({
-    Username: u.username,
-    Email: u.email,
-    ID: <Link to={`/user/${u.id}`}>{u.id}</Link>
-  }));
+const getFormattedSearchResults = (users = [], isCMS) =>
+  users.map((u) =>
+    !isCMS
+      ? {
+          Username: u.username,
+          Email: u.email,
+          ID: <Link to={`/user/${u.id}`}>{u.id}</Link>
+        }
+      : {
+          Username: <Link to={`/user/${u.id}`}>{u.username}</Link>,
+          Domain: domainOptions[u.domain],
+          Type: typeOptions[u.contractortype]
+        }
+  );
 
 const UserSearch = ({ TopBanner, PageDetails, Main, Title }) => {
   const { onSearchUser, searchResult, isCMS } = useSearchUser();
@@ -77,10 +87,10 @@ const UserSearch = ({ TopBanner, PageDetails, Main, Title }) => {
   useEffect(
     function updateFoundUsers() {
       if (searchResult) {
-        setFoundUsers(getFormattedSearchResults(searchResult));
+        setFoundUsers(getFormattedSearchResults(searchResult, isCMS));
       }
     },
-    [searchResult]
+    [searchResult, isCMS]
   );
   return (
     <>
@@ -172,7 +182,14 @@ const UserSearch = ({ TopBanner, PageDetails, Main, Title }) => {
           <Message kind="error">{searchError.toString()}</Message>
         ) : foundUsers && !!foundUsers.length ? (
           <Card className={classNames("container", "margin-bottom-m")}>
-            <Table data={foundUsers} headers={["Username", "Email", "ID"]} />
+            <Table
+              data={foundUsers}
+              headers={
+                !isCMS
+                  ? ["Username", "Email", "ID"]
+                  : ["Username", "Domain", "Type"]
+              }
+            />
           </Card>
         ) : (
           <HelpMessage>No users to show</HelpMessage>

--- a/src/containers/User/Search/Search.jsx
+++ b/src/containers/User/Search/Search.jsx
@@ -16,10 +16,10 @@ import {
 } from "src/containers/User/Detail/ManageContractor/helpers";
 import HelpMessage from "src/components/HelpMessage";
 import SelectField from "src/components/Select/SelectField";
-import * as Yup from "yup";
 import { useSearchUser } from "./hooks";
 import styles from "./Search.module.css";
 import Link from "src/components/Link";
+import { searchSchema } from "./validation";
 
 const getFormattedSearchResults = (users = []) =>
   users.map((u) => ({
@@ -83,16 +83,15 @@ const UserSearch = ({ TopBanner, PageDetails, Main, Title }) => {
               searchBy: "email"
             }}
             onSubmit={onSubmit}
-            validationSchema={Yup.object().shape({
-              searchTerm: Yup.string().required("Required")
-            })}>
+            validationSchema={searchSchema({ isCMS })}>
             {({
               values,
               handleChange,
               handleSubmit,
               isSubmitting,
               setFieldValue,
-              isValid
+              isValid,
+              errors
             }) => {
               const handleChangeSearchBy = (v) => {
                 setFieldValue("searchBy", v.value);
@@ -102,6 +101,7 @@ const UserSearch = ({ TopBanner, PageDetails, Main, Title }) => {
               const isByEmail = values.searchBy === "email";
               const isByUsername = values.searchBy === "username";
               const showTextBox = isByUsername || isByEmail;
+              console.log({ errors, isValid });
               return (
                 <form>
                   <RadioButtonGroup

--- a/src/containers/User/Search/Search.jsx
+++ b/src/containers/User/Search/Search.jsx
@@ -53,9 +53,24 @@ const UserSearch = ({ TopBanner, PageDetails, Main, Title }) => {
   async function onSubmit(values, { setSubmitting }) {
     try {
       setSearchError(null);
-      await onSearchUser({
-        [values.searchBy]: values.searchTerm
-      });
+      const isByDomain = values.searchBy === "domain";
+      const isByType = values.searchBy === "contractortype";
+      const isByEmail = values.searchBy === "email";
+      const isByUsername = values.searchBy === "username";
+
+      await onSearchUser(
+        {
+          [values.searchBy]:
+            isByUsername || isByEmail
+              ? values.searchTerm
+              : isByType
+              ? values.contractortype.value
+              : isByDomain
+              ? values.domain.value
+              : ""
+        },
+        isCMS
+      );
       setSubmitting(false);
     } catch (e) {
       setSubmitting(false);
@@ -90,18 +105,17 @@ const UserSearch = ({ TopBanner, PageDetails, Main, Title }) => {
               handleSubmit,
               isSubmitting,
               setFieldValue,
-              isValid,
-              errors
+              isValid
             }) => {
-              const handleChangeSearchBy = (v) => {
+              const handleChangeSearchBy = (v) =>
                 setFieldValue("searchBy", v.value);
-              };
+              const handleChangeSelectField = (field) => (v) =>
+                setFieldValue(field, v);
               const isByDomain = values.searchBy === "domain";
               const isByType = values.searchBy === "contractortype";
               const isByEmail = values.searchBy === "email";
               const isByUsername = values.searchBy === "username";
               const showTextBox = isByUsername || isByEmail;
-              console.log({ errors, isValid });
               return (
                 <form>
                   <RadioButtonGroup
@@ -127,6 +141,8 @@ const UserSearch = ({ TopBanner, PageDetails, Main, Title }) => {
                         name="type"
                         className={styles.select}
                         options={selectTypeOptions}
+                        value={values.contractortype}
+                        onChange={handleChangeSelectField("contractortype")}
                         placeholder="Choose contractor type"
                       />
                     )}
@@ -135,6 +151,8 @@ const UserSearch = ({ TopBanner, PageDetails, Main, Title }) => {
                         name="domain"
                         className={styles.select}
                         options={selectDomainOptions}
+                        value={values.domain}
+                        onChange={handleChangeSelectField("domain")}
                         placeholder="Choose a domain"
                       />
                     )}

--- a/src/containers/User/Search/Search.module.css
+++ b/src/containers/User/Search/Search.module.css
@@ -12,6 +12,16 @@
   margin-top: 0;
 }
 
+.select {
+  height: 4.6rem;
+  width: 24rem;
+  margin: 0 2rem 2rem 0;
+}
+
+.select [class*="customSelect__control"] {
+  height: 97%;
+}
+
 .searchButton {
   max-height: 4.2rem;
 }

--- a/src/containers/User/Search/Search.module.css
+++ b/src/containers/User/Search/Search.module.css
@@ -19,7 +19,7 @@
 }
 
 .select [class*="customSelect__control"] {
-  height: 97%;
+  height: calc(100% - 0.5rem);
 }
 
 .searchButton {

--- a/src/containers/User/Search/hooks.js
+++ b/src/containers/User/Search/hooks.js
@@ -35,6 +35,7 @@ export function useReactiveSearchUser(email, username) {
 export function useSearchUser() {
   const searchResult = useSelector(sel.searchResults);
   const onSearchUser = useAction(act.onSearchUser);
+  const isCMS = useSelector(sel.isCMS);
 
-  return { searchResult, onSearchUser };
+  return { searchResult, onSearchUser, isCMS };
 }

--- a/src/containers/User/Search/validation.js
+++ b/src/containers/User/Search/validation.js
@@ -1,0 +1,19 @@
+import * as Yup from "yup";
+
+export const searchSchema = ({ isCMS }) =>
+  Yup.object().shape({
+    searchBy: Yup.string()
+      .required("required")
+      .oneOf(["email", "username", "domain", "contractortype"]),
+    searchTerm: Yup.string().when("searchBy", (searchBy, schema) =>
+      !isCMS || searchBy === "email" || searchBy === "username"
+        ? schema.required("required")
+        : schema
+    ),
+    domain: Yup.string().when("searchBy", (searchBy, schema) =>
+      searchBy === "domain" ? schema.required("required") : schema
+    ),
+    contractortype: Yup.string().when("searchBy", (searchBy, schema) =>
+      searchBy === "contractortype" ? schema.required("required") : schema
+    )
+  });

--- a/src/containers/User/Search/validation.js
+++ b/src/containers/User/Search/validation.js
@@ -1,19 +1,18 @@
 import * as Yup from "yup";
 
-export const searchSchema = ({ isCMS }) =>
-  Yup.object().shape({
-    searchBy: Yup.string()
-      .required("required")
-      .oneOf(["email", "username", "domain", "contractortype"]),
-    searchTerm: Yup.string().when("searchBy", (searchBy, schema) =>
-      !isCMS || searchBy === "email" || searchBy === "username"
-        ? schema.required("required")
-        : schema
-    ),
-    domain: Yup.string().when("searchBy", (searchBy, schema) =>
-      searchBy === "domain" ? schema.required("required") : schema
-    ),
-    contractortype: Yup.string().when("searchBy", (searchBy, schema) =>
-      searchBy === "contractortype" ? schema.required("required") : schema
-    )
-  });
+export const searchSchema = Yup.object().shape({
+  searchBy: Yup.string()
+    .required("required")
+    .oneOf(["email", "username", "domain", "contractortype"]),
+  searchTerm: Yup.string().when("searchBy", (searchBy, schema) =>
+    searchBy === "email" || searchBy === "username"
+      ? schema.required("required")
+      : schema
+  ),
+  domain: Yup.object().when("searchBy", (searchBy, schema) =>
+    searchBy === "domain" ? schema.required("required") : schema
+  ),
+  contractortype: Yup.object().when("searchBy", (searchBy, schema) =>
+    searchBy === "contractortype" ? schema.required("required") : schema
+  )
+});

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -474,6 +474,9 @@ export const userProposals = (userid, after) => {
 export const searchUser = (obj) =>
   GET(`/v1/users?${qs.stringify(obj)}`).then(getResponse);
 
+export const searchCmsUsers = (obj) =>
+  GET(`/v1/cmsusers?${qs.stringify(obj)}`).then(getResponse);
+
 export const proposal = (token, version = null) =>
   GET(`/v1/proposals/${token}` + (version ? `?version=${version}` : "")).then(
     getResponse


### PR DESCRIPTION
This diff adds two options to CMS admin's search user page filters:
 - `Domain`
 - `Contractor Type`

### Solution description

Extends existing user search page, now in CMS mode the page will have different filtering options, instead of `username` & `email` we have in proposals mode, admin can search CMS users by `contractor type` & `domain`.

This diff uses the isCMS redux flag to determine which filters to display to user, how to map returned result from BE to table and to decide which endpoint to call(`/users` or `/cmsusers`.

### UI Changes Screenshot

![image](https://user-images.githubusercontent.com/10324528/85809808-5dafdc00-b759-11ea-984a-66d5d6cb3d70.png)


Closes #1959 

