### PR TITLE
[cms] fix: fetch invoice proposals lineitem correctly

### DIFF
--- a/src/components/ProposalsList/ProposalItem.jsx
+++ b/src/components/ProposalsList/ProposalItem.jsx
@@ -1,12 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import {
-  StatusBar,
-  StatusTag,
-  classNames,
-  Icon,
-  useMediaQuery
-} from "pi-ui";
+import { StatusBar, StatusTag, classNames, Icon, useMediaQuery } from "pi-ui";
 import VotesCount from "../Proposal/VotesCount";
 import { Row } from "../layout";
 import {

--- a/src/containers/Invoice/Detail/Detail.jsx
+++ b/src/containers/Invoice/Detail/Detail.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from "react";
+import React from "react";
 import { withRouter } from "react-router-dom";
 import { Message } from "pi-ui";
 import { useInvoice } from "./hooks";
@@ -8,62 +8,23 @@ import { AdminInvoiceActionsProvider } from "src/containers/Invoice/Actions";
 import Comments from "src/containers/Comments";
 import { isUnreviewedInvoice } from "../helpers";
 import { GoBackLink } from "src/components/Router";
-import useApprovedProposals from "src/hooks/api/useApprovedProposals";
 import get from "lodash/fp/get";
-import isEmpty from "lodash/isEmpty";
-import flow from "lodash/fp/flow";
-import map from "lodash/fp/map";
-import filter from "lodash/fp/filter";
-import uniq from "lodash/fp/uniq";
-
-const PAGE_SIZE = 20;
 
 const InvoiceDetail = ({ Main, match }) => {
   const invoiceToken = get("params.token", match);
   const threadParentCommentID = get("params.commentid", match);
-  const { invoice, loading, currentUser, error } = useInvoice(invoiceToken);
+  const {
+    invoice,
+    loading,
+    currentUser,
+    error,
+    proposals,
+    proposalsError
+  } = useInvoice(invoiceToken);
   const isAuthor =
     currentUser && invoice && invoice.userid === currentUser.userid;
   const isAdmin = currentUser && currentUser.isadmin;
   const isPublicMode = !isAdmin && !isAuthor;
-  const tokens = useMemo(
-    () =>
-      invoice &&
-      invoice.input &&
-      invoice.input.lineitems &&
-      flow(
-        map(({ proposaltoken }) => proposaltoken),
-        uniq,
-        filter((t) => t !== "")
-      )(invoice.input.lineitems),
-    [invoice]
-  );
-
-  const {
-    proposals,
-    proposalsByToken,
-    onFetchProposalsBatchByTokensRemaining,
-    isLoading,
-    error: proposalsError
-  } = useApprovedProposals();
-
-  useEffect(() => {
-    if (!isLoading && !isEmpty(proposalsByToken)) {
-      const remainingTokens = tokens
-        ? tokens.filter(
-            (t) => !Object.keys(proposalsByToken).some((pt) => pt === t)
-          )
-        : [];
-      if (!isEmpty(remainingTokens)) {
-        onFetchProposalsBatchByTokensRemaining(remainingTokens, PAGE_SIZE);
-      }
-    }
-  }, [
-    isLoading,
-    proposalsByToken,
-    tokens,
-    onFetchProposalsBatchByTokensRemaining
-  ]);
 
   return (
     <>

--- a/src/containers/Invoice/Detail/hooks.js
+++ b/src/containers/Invoice/Detail/hooks.js
@@ -2,7 +2,13 @@ import { useMemo } from "react";
 import * as sel from "src/selectors";
 import * as act from "src/actions";
 import { useSelector, useAction } from "src/redux";
-import useAPIAction from "src/hooks/utils/useAPIAction";
+import useFetchMachine from "src/hooks/utils/useFetchMachine";
+import { getProposalsTokensFromInvoice } from "../helpers";
+import isEmpty from "lodash/fp/isEmpty";
+import isEqual from "lodash/fp/isEqual";
+import values from "lodash/fp/values";
+import keys from "lodash/fp/keys";
+import difference from "lodash/fp/difference";
 
 export function useInvoice(invoiceToken) {
   const invoiceSelector = useMemo(
@@ -11,13 +17,65 @@ export function useInvoice(invoiceToken) {
   );
   const invoice = useSelector(invoiceSelector);
   const currentUser = useSelector(sel.currentUser);
+  const proposalsByToken = useSelector(sel.proposalsByToken);
   const onFetchInvoice = useAction(act.onFetchInvoice);
-  const requestParams = useMemo(() => [invoiceToken], [invoiceToken]);
-  const [loading, error] = useAPIAction(
-    onFetchInvoice,
-    requestParams,
-    !invoice || !invoice.payout
-  );
+  const onFetchProposalsBatch = useAction(act.onFetchProposalsBatch);
 
-  return { invoice, loading, error, currentUser };
+  const unfetchedProposalsTokens = difference(
+    getProposalsTokensFromInvoice(invoice)
+  )(keys(proposalsByToken));
+
+  const hasUnfetchedProposalsTokens = !isEmpty(unfetchedProposalsTokens);
+
+  const initialValues = {
+    status: "idle",
+    loading: true
+  };
+
+  const [
+    state,
+    send,
+    { FETCH, VERIFY, REJECT, RESOLVE, RETRY }
+  ] = useFetchMachine({
+    actions: {
+      initial: () => {
+        if (!invoice || (invoice && !invoice.payout)) {
+          onFetchInvoice(invoiceToken)
+            .then(() => send(VERIFY))
+            .catch((e) => send(REJECT, e));
+          return send(FETCH);
+        }
+        return send(VERIFY);
+      },
+      load: () => {
+        if (!invoice || hasUnfetchedProposalsTokens) {
+          return;
+        }
+        return send(VERIFY);
+      },
+      verify: function verifyRemainingProposalsTokens() {
+        if (invoice && hasUnfetchedProposalsTokens) {
+          onFetchProposalsBatch(unfetchedProposalsTokens, false)
+            .then(() => send(VERIFY))
+            .catch((e) => send(REJECT, e));
+          return send(FETCH);
+        }
+        return send(RESOLVE, { invoice, proposals: values(proposalsByToken) });
+      },
+      done: () => {
+        if (!isEqual(state.invoice, invoice)) {
+          return send(RETRY, initialValues);
+        }
+      }
+    },
+    initialValues
+  });
+
+  return {
+    invoice: state.invoice,
+    loading: state.loading || state.verifying,
+    proposals: state.proposals,
+    proposalsError: state.error,
+    currentUser
+  };
 }

--- a/src/containers/Invoice/Edit/Edit.jsx
+++ b/src/containers/Invoice/Edit/Edit.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import get from "lodash/fp/get";
 import { withRouter } from "react-router-dom";
@@ -9,7 +9,6 @@ import { useEditInvoice } from "./hooks";
 import { fromUSDCentsToUSDUnits } from "src/helpers";
 import InvoiceLoader from "src/components/Invoice/InvoiceLoader";
 import InvoiceForm from "src/components/InvoiceForm";
-import { getProposalsTokensFromInvoice } from "../helpers";
 
 const EditInvoice = ({ match }) => {
   const tokenFromUrl = get("params.token", match);
@@ -37,14 +36,7 @@ const EditInvoice = ({ match }) => {
       }
     : null;
 
-  const proposalsTokens = useMemo(
-    () => getProposalsTokensFromInvoice(invoice),
-    [invoice]
-  );
-
-  const { proposals, error: proposalsError } = useApprovedProposals(
-    proposalsTokens
-  );
+  const { proposals, error: proposalsError } = useApprovedProposals();
   return (
     <Card className="container margin-bottom-l">
       {error ? (

--- a/src/containers/Invoice/helpers.js
+++ b/src/containers/Invoice/helpers.js
@@ -93,12 +93,11 @@ export const getInvoiceTotalHours = (invoice) => {
 };
 
 export const getInvoiceTotalExpenses = (invoice) => {
-  console.log(invoice);
   if (!invoice) return 0;
-  return invoice.input.lineitems.reduce((total, item) => {
-    console.log("item", item, total);
-    return (total += item.expenses / 100);
-  }, 0);
+  return invoice.input.lineitems.reduce(
+    (total, item) => (total += item.expenses / 100),
+    0
+  );
 };
 
 export const getInvoiceTotalAmount = (invoice) => {

--- a/src/containers/Invoice/helpers.js
+++ b/src/containers/Invoice/helpers.js
@@ -93,8 +93,10 @@ export const getInvoiceTotalHours = (invoice) => {
 };
 
 export const getInvoiceTotalExpenses = (invoice) => {
+  console.log(invoice);
   if (!invoice) return 0;
   return invoice.input.lineitems.reduce((total, item) => {
+    console.log("item", item, total);
     return (total += item.expenses / 100);
   }, 0);
 };

--- a/src/hooks/utils/useFetchMachine.js
+++ b/src/hooks/utils/useFetchMachine.js
@@ -63,6 +63,8 @@ const fetchReducer = (state, action) => {
         set("error", action.payload),
         set("status", nextState)
       )(state);
+    case RETRY:
+      return action.payload;
     default:
       return set("error", new Error("unhanlded state machine action"))(state);
   }


### PR DESCRIPTION
Due to some mistakes, the invoice details was not correctly using the updated fetch machine. This diff closes #2162 and fixes this issue

### Solution description

The solution was to use the fetch machine correctly, and create a simple fetching flow for invoices, just like we do for RFP proposals, but instead, we need to fetch the info for invoices proposals tokens.
