### PR TITLE
[CMS] fix: Invoice form `rate` field console error

### DIFF
--- a/src/components/InvoiceForm/InvoiceForm.jsx
+++ b/src/components/InvoiceForm/InvoiceForm.jsx
@@ -217,6 +217,7 @@ const InvoiceFormWrapper = ({
     contact: user ? user.contractorcontact : "",
     address: "",
     exchangerate: "",
+    rate: "",
     date: getInitialDateValue(),
     lineitems: [generateBlankLineItem(policy)],
     files: []


### PR DESCRIPTION
This diff fixes console error which was thrown once user changed
`rate` field in invoice form - see below screenshot.

### Solution description
Adds initial value 


### UI Changes Screenshot
<img width="1502" alt="image" src="https://user-images.githubusercontent.com/10324528/87034748-a8653580-c1e8-11ea-8809-1878345610c6.png">


