### PR TITLE
markdown editor: fix editor styling for preview mode

### DIFF
--- a/src/components/MarkdownEditor/styles.css
+++ b/src/components/MarkdownEditor/styles.css
@@ -48,6 +48,10 @@ li.mde-header-item > button {
   display: none;
 }
 
+.react-mde .invisible {
+  display: none;
+}
+
 .mde-tabs button,
 .mde-header-group:not(:last-child) .mde-header-item button {
   background: none;

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -254,10 +254,6 @@
   display: none;
 }
 
-.react-mde .invisible {
-  display: none;
-}
-
 /* EXTRA SMALL */
 @media screen and (max-width: 560px) {
   .hide-on-mobile {

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -254,6 +254,10 @@
   display: none;
 }
 
+.react-mde .invisible {
+  display: none;
+}
+
 /* EXTRA SMALL */
 @media screen and (max-width: 560px) {
   .hide-on-mobile {


### PR DESCRIPTION
Closes #2137.

After investigating a bit the react-mde package, I found out that the `invisible` styling was not being attached to the markdown preview component.

This diff adds it.