### PR TITLE
RFP submissions: make submission's name a link

### DIFF
--- a/src/components/ProposalsList/ProposalItem.jsx
+++ b/src/components/ProposalsList/ProposalItem.jsx
@@ -3,7 +3,6 @@ import PropTypes from "prop-types";
 import {
   StatusBar,
   StatusTag,
-  Text,
   classNames,
   Icon,
   useMediaQuery
@@ -27,6 +26,7 @@ import {
 } from "src/containers/Proposal/helpers";
 import styles from "./ProposalsList.module.css";
 import { Status, Event, CommentsLink } from "../RecordWrapper";
+import Link from "../Link";
 import { useProposalVoteTimeInfo } from "src/containers/Proposal/hooks";
 import { useProposalURLs } from "src/containers/Proposal/hooks";
 import { useRouter } from "src/components/Router";
@@ -64,7 +64,9 @@ const ProposalItem = ({
         onClick={goToFullProposal(history, proposalURL)}
         noMargin>
         <div className={classNames(styles.itemTitle, "flex-column")}>
-          <Text color="primaryDark">{name}</Text>
+          <Link dark to={proposalURL}>
+            {name}
+          </Link>
           <CommentsLink
             showIcon={false}
             numOfComments={numcomments}


### PR DESCRIPTION
This diff makes the submission's name a link in RFP submissions list overview section(see screenshot below), 
to make possible for users to open the submission in a new tab.

### Dependencies

Closes #2146 

### UI Changes Screenshot

After:
<img width="334" alt="image" src="https://user-images.githubusercontent.com/10324528/94738874-bb674c00-0378-11eb-8d38-689cdc4b346f.png">

