### PR TITLE
[cms] fix: prevent infinite loading state for proposals on invoice details

### DIFF
--- a/src/containers/Invoice/Detail/Detail.jsx
+++ b/src/containers/Invoice/Detail/Detail.jsx
@@ -15,6 +15,8 @@ import map from "lodash/fp/map";
 import filter from "lodash/fp/filter";
 import uniq from "lodash/fp/uniq";
 
+const PAGE_SIZE = 20;
+
 const InvoiceDetail = ({ Main, match }) => {
   const invoiceToken = get("params.token", match);
   const threadParentCommentID = get("params.commentid", match);
@@ -34,23 +36,28 @@ const InvoiceDetail = ({ Main, match }) => {
 
   const {
     proposals,
-    proposalByToken,
-    onFetchProposalsBatch,
+    proposalsByToken,
+    onFetchProposalsBatchByTokensRemaining,
     isLoading
   } = useApprovedProposals();
 
   useEffect(() => {
-    if (!isLoading && !isEmpty(proposalByToken)) {
+    if (!isLoading && !isEmpty(proposalsByToken)) {
       const remainingTokens = tokens
         ? tokens.filter(
-            (t) => !Object.keys(proposalByToken).some((pt) => pt === t)
+            (t) => !Object.keys(proposalsByToken).some((pt) => pt === t)
           )
         : [];
       if (!isEmpty(remainingTokens)) {
-        onFetchProposalsBatch(remainingTokens, false);
+        onFetchProposalsBatchByTokensRemaining(remainingTokens, PAGE_SIZE);
       }
     }
-  }, [isLoading, proposalByToken, tokens, onFetchProposalsBatch]);
+  }, [
+    isLoading,
+    proposalsByToken,
+    tokens,
+    onFetchProposalsBatchByTokensRemaining
+  ]);
 
   return (
     <>

--- a/src/hooks/api/useApprovedProposals.js
+++ b/src/hooks/api/useApprovedProposals.js
@@ -4,6 +4,8 @@ import useProposalsBatch from "src/hooks/api/useProposalsBatch";
 import { isEmpty } from "src/helpers";
 import keys from "lodash/keys";
 
+const PAGE_SIZE = 20;
+
 const remainingTokensFilter = (proposals) => (token) =>
   !keys(proposals).some((proposalToken) => proposalToken === token);
 
@@ -24,9 +26,10 @@ export default function useApprovedProposals(initialTokens = []) {
     getRemainingTokens(proposalsTokens.approved, proposalsByToken)
   );
 
-  const requestParams = useMemo(() => [proposalsTokens.approved, false], [
-    proposalsTokens
-  ]);
+  const requestParams = useMemo(
+    () => [proposalsTokens.approved.slice(0, PAGE_SIZE), false],
+    [proposalsTokens]
+  );
 
   const needsFetch = useMemo(
     () =>
@@ -90,6 +93,7 @@ export default function useApprovedProposals(initialTokens = []) {
     isLoading: loading || isLoadingTokenInventory,
     error,
     remainingTokens,
-    onFetchRemainingProposalsBatch
+    onFetchRemainingProposalsBatch,
+    onFetchProposalsBatchByTokensRemaining
   };
 }

--- a/src/hooks/api/useApprovedProposals.js
+++ b/src/hooks/api/useApprovedProposals.js
@@ -27,7 +27,12 @@ export default function useApprovedProposals(initialTokens = []) {
   );
 
   const requestParams = useMemo(
-    () => [proposalsTokens.approved.slice(0, PAGE_SIZE), false],
+    () => [
+      proposalsTokens.approved
+        ? proposalsTokens.approved.slice(0, PAGE_SIZE)
+        : [],
+      false
+    ],
     [proposalsTokens]
   );
 


### PR DESCRIPTION
This diff closes #2087 an issue that reported that proposals not loaded by initial batch call were never being loaded.

### Solution description

- Use the `onFetchProposalsBatchByTokensRemaining` action passing the page limit size;
- Use the correct `proposalsByToken` declaration;
- Limit the initial batch call to prevent errors reported by https://github.com/decred/politeia/pull/1268 until it goes live.

