### PR TITLE
fix: verify if app is CMS before using getContractorDomains

### DIFF
--- a/src/containers/User/Search/Search.jsx
+++ b/src/containers/User/Search/Search.jsx
@@ -48,7 +48,7 @@ const UserSearch = ({ TopBanner, PageDetails, Main, Title }) => {
   const {
     policy: { supporteddomains }
   } = usePolicy();
-  const contractorDomains = getContractorDomains(supporteddomains);
+  const contractorDomains = isCMS ? getContractorDomains(supporteddomains) : [];
   const searchOptions = useMemo(() => {
     if (isCMS) {
       return [


### PR DESCRIPTION
Small check that I've missed.