### PR TITLE
style: add scroll to pre tag comment overflow

### DIFF
--- a/src/components/Markdown/styles.css
+++ b/src/components/Markdown/styles.css
@@ -465,8 +465,9 @@
   border-radius: 3px;
   font-size: 85%;
   line-height: 1.45;
-  overflow: auto;
+  overflow: scroll;
   padding: 16px;
+  max-width: 100%;
 }
 
 .dark .markdown-body .highlight pre,


### PR DESCRIPTION
Fixes #2042 

### Solution description

Add overflow to `pre` tag on `markdown-body`

### UI Changes Screenshot

![trulyfix](https://user-images.githubusercontent.com/13955303/87047426-e0f91500-c1d0-11ea-9d6a-b29a826ad568.gif)


