### PR TITLE
cms: improve proposal billing pages

### DIFF
--- a/src/containers/Invoice/Payouts/PayoutsList.jsx
+++ b/src/containers/Invoice/Payouts/PayoutsList.jsx
@@ -139,7 +139,9 @@ const PayoutsList = ({ TopBanner, PageDetails, Main }) => {
           </>
         )}
         {!hasPayouts && (
-          <HelpMessage>{"There are no approved invoices!"}</HelpMessage>
+          <HelpMessage>
+            {"There are no payouts for approved invoices"}
+          </HelpMessage>
         )}
       </Main>
     </>

--- a/src/containers/Invoice/ProposalBillingDetails/ProposalBillingDetails.jsx
+++ b/src/containers/Invoice/ProposalBillingDetails/ProposalBillingDetails.jsx
@@ -152,8 +152,9 @@ const ProposalBillingDetails = ({ TopBanner, PageDetails, Main, match }) => {
             There are no billings for this proposal yet
           </Card>
         ) : (
-          <Card paddingSize="small">
+          <Card paddingSize="small" className={styles.tableWrapper}>
             <Table
+              className={styles.table}
               data={getDetailsData(
                 proposalBillingDetails.invoices,
                 subContractors

--- a/src/containers/Invoice/ProposalBillingDetails/ProposalBillingDetails.jsx
+++ b/src/containers/Invoice/ProposalBillingDetails/ProposalBillingDetails.jsx
@@ -6,36 +6,98 @@ import { GoBackLink } from "src/components/Router";
 import get from "lodash/fp/get";
 import Link from "src/components/Link";
 import { usdFormatter, formatCentsToUSD } from "src/utils";
+import { fromMinutesToHours } from "src/helpers";
+import {
+  getInvoiceTotalLabor,
+  getInvoiceTotalExpenses,
+  getInvoiceTotal,
+  getSubContractorTotal,
+  TABLE_HEADERS,
+  getSubContractorTotalLabor,
+  getSubContractorRate,
+  getSubContractor
+} from "./helpers";
 import styles from "./ProposalBillingDetails.module.css";
+import { useSubContractors } from "src/hooks";
 
-const HEADERS = [
-  "User",
-  "Contractor Rate",
-  "Exchange Rate",
-  "Total (DCR)",
-  "Total (USD)",
-  "Invoice"
-];
-
-const getInvoiceTotal = (rate, lineItems) => {
-  const laborInMinutes = lineItems.reduce((acc, cur) => acc + cur.labor, 0);
-  const laborInHours = laborInMinutes / 60;
-  return laborInHours * rate; // total
+const SubContractorReference = ({ username = "", userid = "", value }) => {
+  const [show, setShow] = useState();
+  return (
+    <div
+      onMouseEnter={() => setShow(true)}
+      onMouseLeave={() => setShow(false)}
+      className={styles.value}>
+      {value}*
+      {show && (
+        <Link className={styles.reference} to={`/user/${userid}`}>
+          <b>Sub Contractor:</b> {username}
+        </Link>
+      )}
+    </div>
+  );
 };
 
-const getDetailsData = (invoices) =>
+const getDetailsData = (invoices, subContractors) =>
   (invoices &&
     invoices.map(({ username, userid, censorshiprecord: { token }, input }) => {
       const totalUsd = getInvoiceTotal(input.contractorrate, input.lineitems);
       const totalDcr = totalUsd / input.exchangerate;
-      return {
+      const totalLabor = getInvoiceTotalLabor(input.lineitems);
+      const totalExpenses = getInvoiceTotalExpenses(input ? { input } : null);
+      const subContractorTotalLabor = getSubContractorTotalLabor(
+        input.lineitems
+      );
+      let detailsData = {
         User: <Link to={`/user/${userid}`}>{username}</Link>,
         "Contractor Rate": usdFormatter.format(input.contractorrate / 100),
         "Exchange Rate": usdFormatter.format(input.exchangerate / 100),
+        "Labor (hours)": fromMinutesToHours(totalLabor),
+        "Expense (USD)": usdFormatter.format(totalExpenses),
         "Total (DCR)": totalDcr.toFixed(8),
         "Total (USD)": usdFormatter.format(totalUsd / 100),
         Invoice: <Link to={`/invoices/${token}`}>{token}</Link>
       };
+      if (subContractorTotalLabor && !totalExpenses) {
+        const subContractorTotal = getSubContractorTotal(input.lineitems);
+        const subContractorTotalDcr = subContractorTotal / input.exchangerate;
+        const subContractorRate = getSubContractorRate(input.lineitems);
+        const { username, id } = getSubContractor(
+          input.lineitems,
+          subContractors
+        );
+        detailsData = {
+          ...detailsData,
+          "Total (USD)": (
+            <SubContractorReference
+              value={usdFormatter.format(subContractorTotal / 100)}
+              username={username}
+              userid={id}
+            />
+          ),
+          "Total (DCR)": (
+            <SubContractorReference
+              value={subContractorTotalDcr.toFixed(8)}
+              username={username}
+              userid={id}
+            />
+          ),
+          "Labor (hours)": (
+            <SubContractorReference
+              value={fromMinutesToHours(subContractorTotalLabor)}
+              username={username}
+              userid={id}
+            />
+          ),
+          "Contractor Rate": (
+            <SubContractorReference
+              value={usdFormatter.format(subContractorRate / 100)}
+              username={username}
+              userid={id}
+            />
+          )
+        };
+      }
+      return detailsData;
     })) ||
   [];
 
@@ -48,15 +110,24 @@ const ProposalBillingDetails = ({ TopBanner, PageDetails, Main, match }) => {
     loading
   } = useProposalBillingDetails(tokenFromUrl);
 
+  const {
+    subContractors,
+    loading: loadingSubContractors,
+    error: subContractorsError
+  } = useSubContractors();
+
   useEffect(() => {
     getSpendingDetails(tokenFromUrl).catch((e) => setError(e));
   }, [getSpendingDetails, tokenFromUrl]);
 
-  const isDetailsLoaded = proposalBillingDetails && !loading;
   const isTotalZero =
     proposalBillingDetails &&
     proposalBillingDetails.totalbilled === 0 &&
     proposalBillingDetails.invoices.length === 0;
+  const isDetailsLoaded =
+    proposalBillingDetails && !loading && !loadingSubContractors;
+
+  const anyError = subContractorsError || error;
   return (
     <>
       <TopBanner>
@@ -70,8 +141,8 @@ const ProposalBillingDetails = ({ TopBanner, PageDetails, Main, match }) => {
       </TopBanner>
       <Main fillScreen>
         <GoBackLink />
-        {error ? (
-          <Message kind="error">{error.toString()}</Message>
+        {anyError ? (
+          <Message kind="error">{anyError.toString()}</Message>
         ) : !isDetailsLoaded ? (
           <div className={styles.spinnerWrapper}>
             <Spinner invert />
@@ -83,8 +154,11 @@ const ProposalBillingDetails = ({ TopBanner, PageDetails, Main, match }) => {
         ) : (
           <Card paddingSize="small">
             <Table
-              data={getDetailsData(proposalBillingDetails.invoices)}
-              headers={HEADERS}
+              data={getDetailsData(
+                proposalBillingDetails.invoices,
+                subContractors
+              )}
+              headers={TABLE_HEADERS}
             />
             <H3 className={styles.totalText}>
               Total: {formatCentsToUSD(proposalBillingDetails.totalbilled)}

--- a/src/containers/Invoice/ProposalBillingDetails/ProposalBillingDetails.module.css
+++ b/src/containers/Invoice/ProposalBillingDetails/ProposalBillingDetails.module.css
@@ -7,3 +7,12 @@
 .totalText {
   text-align: right;
 }
+
+.reference {
+  display: block;
+  font-size: 0.7em;
+}
+
+.value {
+  cursor: pointer;
+}

--- a/src/containers/Invoice/ProposalBillingDetails/ProposalBillingDetails.module.css
+++ b/src/containers/Invoice/ProposalBillingDetails/ProposalBillingDetails.module.css
@@ -16,3 +16,16 @@
 .value {
   cursor: pointer;
 }
+
+.tableWrapper > div > .table {
+  table-layout: fixed;
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: 100%;
+  min-width: 100rem;
+  background-color: transparent;
+}
+
+.tableWrapper > div {
+  overflow-x: auto;
+}

--- a/src/containers/Invoice/ProposalBillingDetails/helpers.js
+++ b/src/containers/Invoice/ProposalBillingDetails/helpers.js
@@ -1,0 +1,61 @@
+import { SUB_HOURS_LINE_ITEM } from "../constants";
+import map from "lodash/fp/map";
+import flow from "lodash/fp/flow";
+import sum from "lodash/fp/sum";
+import filter from "lodash/fp/filter";
+import head from "lodash/fp/head";
+import get from "lodash/fp/get";
+export { getInvoiceTotalExpenses } from "../helpers";
+
+export const TABLE_HEADERS = [
+  "User",
+  "Contractor Rate",
+  "Exchange Rate",
+  "Labor (hours)",
+  "Expense (USD)",
+  "Total (DCR)",
+  "Total (USD)",
+  "Invoice"
+];
+
+export const isSubContractorLineItem = (item) =>
+  item.type === SUB_HOURS_LINE_ITEM;
+
+export const getSubContractorTotal = (lineItems) =>
+  lineItems
+    .filter(isSubContractorLineItem)
+    .reduce(
+      (acc, lineItem) => acc + (lineItem.subrate * lineItem.labor) / 60,
+      0
+    );
+
+export const getInvoiceTotal = (rate, lineItems) => {
+  const laborInMinutes = lineItems
+    .filter((item) => !isSubContractorLineItem(item))
+    .reduce((acc, cur) => acc + cur.labor, 0);
+
+  const expensesInUsd = lineItems.reduce((acc, cur) => acc + cur.expenses, 0);
+  const laborInHours = laborInMinutes / 60;
+
+  return laborInHours * rate + expensesInUsd; // total
+};
+
+export const getInvoiceTotalLabor = (lineItems) =>
+  flow(
+    map(({ labor }) => labor),
+    sum
+  )(lineItems);
+
+const getSubContractorsInfo = (lineItems) =>
+  filter(isSubContractorLineItem)(lineItems);
+
+export const getSubContractorTotalLabor = (lineItems) =>
+  flow(getSubContractorsInfo, getInvoiceTotalLabor)(lineItems);
+
+export const getSubContractorRate = (lineItems) =>
+  flow(getSubContractorsInfo, head, get("subrate"))(lineItems);
+
+export const getSubContractor = (lineItems, subContractors = []) => {
+  const id = flow(getSubContractorsInfo, head, get("subuserid"))(lineItems);
+  return subContractors.find((sc) => sc.id === id);
+};

--- a/src/containers/Invoice/ProposalBillingSummary/ProposalBillingSummary.jsx
+++ b/src/containers/Invoice/ProposalBillingSummary/ProposalBillingSummary.jsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from "react";
-import { Spinner, Card, H2, BoxTextInput, Message } from "pi-ui";
+import { Spinner, BoxTextInput, Message, Table } from "pi-ui";
 import { useProposalBillingSummary } from "./hooks";
 import styles from "./ProposalBillingSummary.module.css";
 import { formatCentsToUSD } from "src/utils";
 import Link from "src/components/Link";
+
+const TABLE_HEADERS = ["Proposal", "Amount"];
 
 const ProposalBillingSummary = ({ TopBanner, PageDetails, Main }) => {
   const [error, setError] = useState();
@@ -60,22 +62,20 @@ const ProposalBillingSummary = ({ TopBanner, PageDetails, Main }) => {
             <Spinner invert />
           </div>
         ) : (
-          proposals.map(({ token, title, totalbilled }) => {
-            return (
-              <Card paddingSize="small" className={styles.card} key={token}>
-                <div className={styles.title}>
-                  <Link
-                    to={`/admin/proposalsbilling/${token}`}
-                    className={styles.titleLink}>
-                    <H2>{title}</H2>
-                  </Link>
-                </div>
-                <div className={styles.billed}>
-                  <H2>{formatCentsToUSD(totalbilled)}</H2>
-                </div>
-              </Card>
-            );
-          })
+          <Table
+            className={styles.table}
+            data={proposals.map(({ token, title, totalbilled }) => ({
+              Proposal: (
+                <Link
+                  to={`/admin/proposalsbilling/${token}`}
+                  className={styles.titleLink}>
+                  {title}
+                </Link>
+              ),
+              Amount: formatCentsToUSD(totalbilled)
+            }))}
+            headers={TABLE_HEADERS}
+          />
         )}
       </Main>
     </>

--- a/src/containers/Invoice/ProposalBillingSummary/ProposalBillingSummary.jsx
+++ b/src/containers/Invoice/ProposalBillingSummary/ProposalBillingSummary.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Spinner, BoxTextInput, Message, Table } from "pi-ui";
+import { Spinner, BoxTextInput, Message, Table, Card } from "pi-ui";
 import { useProposalBillingSummary } from "./hooks";
 import styles from "./ProposalBillingSummary.module.css";
 import { formatCentsToUSD } from "src/utils";
@@ -62,20 +62,22 @@ const ProposalBillingSummary = ({ TopBanner, PageDetails, Main }) => {
             <Spinner invert />
           </div>
         ) : (
-          <Table
-            className={styles.table}
-            data={proposals.map(({ token, title, totalbilled }) => ({
-              Proposal: (
-                <Link
-                  to={`/admin/proposalsbilling/${token}`}
-                  className={styles.titleLink}>
-                  {title}
-                </Link>
-              ),
-              Amount: formatCentsToUSD(totalbilled)
-            }))}
-            headers={TABLE_HEADERS}
-          />
+          <Card paddingSize="small" className={styles.card}>
+            <Table
+              className={styles.table}
+              data={proposals.map(({ token, title, totalbilled }) => ({
+                Proposal: (
+                  <Link
+                    to={`/admin/proposalsbilling/${token}`}
+                    className={styles.titleLink}>
+                    {title}
+                  </Link>
+                ),
+                Amount: formatCentsToUSD(totalbilled)
+              }))}
+              headers={TABLE_HEADERS}
+            />
+          </Card>
         )}
       </Main>
     </>

--- a/src/containers/Invoice/ProposalBillingSummary/ProposalBillingSummary.module.css
+++ b/src/containers/Invoice/ProposalBillingSummary/ProposalBillingSummary.module.css
@@ -13,17 +13,16 @@
   display: flex;
 }
 
-.title {
-  flex-grow: 1;
-}
-
 .titleLink {
   color: var(--tab-text-active-color) !important;
 }
 
 .billed {
-  margin-left: 2rem;
   display: flex;
   align-self: flex-start;
   justify-content: flex-end;
+}
+
+.table {
+  width: 100%;
 }

--- a/src/containers/Invoice/constants.js
+++ b/src/containers/Invoice/constants.js
@@ -7,3 +7,5 @@ export const INVOICE_STATUS_DISPUTED = 4; // Invoice has been disputed for some 
 export const INVOICE_STATUS_REJECTED = 5; // Invoice needs to be revised
 export const INVOICE_STATUS_APPROVED = 6; // Invoice has been approved
 export const INVOICE_STATUS_PAID = 7; // Invoice has been paid
+
+export const SUB_HOURS_LINE_ITEM = 4;

--- a/src/reducers/models/invoicePayouts.js
+++ b/src/reducers/models/invoicePayouts.js
@@ -1,5 +1,5 @@
 import * as act from "src/actions/types";
-import { set } from "lodash/fp";
+import set from "lodash/fp/set";
 
 const DEFAULT_STATE = {
   payouts: [],
@@ -15,6 +15,7 @@ const invoicePayouts = (state = DEFAULT_STATE, action) =>
             set("payouts", action.payload.payouts)(state),
           [act.RECEIVE_INVOICE_PAYOUTS]: () =>
             set("payoutSummaries", action.payload.invoices)(state),
+          [act.RECEIVE_PAY_APPROVED]: () => DEFAULT_STATE,
           [act.RECEIVE_LOGOUT]: () => DEFAULT_STATE
         }[action.type] || (() => state)
       )();

--- a/src/reducers/models/proposalBilling.js
+++ b/src/reducers/models/proposalBilling.js
@@ -1,5 +1,5 @@
 import * as act from "src/actions/types";
-import { set } from "lodash/fp";
+import set from "lodash/fp/set";
 
 const DEFAULT_STATE = {
   proposalsList: null,
@@ -15,6 +15,7 @@ const proposalBilling = (state = DEFAULT_STATE, action) =>
             set("proposalsList", action.payload.proposals)(state),
           [act.RECEIVE_SPENDING_DETAILS]: () =>
             set("proposalDetails", action.payload.details)(state),
+          [act.RECEIVE_PAY_APPROVED]: () => DEFAULT_STATE,
           [act.RECEIVE_LOGOUT]: () => DEFAULT_STATE
         }[action.type] || (() => state)
       )();


### PR DESCRIPTION
This PR improves the proposals billing pages (summary and details).

Closes #2086 
Closes #2085 

## Details
- handle expenses and labor
- handle subcontractors lineitem types properly
- **Before**
    <img width="961" alt="Screen Shot 2020-08-28 at 6 35 27 PM" src="https://user-images.githubusercontent.com/22639213/91616959-42319f00-e95d-11ea-8ea6-50947365b219.png">

- **After**
    ![proposalbilling](https://user-images.githubusercontent.com/22639213/91616819-e2d38f00-e95c-11ea-9001-bf12aeeb9a6d.gif)

## Summary:
- improve listing view by switching cards view to table view
- reset list after invoices get paid
- **Before:**
    <img width="1075" alt="Screen Shot 2020-08-28 at 6 41 18 PM" src="https://user-images.githubusercontent.com/22639213/91617281-12cf6200-e95e-11ea-8598-35a3dc929f4e.png">

- **After**
    <img width="960" alt="Screen Shot 2020-08-28 at 6 39 41 PM" src="https://user-images.githubusercontent.com/22639213/91617191-df8cd300-e95d-11ea-95dc-ea4ca569f7a5.png">


## Dependencies
Depends on https://github.com/decred/politeia/pull/1286
