### PR TITLE
keys: Fix old storage key replacements

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -223,9 +223,9 @@ export const onLogin = ({ email, password }) =>
       .then((response) => {
         dispatch(act.RECEIVE_LOGIN(response));
         const { userid, username } = response;
-        pki.needStorageKeyReplace(username).then((needReplace) => {
-          if (needReplace) {
-            pki.replaceStorageKey(username, userid);
+        pki.needStorageKeyReplace(email, username).then((keyNeedsReplace) => {
+          if (keyNeedsReplace) {
+            pki.replaceStorageKey(keyNeedsReplace, userid);
           }
           return response;
         });

--- a/src/lib/pki.js
+++ b/src/lib/pki.js
@@ -84,10 +84,19 @@ export const importKeys = (uuid, keys) =>
     loadKeys(uuid, decodedKeys)
   );
 
-export const needStorageKeyReplace = (username) =>
-  localforage
-    .keys()
-    .then((keys) => (keys.includes(STORAGE_PREFIX + username) ? true : false));
+// The key that we check for replacement are:
+// Email for older identities in pi.
+// Username for newly created accounts.
+export const needStorageKeyReplace = (email, username) =>
+  localforage.keys().then((keys) => {
+    if (keys.includes(STORAGE_PREFIX + email)) {
+      return email;
+    }
+    if (keys.includes(STORAGE_PREFIX + username)) {
+      return username;
+    }
+    return null;
+  });
 export const replaceStorageKey = (oldKey, newKey) =>
   myKeyPair(oldKey).then((keys) =>
     loadKeys(newKey, keys).then(() =>


### PR DESCRIPTION
This diff solves a problem where we only check for localforage key replacements with the username. One of our privacy updates on pi was to remove the user email as key to localstorage items. We replaced it by uuid. Still, on the initial stages of pi, we need a user key created when we still don't have a user email. Therefore, we temporarily use username until the user's first login, and we replace it with the uuid.

With the latest gui update, all keys got nuked because they were under email key, and we were only checking for username. In order to update older keys, we need to check for replacements under the email key as well. This diff does that.