### PR TITLE
fix: singular form in block countdown when 1 block left

### DIFF
--- a/src/components/Proposal/Proposal.jsx
+++ b/src/components/Proposal/Proposal.jsx
@@ -261,7 +261,9 @@ const Proposal = React.memo(function Proposal({
                             styles.blocksLeft
                           )}
                           size="small">
-                          {`${voteBlocksLeft} blocks left`}
+                          {`${voteBlocksLeft} block${
+                            voteBlocksLeft > 1 ? "s" : ""
+                          } left`}
                         </Text>
                       </>
                     )}


### PR DESCRIPTION
This diff fixes the spelling issue reported on #2115 

### Dependencies

Closes #2115 

### UI Changes Screenshot

After:

<img width="284" alt="image" src="https://user-images.githubusercontent.com/10324528/91669130-5b804a00-eb1b-11ea-8b99-9680df2ecfd5.png">

<img width="284" alt="image" src="https://user-images.githubusercontent.com/10324528/91669135-62a75800-eb1b-11ea-8f2c-e0135a34f144.png">
