### PR TITLE
fix: properly include exchangerate to the invoice draft data

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -202,32 +202,18 @@ export const onLoadDraftProposals = (uuid) => (dispatch, getState) => {
 export const onDeleteDraftProposal = (draftId) =>
   act.DELETE_DRAFT_PROPOSAL(draftId);
 
-export const onSaveDraftInvoice = ({
-  date,
-  name,
-  location,
-  contact,
-  rate,
-  address,
-  lineitems,
-  files,
-  draftId
-}) => (dispatch, getState) => {
+export const onSaveDraftInvoice = ({ draftId, ...rest }) => (
+  dispatch,
+  getState
+) => {
   const policy = sel.policy(getState());
   resetNewInvoiceData(policy);
   const id = draftId || uniqueID("draft");
   dispatch(
     act.SAVE_DRAFT_INVOICE({
-      date,
-      name,
-      location,
-      contact,
-      rate,
-      address,
-      lineitems,
-      files,
       id,
-      timestamp: Date.now() / 1000
+      timestamp: Date.now() / 1000,
+      ...rest
     })
   );
   return id;

--- a/src/components/InvoiceForm/DraftSaver.jsx
+++ b/src/components/InvoiceForm/DraftSaver.jsx
@@ -3,6 +3,7 @@ import { Button } from "pi-ui";
 import { FormikConsumer } from "formik";
 import { useDraftInvoices } from "src/containers/Invoice/User/hooks";
 import { getQueryStringValue, setQueryStringValue } from "src/lib/queryString";
+import omit from "lodash/omit";
 
 const DraftSaver = ({ values, setValues, submitSuccess }) => {
   const [draftId, setDraftId] = useState(getQueryStringValue("draft"));
@@ -63,26 +64,8 @@ const DraftSaver = ({ values, setValues, submitSuccess }) => {
       const foundDraftInvoice =
         !!draftInvoices && draftId && draftInvoices[draftId];
       if (foundDraftInvoice) {
-        const {
-          date,
-          name,
-          location,
-          contact,
-          address,
-          rate,
-          files,
-          lineitems
-        } = foundDraftInvoice;
-        setValues({
-          date,
-          name,
-          location,
-          contact,
-          address,
-          rate,
-          files,
-          lineitems
-        });
+        const values = foundDraftInvoice;
+        setValues(omit(values, "timestamp"));
       }
     },
     [draftInvoices, draftId, setValues]


### PR DESCRIPTION
Fixes #2056.

### Solution description

The exchangerate key was left out by mistake in the original implementation. To fix it I improved the code to be more generalist. All keys added to the Formik form will be stored in the localStorage when a draft is saved. 