### PR TITLE
[CMS] fix: remove static references to cms_domains

### DIFF
--- a/src/components/DCC/DCC.jsx
+++ b/src/components/DCC/DCC.jsx
@@ -8,13 +8,15 @@ import {
   getDccStatusTagProps,
   presentationalDccType,
   presentationalDccContractorType,
-  presentationalDccDomain,
   presentationalStatement,
   isRevocationDcc,
   isDccActive,
   isDccApproved
 } from "src/containers/DCC/helpers";
 import { SupportOppose, DccActions } from "src/containers/DCC/Actions";
+import { usePolicy } from "src/hooks";
+
+import { getContractorDomains, getDomainName } from "src/helpers";
 
 const Dcc = ({ dcc, extended }) => {
   const {
@@ -28,12 +30,19 @@ const Dcc = ({ dcc, extended }) => {
     timereviewed
   } = dcc;
 
+  const {
+    policy: { supporteddomains }
+  } = usePolicy();
+
+  const contractorDomains = getContractorDomains(supporteddomains);
+
   const isActive = isDccActive(dcc);
   const dccToken = censorshiprecord && censorshiprecord.token;
   const dccURL = `/dccs/${dccToken}`;
   const dccDomain = dccpayload && dccpayload.domain;
   const dccContractorType = dccpayload && dccpayload.contractortype;
   const dccStatement = dccpayload && dccpayload.statement;
+  const domainName = getDomainName(contractorDomains, dccDomain);
 
   return (
     <RecordWrapper>
@@ -70,9 +79,7 @@ const Dcc = ({ dcc, extended }) => {
                       {presentationalDccContractorType(dccContractorType)}
                     </Text>
                   )}
-                  {!extended && (
-                    <Text>{presentationalDccDomain(dccDomain)}</Text>
-                  )}
+                  {!extended && <Text>{domainName}</Text>}
                   <Event event="submitted" timestamp={timesubmitted} />
                   {timereviewed && (
                     <Event
@@ -103,10 +110,7 @@ const Dcc = ({ dcc, extended }) => {
                   className={styles.topDetails}>
                   <Field label="Type" value={presentationalDccType(dcc)} />
                   <Field label="Nominee" value={nomineeusername} />
-                  <Field
-                    label="Domain"
-                    value={presentationalDccDomain(dccDomain)}
-                  />
+                  <Field label="Domain" value={domainName} />
                   {!isRevocationDcc(dcc) && (
                     <Field
                       label="Contractor Type"

--- a/src/components/DCC/DCC.jsx
+++ b/src/components/DCC/DCC.jsx
@@ -15,7 +15,6 @@ import {
 } from "src/containers/DCC/helpers";
 import { SupportOppose, DccActions } from "src/containers/DCC/Actions";
 import { usePolicy } from "src/hooks";
-
 import { getContractorDomains, getDomainName } from "src/helpers";
 
 const Dcc = ({ dcc, extended }) => {
@@ -33,9 +32,7 @@ const Dcc = ({ dcc, extended }) => {
   const {
     policy: { supporteddomains }
   } = usePolicy();
-
   const contractorDomains = getContractorDomains(supporteddomains);
-
   const isActive = isDccActive(dcc);
   const dccToken = censorshiprecord && censorshiprecord.token;
   const dccURL = `/dccs/${dccToken}`;

--- a/src/components/DCC/DraftDcc.jsx
+++ b/src/components/DCC/DraftDcc.jsx
@@ -4,13 +4,21 @@ import { Button, Text } from "pi-ui";
 import RecordWrapper from "../RecordWrapper";
 import {
   presentationalDraftDccName,
-  presentationalDccDomain,
   presentationalStatement
 } from "src/containers/DCC/helpers";
 import styles from "./DraftDcc.module.css";
+import { usePolicy } from "src/hooks";
+import { getContractorDomains, getDomainName } from "src/helpers";
 
 const DraftDcc = ({ draft, onDelete }) => {
+  const {
+    policy: { supporteddomains }
+  } = usePolicy();
+
+  const contractorDomains = getContractorDomains(supporteddomains);
   const { id, timestamp, statement, domain } = draft;
+  const domainName = getDomainName(contractorDomains, domain);
+
   function handleDeleteDraft() {
     onDelete(id);
   }
@@ -45,11 +53,7 @@ const DraftDcc = ({ draft, onDelete }) => {
               subtitle={
                 <Subtitle>
                   <Event keepOnMobile event="edited" timestamp={timestamp} />
-                  {domain && (
-                    <Text id="draft-domain">
-                      {presentationalDccDomain(domain)}
-                    </Text>
-                  )}
+                  {domain && <Text id="draft-domain">{domainName}</Text>}
                   {statement && (
                     <Text truncate={true} id="draft-statement">
                       {presentationalStatement(statement)}

--- a/src/components/DCC/DraftDcc.jsx
+++ b/src/components/DCC/DraftDcc.jsx
@@ -14,7 +14,6 @@ const DraftDcc = ({ draft, onDelete }) => {
   const {
     policy: { supporteddomains }
   } = usePolicy();
-
   const contractorDomains = getContractorDomains(supporteddomains);
   const { id, timestamp, statement, domain } = draft;
   const domainName = getDomainName(contractorDomains, domain);

--- a/src/components/DccForm/DccForm.jsx
+++ b/src/components/DccForm/DccForm.jsx
@@ -8,7 +8,6 @@ import { dccValidationSchema } from "./validation";
 import DraftSaver from "./DraftSaver";
 import styles from "./DccForm.module.css";
 import {
-  getDomainOptions,
   getContractorTypeOptions,
   getDccTypeOptions,
   getNomineeOptions,
@@ -23,6 +22,7 @@ import {
   useSessionStorage,
   useScrollFormOnError
 } from "src/hooks";
+import { getContractorDomains } from "src/helpers";
 
 const Select = ({ error, ...props }) => (
   <div
@@ -47,6 +47,12 @@ const DccForm = React.memo(function DccForm({
   isUserValid,
   isSupervisor
 }) {
+  const {
+    policy: { supporteddomains }
+  } = usePolicy();
+
+  const contractorDomains = getContractorDomains(supporteddomains);
+
   const [isIssuance, setIsIssuance] = useState();
   useScrollFormOnError(errors && errors.global);
 
@@ -142,7 +148,7 @@ const DccForm = React.memo(function DccForm({
 
       <Select
         name="domain"
-        options={getDomainOptions()}
+        options={contractorDomains}
         placeholder="Domain"
         error={touched.domain && errors.domain}
         onChange={handleChangeSelector("domain")}

--- a/src/components/DccForm/DccForm.jsx
+++ b/src/components/DccForm/DccForm.jsx
@@ -50,9 +50,7 @@ const DccForm = React.memo(function DccForm({
   const {
     policy: { supporteddomains }
   } = usePolicy();
-
   const contractorDomains = getContractorDomains(supporteddomains);
-
   const [isIssuance, setIsIssuance] = useState();
   useScrollFormOnError(errors && errors.global);
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -148,16 +148,6 @@ export const CMS_USER_TYPES = [
   "Revoked"
 ];
 
-export const CMS_DOMAINS = [
-  "No domain defined",
-  "Development",
-  "Marketing",
-  "Design",
-  "Research",
-  "Documentation",
-  "Community Management"
-];
-
 export const NOJS_ROUTE_PREFIX = "/nojavascript";
 
 export const MONTHS_LABELS = [

--- a/src/containers/DCC/constants.js
+++ b/src/containers/DCC/constants.js
@@ -13,14 +13,6 @@ export const CONTRACTOR_TYPE_SUBCONTRACTOR = 3;
 export const CONTRACTOR_TYPE_NOMINEE = 4;
 export const CONTRACTOR_TYPE_REVOKED = 5;
 
-export const DCC_DOMAINS = [
-  "Development",
-  "Marketing",
-  "Design",
-  "Research",
-  "Documentation",
-  "Community Management"
-];
 export const DCC_DOMAIN_INVALID = 0;
 export const DCC_DOMAIN_DEVELOPER = 1;
 

--- a/src/containers/DCC/helpers.js
+++ b/src/containers/DCC/helpers.js
@@ -17,7 +17,7 @@ import isEmpty from "lodash/isEmpty";
 import some from "lodash/fp/some";
 import isEqual from "lodash/fp/isEqual";
 import { or } from "src/lib/fp";
-import { CMS_USER_TYPES, CMS_DOMAINS } from "../../constants";
+import { CMS_USER_TYPES } from "../../constants";
 
 const dccTypes = {
   [DCC_TYPE_REVOCATION]: "Revocation",
@@ -94,12 +94,6 @@ export const presentationalDraftDccName = (draft) =>
 export const presentationalDccContractorType = (type) => CMS_USER_TYPES[type];
 
 /**
- * Returns a presentational Domain name
- * @param {Number} domain
- */
-export const presentationalDccDomain = (domain) => CMS_DOMAINS[domain];
-
-/**
  * Returns statement if it exists, otherwise returns a message indicating that
  * dcc is empty
  * @param {String} domain
@@ -131,12 +125,6 @@ export const isDccActive = (dcc) => dcc && dcc.status === DCC_STATUS_ACTIVE;
  * @param {Object} dcc
  */
 export const isDccApproved = (dcc) => dcc && dcc.status === DCC_STATUS_APPROVED;
-
-/**
- * Returns domain options for selectors
- */
-export const getDomainOptions = () =>
-  CMS_DOMAINS.map((label, value) => ({ label, value }));
 
 /**
  * Returns contractor type options for selectors

--- a/src/containers/User/Detail/ManageContractor/ManageDccForm.jsx
+++ b/src/containers/User/Detail/ManageContractor/ManageDccForm.jsx
@@ -4,7 +4,6 @@ import React, { useCallback, useState } from "react";
 import InfoSection from "../InfoSection.jsx";
 import {
   selectTypeOptions,
-  selectDomainOptions,
   getInitialAndOptionsProposals,
   getInitialAndOptionsSupervisors
 } from "./helpers";
@@ -12,6 +11,8 @@ import { Formik } from "formik";
 import styles from "./ManageContractor.module.css";
 import useSupervisors from "src/hooks/api/useSupervisors";
 import useApprovedProposals from "src/hooks/api/useApprovedProposals";
+import { usePolicy } from "src/hooks";
+import { getContractorDomains } from "src/helpers";
 
 const selectStyles = {
   container: (provided) => ({
@@ -37,6 +38,12 @@ const ManageDccForm = ({ onUpdate, user }) => {
     supervisoruserids = [],
     proposalsowned = []
   } = user;
+
+  const {
+    policy: { supporteddomains }
+  } = usePolicy();
+
+  const contractorDomains = getContractorDomains(supporteddomains);
 
   const [updated, setUpdated] = useState(false);
 
@@ -130,7 +137,7 @@ const ManageDccForm = ({ onUpdate, user }) => {
                   info={
                     <SelectField
                       name="domain"
-                      options={selectDomainOptions}
+                      options={contractorDomains}
                       styles={selectStyles}
                     />
                   }

--- a/src/containers/User/Detail/ManageContractor/ManageDccForm.jsx
+++ b/src/containers/User/Detail/ManageContractor/ManageDccForm.jsx
@@ -38,13 +38,10 @@ const ManageDccForm = ({ onUpdate, user }) => {
     supervisoruserids = [],
     proposalsowned = []
   } = user;
-
   const {
     policy: { supporteddomains }
   } = usePolicy();
-
   const contractorDomains = getContractorDomains(supporteddomains);
-
   const [updated, setUpdated] = useState(false);
 
   // Parse supervisors initial values and options

--- a/src/containers/User/Detail/ManageContractor/UserView.jsx
+++ b/src/containers/User/Detail/ManageContractor/UserView.jsx
@@ -2,13 +2,9 @@ import React from "react";
 import PropTypes from "prop-types";
 import { H2, Message, Button, Spinner } from "pi-ui";
 import InfoSection from "../InfoSection.jsx";
-import {
-  typeOptions,
-  domainOptions,
-  getOwnedProposals,
-  getSupervisorsNames
-} from "./helpers";
-import { useApprovedProposals, useSupervisors } from "src/hooks";
+import { typeOptions, getOwnedProposals, getSupervisorsNames } from "./helpers";
+import { useApprovedProposals, useSupervisors, usePolicy } from "src/hooks";
+import { getContractorDomains, getDomainName } from "src/helpers";
 
 const UserDccInfo = ({
   contractorType,
@@ -92,6 +88,12 @@ const ManageContractorUserView = ({
     proposalsByToken
   );
   const { supervisors } = useSupervisors();
+  const {
+    policy: { supporteddomains }
+  } = usePolicy();
+
+  const contractorDomains = getContractorDomains(supporteddomains);
+
   return (
     <>
       {requireGitHubName && (
@@ -102,7 +104,7 @@ const ManageContractorUserView = ({
       {!hideDccInfo && (
         <UserDccInfo
           contractorType={typeOptions[contractortype]}
-          domain={domainOptions[domain]}
+          domain={getDomainName(contractorDomains, domain)}
           proposalsOwned={ownedProposals}
           isLoadingProposals={isLoading}
           userSupervisors={getSupervisorsNames(supervisors, supervisoruserids)}

--- a/src/containers/User/Detail/ManageContractor/UserView.jsx
+++ b/src/containers/User/Detail/ManageContractor/UserView.jsx
@@ -91,7 +91,6 @@ const ManageContractorUserView = ({
   const {
     policy: { supporteddomains }
   } = usePolicy();
-
   const contractorDomains = getContractorDomains(supporteddomains);
 
   return (

--- a/src/containers/User/Detail/ManageContractor/helpers.js
+++ b/src/containers/User/Detail/ManageContractor/helpers.js
@@ -14,22 +14,7 @@ export const typeOptions = [
   "Proposal Approved"
 ];
 
-export const domainOptions = [
-  "No domain defined",
-  "Development",
-  "Marketing",
-  "Design",
-  "Research",
-  "Documentation",
-  "Community Management"
-];
-
 export const selectTypeOptions = typeOptions.map((op, idx) => ({
-  value: idx,
-  label: op
-}));
-
-export const selectDomainOptions = domainOptions.map((op, idx) => ({
   value: idx,
   label: op
 }));

--- a/src/containers/User/Search/Search.jsx
+++ b/src/containers/User/Search/Search.jsx
@@ -48,9 +48,7 @@ const UserSearch = ({ TopBanner, PageDetails, Main, Title }) => {
   const {
     policy: { supporteddomains }
   } = usePolicy();
-
   const contractorDomains = getContractorDomains(supporteddomains);
-
   const searchOptions = useMemo(() => {
     if (isCMS) {
       return [

--- a/src/containers/User/Search/Search.jsx
+++ b/src/containers/User/Search/Search.jsx
@@ -12,8 +12,6 @@ import {
 import React, { useEffect, useState } from "react";
 import {
   selectTypeOptions,
-  selectDomainOptions,
-  domainOptions,
   typeOptions
 } from "src/containers/User/Detail/ManageContractor/helpers";
 import HelpMessage from "src/components/HelpMessage";
@@ -21,9 +19,11 @@ import SelectField from "src/components/Select/SelectField";
 import { useSearchUser } from "./hooks";
 import styles from "./Search.module.css";
 import Link from "src/components/Link";
+import { usePolicy } from "src/hooks";
 import { searchSchema } from "./validation";
+import { getContractorDomains, getDomainName } from "src/helpers";
 
-const getFormattedSearchResults = (users = [], isCMS) =>
+const getFormattedSearchResults = (users = [], isCMS, supporteddomains) =>
   users.map((u) =>
     !isCMS
       ? {
@@ -33,7 +33,10 @@ const getFormattedSearchResults = (users = [], isCMS) =>
         }
       : {
           Username: <Link to={`/user/${u.id}`}>{u.username}</Link>,
-          Domain: domainOptions[u.domain],
+          Domain: getDomainName(
+            getContractorDomains(supporteddomains),
+            u.domain
+          ),
           Type: typeOptions[u.contractortype]
         }
   );
@@ -42,6 +45,11 @@ const UserSearch = ({ TopBanner, PageDetails, Main, Title }) => {
   const { onSearchUser, searchResult, isCMS } = useSearchUser();
   const [searchError, setSearchError] = useState(null);
   const [foundUsers, setFoundUsers] = useState([]);
+  const {
+    policy: { supporteddomains }
+  } = usePolicy();
+
+  const contractorDomains = getContractorDomains(supporteddomains);
 
   const searchOptions = useMemo(() => {
     if (isCMS) {
@@ -87,10 +95,12 @@ const UserSearch = ({ TopBanner, PageDetails, Main, Title }) => {
   useEffect(
     function updateFoundUsers() {
       if (searchResult) {
-        setFoundUsers(getFormattedSearchResults(searchResult, isCMS));
+        setFoundUsers(
+          getFormattedSearchResults(searchResult, isCMS, supporteddomains)
+        );
       }
     },
-    [searchResult, isCMS]
+    [searchResult, isCMS, supporteddomains]
   );
   return (
     <>
@@ -156,7 +166,7 @@ const UserSearch = ({ TopBanner, PageDetails, Main, Title }) => {
                       <SelectField
                         name="domain"
                         className={styles.select}
-                        options={selectDomainOptions}
+                        options={contractorDomains}
                         value={values.domain}
                         onChange={handleChangeSelectField("domain")}
                         placeholder="Choose a domain"

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -507,9 +507,8 @@ export const getContractorDomains = (supporteddomains) => [
  * @param {number|string} op
  */
 export const getDomainName = (contractorDomains, op) => {
-  let domainName;
-  contractorDomains.forEach((domain) => {
-    if (domain.value === op) domainName = domain.label;
-  });
+  const { label: domainName } = contractorDomains.find(
+    (domain) => domain.value === op
+  );
   return domainName;
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -6,6 +6,7 @@ import gte from "lodash/fp/gt";
 import range from "lodash/fp/range";
 import * as pki from "./lib/pki";
 import { sha3_256 } from "js-sha3";
+import { capitalize } from "src/utils/strings";
 
 import { INVALID_FILE } from "./constants";
 import {
@@ -485,4 +486,30 @@ export const isAnchoring = (
     targetDate.getTime()
   );
   return timeDiffMinutes >= 0 && timeDiffMinutes < anchoringDuration;
+};
+/**
+ * Function to format supported domains in the format for Select/Dropdown
+ * components
+ * @param {array} supporteddomains
+ */
+export const getContractorDomains = (supporteddomains) => [
+  { label: "No domain defined", value: 0 },
+  ...supporteddomains.map((item) => ({
+    label: capitalize(item.description),
+    value: item.type
+  }))
+];
+
+/**
+ * Function to return the domain name given an array of contractor domains and
+ * a domain type
+ * @param {array} contractorDomains
+ * @param {number|string} op
+ */
+export const getDomainName = (contractorDomains, op) => {
+  let domainName;
+  contractorDomains.forEach((domain) => {
+    if (domain.value === op) domainName = domain.label;
+  });
+  return domainName;
 };


### PR DESCRIPTION
Closes #2101 

### Solution description

I added two helper functions, `getContractorDomains` so we can transform the `supporteddomains` array into the format we are currently working with and `getDomainName` to get the name of a domain given its type (numeric value in the BE).

I am also using the `usePolicy` hook to get access to the `supporteddomains` array.
