### PR TITLE
fix: improve proposal credits workflow

### DIFF
--- a/src/actions/external_api.js
+++ b/src/actions/external_api.js
@@ -6,10 +6,10 @@ export const payWithFaucet = (address, amount, userid) => (dispatch) => {
   return external_api
     .payWithFaucet(address, amount)
     .then((json) => {
-      if (json.Error) {
-        return dispatch(
-          act.RECEIVE_PAYWALL_PAYMENT_WITH_FAUCET(null, new Error(json.Error))
-        );
+      if (json.error) {
+        const error = new Error(json.error);
+        dispatch(act.RECEIVE_PAYWALL_PAYMENT_WITH_FAUCET(null, error));
+        throw error;
       }
       return dispatch(
         act.RECEIVE_PAYWALL_PAYMENT_WITH_FAUCET({ ...json, userid })

--- a/src/components/ModalBuyProposalCredits/ModalBuyProposalCredits.jsx
+++ b/src/components/ModalBuyProposalCredits/ModalBuyProposalCredits.jsx
@@ -13,6 +13,7 @@ import PaymentComponent from "../PaymentComponent";
 import PaymentStatusTag from "../PaymentStatusTag";
 import styles from "./ModalBuyProposalCredits.module.css";
 import { validationSchema } from "./validation";
+import useProposalCreditsPaymentInfo from "./hooks";
 
 const ModalBuyProposalCredits = ({
   show,
@@ -20,8 +21,7 @@ const ModalBuyProposalCredits = ({
   price,
   initialStep = 0,
   address,
-  status,
-  isPollingCreditsPayment,
+  userID,
   startPollingPayment
 }) => {
   const [creditsNumber, setNumber] = useState(1);
@@ -35,6 +35,12 @@ const ModalBuyProposalCredits = ({
     setModalType(1);
     setNumber(+values.creditsNumber);
   }
+
+  const {
+    isPollingCreditsPayment,
+    status,
+    amount
+  } = useProposalCreditsPaymentInfo(userID);
 
   useEffect(() => {
     setModalType(initialStep);
@@ -52,7 +58,7 @@ const ModalBuyProposalCredits = ({
       {extraSmall && <PaymentStatusTag status={status} />}
       <PaymentComponent
         address={address}
-        amount={+(creditsNumber * price).toFixed(1)}
+        amount={amount || +(creditsNumber * price).toFixed(1)}
         extraSmall={extraSmall}
         status={status}
       />

--- a/src/components/ModalBuyProposalCredits/hooks.js
+++ b/src/components/ModalBuyProposalCredits/hooks.js
@@ -1,0 +1,55 @@
+import { useMemo } from "react";
+import * as sel from "src/selectors";
+import { useSelector } from "src/redux";
+import {
+  PAYWALL_STATUS_LACKING_CONFIRMATIONS,
+  PAYWALL_STATUS_PAID,
+  PAYWALL_STATUS_WAITING
+} from "src/constants";
+import { convertAtomsToDcr } from "src/utils";
+
+const getProposalCreditsPaymentStatus = (numOfConfirmations, txid) => {
+  if (!txid) {
+    return PAYWALL_STATUS_WAITING;
+  }
+  if (numOfConfirmations < 2) {
+    return PAYWALL_STATUS_LACKING_CONFIRMATIONS;
+  }
+  return PAYWALL_STATUS_PAID;
+};
+
+export default function useProposalCreditsPaymentInfo(userID) {
+  const proposalPaywallPaymentConfirmationsSelector = useMemo(
+    () => sel.makeGetPaywallConfirmations(userID),
+    [userID]
+  );
+  const proposalPaywallPaymentTxidSelector = useMemo(
+    () => sel.makeGetPaywallTxid(userID),
+    [userID]
+  );
+  const proposalPaywallPaymentConfirmations = useSelector(
+    proposalPaywallPaymentConfirmationsSelector
+  );
+  const proposalPaywallPaymentTxid = useSelector(
+    proposalPaywallPaymentTxidSelector
+  );
+  const isPollingCreditsPayment = useSelector(sel.pollingCreditsPayment);
+  const proposalPaywallPaymentAmountSelector = useMemo(
+    () => sel.makeGetPaywallAmount(userID),
+    [userID]
+  );
+  const proposalPaywallPaymentAmount = useSelector(
+    proposalPaywallPaymentAmountSelector
+  );
+
+  const status = getProposalCreditsPaymentStatus(
+    proposalPaywallPaymentConfirmations,
+    proposalPaywallPaymentTxid
+  );
+
+  return {
+    status,
+    isPollingCreditsPayment,
+    amount: convertAtomsToDcr(proposalPaywallPaymentAmount)
+  };
+}

--- a/src/components/PaymentStatusTag/PaymentStatusTag.jsx
+++ b/src/components/PaymentStatusTag/PaymentStatusTag.jsx
@@ -19,7 +19,7 @@ const mapPaymentToStatusTag = {
   [PAYWALL_STATUS_LACKING_CONFIRMATIONS]: (
     <StatusTag
       className={styles.statusTag}
-      type="yellowTime"
+      type="bluePending"
       text="Waiting for confirmations"
     />
   ),

--- a/src/containers/User/Detail/Credits/AdminUserCredits.jsx
+++ b/src/containers/User/Detail/Credits/AdminUserCredits.jsx
@@ -72,9 +72,15 @@ const Credits = ({ user }) => {
   useEffect(() => {
     if (proposalPaymentReceived) {
       toggleCreditsPaymentPolling(false);
+      toggleProposalPaymentReceived(false);
       handleCloseModal();
     }
-  }, [proposalPaymentReceived, toggleCreditsPaymentPolling, handleCloseModal]);
+  }, [
+    proposalPaymentReceived,
+    toggleCreditsPaymentPolling,
+    toggleProposalPaymentReceived,
+    handleCloseModal
+  ]);
 
   return isApiRequestingUserProposalCredits ? (
     <div className={styles.spinnerWrapper}>

--- a/src/containers/User/Detail/Credits/helpers.js
+++ b/src/containers/User/Detail/Credits/helpers.js
@@ -31,7 +31,7 @@ const getRowDataForCreditsPurchase = (purchase) => ({
       <DcrTransactionLink txID={purchase.txId} />
     ),
   Status: purchase.confirming ? (
-    <StatusTag type="bluePending" text="Pending" />
+    <StatusTag type="bluePending" text="Waiting for confirmations" />
   ) : (
     <StatusTag type="greenCheck" text="Confirmed" />
   ),

--- a/src/containers/User/Detail/Credits/hooks.js
+++ b/src/containers/User/Detail/Credits/hooks.js
@@ -6,7 +6,6 @@ import { useSelector, useAction } from "src/redux";
 import useModalContext from "src/hooks/utils/useModalContext";
 import ModalBuyProposalCredits from "src/components/ModalBuyProposalCredits";
 import ModalPayPaywall from "src/components/ModalPayPaywall";
-import { getProposalCreditsPaymentStatus } from "./helpers.js";
 
 export function useCredits(userID) {
   const isApiRequestingProposalPaywall = useSelector(
@@ -228,9 +227,7 @@ export function useUserPaymentModals(user) {
   const {
     proposalCreditPrice,
     proposalPaywallAddress,
-    proposalPaywallPaymentConfirmations,
     proposalPaywallPaymentTxid,
-    pollingCreditsPayment,
     toggleCreditsPaymentPolling,
     onPollProposalPaywallPayment,
     toggleProposalPaymentReceived
@@ -261,16 +258,11 @@ export function useUserPaymentModals(user) {
       price: proposalCreditPrice,
       address: proposalPaywallAddress,
       startPollingPayment: onStartPollingPayment,
-      status: getProposalCreditsPaymentStatus(
-        proposalPaywallPaymentConfirmations,
-        proposalPaywallPaymentTxid
-      ),
       initialStep: proposalPaywallPaymentTxid ? 1 : 0,
-      isPollingCreditsPayment: pollingCreditsPayment,
-      onClose: customCloseProposalCreditsModal
+      onClose: customCloseProposalCreditsModal,
+      userID
     });
   };
-
   return {
     handleOpenPaywallModal,
     handleOpenBuyCreditsModal,


### PR DESCRIPTION
This diff closes #2108 issue that reported a weird behavior on proposal
credits workflow.

### Solution description

The addition of `useProposalCreditsPaymentInfo` hook to improve the data
flow on proposal credits payment status. Previously, props were static
and were passed only when modal was opened. To solve this, the hook
returns the status info and the polling credits info.
