### PR TITLE
fix: Filter abandoned proposals out when starting runoff vote

### DIFF
--- a/src/containers/Proposal/Actions/PublicActionsProvider.jsx
+++ b/src/containers/Proposal/Actions/PublicActionsProvider.jsx
@@ -105,15 +105,16 @@ const PublicActionsProvider = ({ children }) => {
       const [submissions] = await onFetchProposalsBatchWithoutState(
         proposal.linkedfrom
       );
-      // Filter abandoned submmsions out.
-      const publicSubmissions = submissions.filter(
-        (prop) => !isAbandonedProposal(prop)
-      );
-      const submissionVotes = publicSubmissions.map(
-        ({ censorshiprecord: { token } = { token: null }, version }) => ({
-          token,
-          proposalversion: version
-        })
+      // Filter abandoned submmsions out & maps to proposal tokens.
+      const submissionVotes = submissions.flatMap((prop) =>
+        isAbandonedProposal(prop)
+          ? []
+          : [
+              {
+                token: prop.censorshiprecord.token,
+                proposalversion: prop.version
+              }
+            ]
       );
       handleOpenModal(ModalStartVote, {
         title: `Start runoff vote - ${proposal.name}`,

--- a/src/containers/Proposal/Actions/PublicActionsProvider.jsx
+++ b/src/containers/Proposal/Actions/PublicActionsProvider.jsx
@@ -2,6 +2,7 @@ import React, { useCallback } from "react";
 import { Text } from "pi-ui";
 import Link from "src/components/Link";
 import { PublicProposalsActionsContext, usePublicActions } from "./hooks";
+import { isAbandonedProposal } from "src/containers/Proposal/helpers";
 import ModalConfirm from "src/components/ModalConfirm";
 import ModalConfirmWithReason from "src/components/ModalConfirmWithReason";
 import ModalStartVote from "src/components/ModalStartVote";
@@ -104,7 +105,11 @@ const PublicActionsProvider = ({ children }) => {
       const [submissions] = await onFetchProposalsBatchWithoutState(
         proposal.linkedfrom
       );
-      const submissionVotes = submissions.map(
+      // Filter abandoned submmsions out.
+      const publicSubmissions = submissions.filter(
+        (prop) => !isAbandonedProposal(prop)
+      );
+      const submissionVotes = publicSubmissions.map(
         ({ censorshiprecord: { token } = { token: null }, version }) => ({
           token,
           proposalversion: version


### PR DESCRIPTION
As abandoned proposals shouldn't participate in the runoff
vote this diff filters abandoned proposals tokens out when
firing start runoff vote action. 