### PR TITLE
Update rendertron docker [nojs]

### DIFF
--- a/nojavascript/RenderTron/Dockerfile
+++ b/nojavascript/RenderTron/Dockerfile
@@ -1,39 +1,42 @@
-FROM node:12.14
+FROM node:12.14 as build
 
 LABEL description="politeiarendertron build"
 LABEL version="1.0"
 LABEL maintainer "jholdstock@decred.org"
 
-#Install chrome
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list' \
-    && apt-get update \
-    && apt-get update && apt-get install -y \
-    google-chrome-stable \
-    --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
-
-#Port that rendertron will run in locally
-ENV PORT=6060
-
 # Install rendertron
-RUN git clone https://github.com/GoogleChrome/rendertron.git \
+RUN git clone https://github.com/GoogleChrome/rendertron.git --branch 3.0.0 --single-branch\
     && cd rendertron \
     && npm install \
     && npm run build \
     # Patching Puppeteer launch arguments \
     && DEFAULT_ARGS="\['--no-sandbox'\]" \
     && ARGS="\['--no-sandbox', '--disable-dev-shm-usage'\]" \
-# To disable HTTPS check  replace previous line with  && ARGS="\['--no-sandbox', '--disable-dev-shm-usage', '--ignore-certificate-errors'\], ignoreHTTPSErrors: true" \
+    # To disable HTTPS check  replace previous line with  && ARGS="\['--no-sandbox', '--disable-dev-shm-usage', '--ignore-certificate-errors'\], ignoreHTTPSErrors: true" \
     && sed -i "s/$DEFAULT_ARGS/$ARGS/g" build/rendertron.js
-#Make user
-RUN groupadd -r rendertronuser && useradd -r -g rendertronuser -G audio,video rendertronuser \
-    && mkdir -p /home/rendertronuser && chown -R rendertronuser:rendertronuser /home/rendertronuser \
-    && chown -R rendertronuser:rendertronuser /rendertron
 
-#Run as non root
-USER rendertronuser
+FROM node:14.5.0-stretch-slim
 
-WORKDIR /rendertron
+COPY --from=build /rendertron /rendertron
 
-CMD ["npm","run","start"]
+# Install chrome 
+RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
+    wget \
+    gnupg2 \
+    ca-certificates \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list \
+    && apt-get update -qq && apt-get install -qq --no-install-recommends \
+    google-chrome-stable \
+    && apt-get remove -y \
+    wget \
+    gnupg2 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* 
+
+#Port that rendertron will run in locally
+ENV PORT=6060
+
+WORKDIR /rendertron/bin
+
+CMD ["rendertron"]

--- a/nojavascript/RenderTron/Dockerfile
+++ b/nojavascript/RenderTron/Dockerfile
@@ -7,13 +7,11 @@ LABEL maintainer "jholdstock@decred.org"
 # Install rendertron
 RUN git clone https://github.com/GoogleChrome/rendertron.git --branch 3.0.0 --single-branch\
     && cd rendertron \
+    # Uncomment below line to disable ssl check
+    #&& sed -i "55s/.*/        puppeteerArgs: ['--no-sandbox','--ignore-certificate-errors']/" src/config.ts \
     && npm install \
-    && npm run build \
-    # Patching Puppeteer launch arguments \
-    && DEFAULT_ARGS="\['--no-sandbox'\]" \
-    && ARGS="\['--no-sandbox', '--disable-dev-shm-usage'\]" \
-    # To disable HTTPS check  replace previous line with  && ARGS="\['--no-sandbox', '--disable-dev-shm-usage', '--ignore-certificate-errors'\], ignoreHTTPSErrors: true" \
-    && sed -i "s/$DEFAULT_ARGS/$ARGS/g" build/rendertron.js
+    && npm run build
+
 
 FROM node:14.5.0-stretch-slim
 


### PR DESCRIPTION
- Updates and sets version of rendertron latest version 3.0.0
- Reduces docker size using multi stage builds
- Removed unnecessary puppeteer arguments. (Also patch to disable SSL cert check which can be uncommented for local network testing)
