### PR TITLE
RFP: disable deadline validation when editing a submission.

### DIFF
--- a/src/components/ProposalForm/ProposalForm.jsx
+++ b/src/components/ProposalForm/ProposalForm.jsx
@@ -247,8 +247,7 @@ const ProposalFormWrapper = ({
   onSubmit,
   disableSubmit,
   history,
-  isPublic,
-  isEdit
+  isPublic
 }) => {
   const [handleOpenModal, handleCloseModal] = useModalContext();
   const openMdModal = useCallback(() => {
@@ -280,7 +279,7 @@ const ProposalFormWrapper = ({
           if (isInvalidToken) {
             throw Error("Proposal not found!");
           }
-          if (!isEdit && !isActiveApprovedRfp(proposal, voteSummary)) {
+          if (!isPublic && !isActiveApprovedRfp(proposal, voteSummary)) {
             throw Error(
               "Make sure token is associated with an approved & not expired RFP"
             );
@@ -301,7 +300,7 @@ const ProposalFormWrapper = ({
         setFieldError("global", e);
       }
     },
-    [history, onSubmit, onFetchProposalsBatchWithoutState, isEdit]
+    [history, onSubmit, onFetchProposalsBatchWithoutState, isPublic]
   );
   return (
     <>

--- a/src/components/ProposalForm/ProposalForm.jsx
+++ b/src/components/ProposalForm/ProposalForm.jsx
@@ -247,7 +247,8 @@ const ProposalFormWrapper = ({
   onSubmit,
   disableSubmit,
   history,
-  isPublic
+  isPublic,
+  isEdit
 }) => {
   const [handleOpenModal, handleCloseModal] = useModalContext();
   const openMdModal = useCallback(() => {
@@ -279,7 +280,7 @@ const ProposalFormWrapper = ({
           if (isInvalidToken) {
             throw Error("Proposal not found!");
           }
-          if (!isActiveApprovedRfp(proposal, voteSummary)) {
+          if (!isEdit && !isActiveApprovedRfp(proposal, voteSummary)) {
             throw Error(
               "Make sure token is associated with an approved & not expired RFP"
             );
@@ -300,7 +301,7 @@ const ProposalFormWrapper = ({
         setFieldError("global", e);
       }
     },
-    [history, onSubmit, onFetchProposalsBatchWithoutState]
+    [history, onSubmit, onFetchProposalsBatchWithoutState, isEdit]
   );
   return (
     <>

--- a/src/containers/Proposal/Edit/Edit.jsx
+++ b/src/containers/Proposal/Edit/Edit.jsx
@@ -67,7 +67,6 @@ const EditProposal = ({ match }) => {
           initialValues={initialValues}
           onSubmit={onEditProposal}
           isPublic={isPublic}
-          isEdit={true}
         />
       ) : (
         <ProposalFormLoader />

--- a/src/containers/Proposal/Edit/Edit.jsx
+++ b/src/containers/Proposal/Edit/Edit.jsx
@@ -67,6 +67,7 @@ const EditProposal = ({ match }) => {
           initialValues={initialValues}
           onSubmit={onEditProposal}
           isPublic={isPublic}
+          isEdit={true}
         />
       ) : (
         <ProposalFormLoader />


### PR DESCRIPTION
This diff closes #2039 - it disables the deadline validations when *editing* an RFP submission.

### Solution description
v1: ~~Adds `isEdit` prop to the `ProposalForm` component which is used for both creating & editing a proposal.
and uses the flag to disable the validation.~~

v2: uses `isPublic` prop in proposal form to disable the validations - as it already used to make rfp token field readonly when editing submission.

Depends on: https://github.com/decred/politeia/pull/1237
