### PR TITLE
fix: force markdown's wide 'code' tag to breakline

### DIFF
--- a/src/components/Markdown/styles.css
+++ b/src/components/Markdown/styles.css
@@ -446,7 +446,7 @@
   font-size: 100%;
   margin: 0;
   padding: 0;
-  white-space: pre;
+  white-space: pre-wrap;
   word-break: normal;
 }
 
@@ -465,7 +465,6 @@
   border-radius: 3px;
   font-size: 85%;
   line-height: 1.45;
-  overflow: scroll;
   padding: 16px;
   max-width: 100%;
 }
@@ -481,8 +480,6 @@
   display: inline;
   line-height: inherit;
   margin: 0;
-  max-width: auto;
-  overflow: visible;
   padding: 0;
   word-wrap: normal;
 }


### PR DESCRIPTION
This diff fixes the display issues reported on #2136 & #2138, usage of wide 'code' inside
the markdown renderer was causing the issue.

### Solution description

Force 'code' tag with wide text to breakline in markdown.

### Dependencies

Fixes #2136 
Fixes #2138 

### UI Changes Screenshot

Before:
<img width="1720" alt="image" src="https://user-images.githubusercontent.com/10324528/94680507-8207ef80-032a-11eb-9dc9-65e9cf225483.png">


After:
<img width="1720" alt="image" src="https://user-images.githubusercontent.com/10324528/94680537-8df3b180-032a-11eb-8f0e-7338ebe79267.png">
