### PR TITLE
diff: improve diff loading state and minor fixes

### DIFF
--- a/src/components/ModalDiff/ModalDiff.module.css
+++ b/src/components/ModalDiff/ModalDiff.module.css
@@ -27,8 +27,15 @@
   overflow: scroll;
 }
 
+.loaderWrapper {
+  width: 920px;
+}
+
 @media screen and (max-width: 560px) {
   .diffTabContent {
     max-height: calc(70vh);
+  }
+  .loaderWrapper {
+    width: 100%;
   }
 }

--- a/src/components/ModalDiff/ModalDiffLoader.jsx
+++ b/src/components/ModalDiff/ModalDiffLoader.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Modal, getThemeProperty, useTheme } from "pi-ui";
+import ContentLoader from "react-content-loader";
+import styles from "./ModalDiff.module.css";
+
+const ModalDiffLoader = ({ onClose, ...props }) => {
+  const { theme } = useTheme();
+  const primaryColor = getThemeProperty(theme, "card-background");
+  const secondaryColor = getThemeProperty(theme, "dimmed-card-background");
+  return (
+    <Modal
+      onClose={onClose}
+      {...props}
+      contentStyle={{ width: "100%", minHeight: "40rem" }}>
+      <div className={styles.loaderWrapper}>
+        <ContentLoader
+          height={500}
+          width={800}
+          speed={2}
+          primaryColor={primaryColor}
+          secondaryColor={secondaryColor}>
+          <rect x="0" y="0" width="700" height="30" />
+          <rect x="0" y="50" width="100" height="20" />
+          <rect x="120" y="50" width="100" height="20" />
+          <rect x="240" y="50" width="100" height="20" />
+          <rect x="0" y="90" width="800" height="400" />
+        </ContentLoader>
+      </div>
+    </Modal>
+  );
+};
+
+export default ModalDiffLoader;

--- a/src/components/ModalDiff/index.js
+++ b/src/components/ModalDiff/index.js
@@ -1,2 +1,3 @@
 export { default as ModalDiffProposal } from "./ModalDiffProposal";
 export { default as ModalDiffInvoice } from "./ModalDiffInvoice";
+export { default as ModalDiffLoader } from "./ModalDiffLoader";

--- a/src/components/ProposalsList/ProposalItem.jsx
+++ b/src/components/ProposalsList/ProposalItem.jsx
@@ -1,12 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import {
-  StatusBar,
-  StatusTag,
-  classNames,
-  Icon,
-  useMediaQuery
-} from "pi-ui";
+import { StatusBar, StatusTag, classNames, Icon, useMediaQuery } from "pi-ui";
 import VotesCount from "../Proposal/VotesCount";
 import { Row } from "../layout";
 import {


### PR DESCRIPTION
Diff processing is computationally expensive, and this was causing some UX issues.

The first noticed issue was that Diffs for **version 1** was not being displayed, and the second was that we needed to add some visual feedback for the user to show him/her that the page wasn't actually broken.

### Solution description
This PR adds a `DiffLoader` component to indicate the loading state of some proposal or invoice diff, and fixes the version 1 bug.

### UI Changes Screenshot

<img width="1331" alt="Screen Shot 2020-10-11 at 11 06 32 AM" src="https://user-images.githubusercontent.com/22639213/95680704-eb50f380-0bb1-11eb-9b60-bacd3778ff52.png">
