### PR TITLE
pi-ui: use default themes' names

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "localforage": "^1.7.3",
     "lodash": "^4.17.19",
     "normalize.css": "^8.0.1",
-    "pi-ui": "https://github.com/decred/pi-ui",
+    "pi-ui": "https://github.com/amassarwi/pi-ui#themesnames",
     "prop-types": "^15.7.2",
     "qr-image": "^3.2.0",
     "query-string": "^6.10.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "localforage": "^1.7.3",
     "lodash": "^4.17.19",
     "normalize.css": "^8.0.1",
-    "pi-ui": "https://github.com/amassarwi/pi-ui#themesnames",
+    "pi-ui": "https://github.com/decred/pi-ui",
     "prop-types": "^15.7.2",
     "qr-image": "^3.2.0",
     "query-string": "^6.10.1",

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,13 @@
 import React from "react";
 import { Router } from "src/components/Router";
 import Config from "src/containers/Config";
-import { defaultLightTheme, ThemeProvider, defaultDarkTheme } from "pi-ui";
+import {
+  defaultLightTheme,
+  ThemeProvider,
+  defaultDarkTheme,
+  DEFAULT_LIGHT_THEME_NAME,
+  DEFAULT_DARK_THEME_NAME
+} from "pi-ui";
 import { ReduxProvider } from "src/redux";
 import Loader from "src/containers/Loader";
 import Routes from "src/pages";
@@ -21,8 +27,8 @@ const themeCustomVariables = {
 };
 
 const themes = {
-  light: { ...defaultLightTheme, ...themeCustomVariables },
-  dark: { ...defaultDarkTheme, ...themeCustomVariables }
+  [DEFAULT_LIGHT_THEME_NAME]: { ...defaultLightTheme, ...themeCustomVariables },
+  [DEFAULT_DARK_THEME_NAME]: { ...defaultDarkTheme, ...themeCustomVariables }
 };
 
 const fonts = [
@@ -56,7 +62,10 @@ const App = () => {
   }
 
   return (
-    <ThemeProvider themes={themes} defaultThemeName="light" fonts={fonts}>
+    <ThemeProvider
+      themes={themes}
+      defaultThemeName={DEFAULT_LIGHT_THEME_NAME}
+      fonts={fonts}>
       <ReduxProvider>
         <Config>
           <Loader>

--- a/src/components/CopyLink.jsx
+++ b/src/components/CopyLink.jsx
@@ -1,12 +1,17 @@
 import React from "react";
-import { getThemeProperty, useHover, useTheme } from "pi-ui";
+import {
+  getThemeProperty,
+  useHover,
+  useTheme,
+  DEFAULT_DARK_THEME_NAME
+} from "pi-ui";
 import PropTypes from "prop-types";
 import IconButton from "src/components/IconButton";
 import CopyToClipboard from "src/components/CopyToClipboard";
 
 const CopyLink = ({ url, className }) => {
   const { theme, themeName } = useTheme();
-  const isDarkTheme = themeName === "dark";
+  const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
   const hoverColor = getThemeProperty(theme, "icon-hover-color");
   const darkIconColor = getThemeProperty(theme, "text-color");
   const [ref, isHovered] = useHover();

--- a/src/components/CopyToClipboard/CopyToClipboard.jsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Tooltip, useTheme, classNames } from "pi-ui";
+import { Tooltip, useTheme, classNames, DEFAULT_DARK_THEME_NAME } from "pi-ui";
 import styles from "./CopyToClipboard.module.css";
 
 const copyToClipboard = (str) => {
@@ -13,7 +13,7 @@ const copyToClipboard = (str) => {
 
 const CopyToClipboard = ({ children, value, tooltipText, className }) => {
   const { themeName } = useTheme();
-  const isDarkTheme = themeName === "dark";
+  const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
 
   const [feedbackActive, setFeedbackActive] = useState(false);
   const onCopyToClipboard = () => {

--- a/src/components/DateTooltip/DateTooltip.jsx
+++ b/src/components/DateTooltip/DateTooltip.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import PropTypes from "prop-types";
 import distance from "date-fns/distance_in_words";
-import { Tooltip, classNames, useTheme } from "pi-ui";
+import { Tooltip, classNames, useTheme, DEFAULT_DARK_THEME_NAME } from "pi-ui";
 import styles from "./DateTooltip.module.css";
 import { formatUnixTimestamp } from "src/utils";
 
@@ -12,7 +12,7 @@ const DateTooltip = ({ timestamp, placement, className, children }) => {
   const timeAgo = useMemo(() => getTimeAgo(timestamp), [timestamp]);
 
   const { themeName } = useTheme();
-  const isDarkTheme = themeName === "dark";
+  const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
 
   return (
     <Tooltip

--- a/src/components/Diff/DiffLineitems.jsx
+++ b/src/components/Diff/DiffLineitems.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useCallback } from "react";
 import PropTypes from "prop-types";
-import { classNames, useTheme } from "pi-ui";
+import { classNames, useTheme, DEFAULT_DARK_THEME_NAME } from "pi-ui";
 import { fromUSDCentsToUSDUnits, fromMinutesToHours } from "src/helpers";
 import styles from "./Diff.module.css";
 import { TableRow } from "src/components/InvoiceDatasheet/InvoiceDatasheet";
@@ -60,7 +60,7 @@ const renderGrid = (lineItems) =>
 
 const DiffLineitems = ({ lineItems, proposals }) => {
   const { themeName } = useTheme();
-  const isDarkTheme = themeName === "dark";
+  const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
 
   const getProposalName = useCallback(
     (token) => get(proposals, [token, "name"]),

--- a/src/components/HeaderNav/HeaderNav.jsx
+++ b/src/components/HeaderNav/HeaderNav.jsx
@@ -4,7 +4,9 @@ import {
   DropdownItem,
   Toggle,
   useTheme,
-  classNames
+  classNames,
+  DEFAULT_DARK_THEME_NAME,
+  DEFAULT_LIGHT_THEME_NAME
 } from "pi-ui";
 import React, { useEffect, useMemo, useCallback } from "react";
 import { NavLink, withRouter } from "react-router-dom";
@@ -55,17 +57,17 @@ const HeaderNav = ({ history }) => {
   }, [history, userid]);
 
   useEffect(() => {
-    if (darkThemeOnLocalStorage && themeName === "light") {
-      setThemeName("dark");
+    if (darkThemeOnLocalStorage && themeName === DEFAULT_LIGHT_THEME_NAME) {
+      setThemeName(DEFAULT_DARK_THEME_NAME);
     }
   }, [darkThemeOnLocalStorage, setThemeName, themeName]);
 
   const onThemeToggleHandler = () => {
-    if (themeName === "light") {
+    if (themeName === DEFAULT_LIGHT_THEME_NAME) {
       setDarkThemeOnLocalStorage(true);
-      setThemeName("dark");
+      setThemeName(DEFAULT_DARK_THEME_NAME);
     } else {
-      setThemeName("light");
+      setThemeName(DEFAULT_LIGHT_THEME_NAME);
       setDarkThemeOnLocalStorage(false);
     }
   };
@@ -93,7 +95,7 @@ const HeaderNav = ({ history }) => {
           <div className={styles.themeToggleWrapper}>
             <Toggle
               onToggle={onThemeToggleHandler}
-              toggled={themeName === "dark"}
+              toggled={themeName === DEFAULT_DARK_THEME_NAME}
             />
             <div className={styles.themeToggleLabel}>Dark Mode</div>
           </div>
@@ -107,7 +109,7 @@ const HeaderNav = ({ history }) => {
         className={classNames(styles.themeToggleWrapper, styles.publicWrapper)}>
         <Toggle
           onToggle={onThemeToggleHandler}
-          toggled={themeName === "dark"}
+          toggled={themeName === DEFAULT_DARK_THEME_NAME}
         />
         <div onClick={onThemeToggleHandler} className={styles.themeToggleLabel}>
           Dark Mode

--- a/src/components/HelpMessage/HelpMessage.jsx
+++ b/src/components/HelpMessage/HelpMessage.jsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { Text, classNames, useTheme } from "pi-ui";
+import { Text, classNames, useTheme, DEFAULT_DARK_THEME_NAME } from "pi-ui";
 import styles from "./HelpMessage.module.css";
 
 const HelpMessage = ({ className, children }) => {
   const { themeName } = useTheme();
-  const isDarkTheme = themeName === "dark";
+  const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
   return (
     <div className={classNames("justify-center", styles.container)}>
       <Text

--- a/src/components/Invoice/Invoice.jsx
+++ b/src/components/Invoice/Invoice.jsx
@@ -4,7 +4,8 @@ import {
   Text,
   useMediaQuery,
   CopyableText,
-  useTheme
+  useTheme,
+  DEFAULT_DARK_THEME_NAME
 } from "pi-ui";
 import React, { useMemo } from "react";
 import PropTypes from "prop-types";
@@ -58,7 +59,7 @@ const Invoice = ({
   const totalDcrAmount = payout && convertAtomsToDcr(payout.dcrtotal);
   const showExtendedVersionPicker = extended && version > 1;
   const showVersionAsText = version > 1 && !extended && !mobile;
-  const isDarkTheme = themeName === "dark";
+  const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
 
   // record attchments without the invoice file
   const invoiceAttachments = useMemo(

--- a/src/components/Logo/Logo.jsx
+++ b/src/components/Logo/Logo.jsx
@@ -1,12 +1,12 @@
 import React from "react";
-import { useTheme } from "pi-ui";
+import { useTheme, DEFAULT_DARK_THEME_NAME } from "pi-ui";
 import PropTypes from "prop-types";
 import { useConfig } from "src/containers/Config";
 
 const Logo = ({ style }) => {
   const { themeName } = useTheme();
   const { logoLight, logoDark } = useConfig();
-  const logoSrc = themeName === "dark" ? logoDark : logoLight;
+  const logoSrc = themeName === DEFAULT_DARK_THEME_NAME ? logoDark : logoLight;
   return (
     <img
       role="presentation"

--- a/src/components/Markdown/test/Markdown.test.js
+++ b/src/components/Markdown/test/Markdown.test.js
@@ -1,6 +1,10 @@
 import React from "react";
 import ReactMarkdown from "react-markdown";
-import { defaultLightTheme, ThemeProvider, defaultDarkTheme } from "pi-ui";
+import {
+  defaultLightTheme,
+  ThemeProvider,
+  DEFAULT_LIGHT_THEME_NAME
+} from "pi-ui";
 import { shallow } from "enzyme";
 import { customRenderers } from "../helpers";
 
@@ -10,8 +14,8 @@ const maliciousBodyText =
 it("filter potencial 'XSS' attackers", () => {
   const wrapper = shallow(
     <ThemeProvider
-      themes={{ light: defaultLightTheme, dark: defaultDarkTheme }}
-      defaultThemeName="light">
+      themes={{ [DEFAULT_LIGHT_THEME_NAME]: defaultLightTheme }}
+      defaultThemeName={DEFAULT_LIGHT_THEME_NAME}>
       <ReactMarkdown
         source={maliciousBodyText}
         renderers={customRenderers(true)}

--- a/src/components/MarkdownEditor/MarkdownEditor.jsx
+++ b/src/components/MarkdownEditor/MarkdownEditor.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo } from "react";
 import PropTypes from "prop-types";
-import { classNames, useTheme } from "pi-ui";
+import { classNames, useTheme, DEFAULT_DARK_THEME_NAME } from "pi-ui";
 import { getCommandsList, getCommandIcon } from "./commands";
 import Markdown from "../Markdown";
 import styles from "./MarkdownEditor.module.css";
@@ -18,7 +18,7 @@ const MarkdownEditor = React.memo(function MarkdownEditor({
   const [tab, setTab] = useState("write");
 
   const { themeName } = useTheme();
-  const isDarkTheme = themeName === "dark";
+  const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
 
   useEffect(() => {
     const textarea = document.getElementsByClassName("mde-text")[0];

--- a/src/components/ModalMDGuide/ModalMDGuide.jsx
+++ b/src/components/ModalMDGuide/ModalMDGuide.jsx
@@ -10,13 +10,14 @@ import {
   H5,
   H6,
   useTheme,
-  classNames
+  classNames,
+  DEFAULT_DARK_THEME_NAME
 } from "pi-ui";
 import styles from "./ModalMDGuide.module.css";
 
 const MDGuideTable = () => {
   const { themeName } = useTheme();
-  const isDarkTheme = themeName === "dark";
+  const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
   const buildRow = (label, content) => ({
     "You type": label,
     "You see": content

--- a/src/components/PaymentComponent/PaymentComponent.jsx
+++ b/src/components/PaymentComponent/PaymentComponent.jsx
@@ -4,7 +4,8 @@ import {
   H4,
   Text,
   useTheme,
-  useMediaQuery
+  useMediaQuery,
+  DEFAULT_DARK_THEME_NAME
 } from "pi-ui";
 import PropTypes from "prop-types";
 import React from "react";
@@ -15,7 +16,7 @@ import styles from "./PaymentComponent.module.css";
 
 const PaymentComponent = ({ address, amount, extraSmall, status }) => {
   const { themeName } = useTheme();
-  const isDarkTheme = themeName === "dark";
+  const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
   const shouldPlaceTooltipBottom = useMediaQuery("(max-width: 675px)");
   return (
     <>

--- a/src/components/Proposal/Proposal.jsx
+++ b/src/components/Proposal/Proposal.jsx
@@ -5,7 +5,8 @@ import {
   Text,
   useMediaQuery,
   useTheme,
-  Tooltip
+  Tooltip,
+  DEFAULT_DARK_THEME_NAME
 } from "pi-ui";
 import React from "react";
 import Markdown from "../Markdown";
@@ -141,7 +142,7 @@ const Proposal = React.memo(function Proposal({
   };
 
   const { themeName } = useTheme();
-  const isDarkTheme = themeName === "dark";
+  const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
 
   return (
     <>

--- a/src/components/Proposal/VotesCount.jsx
+++ b/src/components/Proposal/VotesCount.jsx
@@ -1,6 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Text, useMediaQuery, Tooltip, useTheme, classNames } from "pi-ui";
+import {
+  Text,
+  useMediaQuery,
+  Tooltip,
+  useTheme,
+  classNames,
+  DEFAULT_DARK_THEME_NAME
+} from "pi-ui";
 import iconSearchSmall from "src/assets/images/search-small.svg";
 import styles from "./Proposal.module.css";
 
@@ -13,7 +20,7 @@ const VotesCount = ({
   const isMobileScreen = useMediaQuery("(max-width:560px)");
   const votesLeft = quorumVotes - votesReceived;
   const { themeName } = useTheme();
-  const isDarkTheme = themeName === "dark";
+  const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
 
   return (
     <div className={styles.voteCount}>

--- a/src/components/ProposalForm/ProposalForm.jsx
+++ b/src/components/ProposalForm/ProposalForm.jsx
@@ -9,7 +9,8 @@ import {
   useTheme,
   Icon,
   classNames,
-  Tooltip
+  Tooltip,
+  DEFAULT_DARK_THEME_NAME
 } from "pi-ui";
 import { Row } from "src/components/layout";
 import DatePickerField from "../DatePickerField";
@@ -58,7 +59,7 @@ const ProposalForm = React.memo(function ProposalForm({
   const {
     policy: { minlinkbyperiod, maxlinkbyperiod }
   } = usePolicy();
-  const isDarkTheme = themeName === "dark";
+  const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
   const isRfp = values.type === PROPOSAL_TYPE_RFP;
   const isRfpSubmission = values.type === PROPOSAL_TYPE_RFP_SUBMISSION;
 

--- a/src/components/RecordWrapper/RecordWrapper.jsx
+++ b/src/components/RecordWrapper/RecordWrapper.jsx
@@ -15,7 +15,8 @@ import {
   getThemeProperty,
   Tooltip,
   CopyableText,
-  useMediaQuery
+  useMediaQuery,
+  DEFAULT_DARK_THEME_NAME
 } from "pi-ui";
 import { Row } from "../layout";
 import Link from "../Link";
@@ -67,7 +68,7 @@ export const Title = ({ children, isAbandoned, url, ...props }) => {
   const SimpleWrapper = (props) => <div {...props} />;
   const Wrapper = url ? Link : SimpleWrapper;
   const { themeName } = useTheme();
-  const isDarkTheme = themeName === "dark";
+  const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
   const titleClass = isAbandoned
     ? isDarkTheme
       ? styles.darkAbandonedTitle
@@ -176,7 +177,7 @@ export const ChartsLink = ({ token }) => {
     : "dcrdata.decred.org";
 
   const { themeName } = useTheme();
-  const isDarkTheme = themeName === "dark";
+  const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
 
   return (
     <Tooltip
@@ -207,7 +208,7 @@ export const GithubLink = ({ token }) => {
   const iconColor = isHovered ? hoverColor : undefined;
 
   const { themeName } = useTheme();
-  const isDarkTheme = themeName === "dark";
+  const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
 
   return (
     <Tooltip
@@ -235,7 +236,7 @@ export const CommentsLink = ({
   className
 }) => {
   const { themeName } = useTheme();
-  const isDarkTheme = themeName === "dark";
+  const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
   return (
     <Link
       to={url}
@@ -257,7 +258,7 @@ export const CommentsLink = ({
 
 export const RfpProposalLink = ({ url, rfpTitle }) => {
   const { themeName } = useTheme();
-  const isDarkTheme = themeName === "dark";
+  const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
   return (
     <div className={styles.rfpLink}>
       <span

--- a/src/components/Router/GoBackLink.jsx
+++ b/src/components/Router/GoBackLink.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import { Link, classNames, useTheme } from "pi-ui";
+import { Link, classNames, useTheme, DEFAULT_DARK_THEME_NAME } from "pi-ui";
 import { useRouter } from "src/components/Router";
 import styles from "./GoBackLink.module.css";
 
@@ -7,7 +7,7 @@ const backArrow = <>&#8592;</>;
 
 const GoBackLink = () => {
   const { themeName } = useTheme();
-  const isDarkTheme = themeName === "dark";
+  const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
   const { pastLocations, history } = useRouter();
   const previousLocation = pastLocations[1];
 

--- a/src/components/WhatAreYourThoughts/WhatAreYourThoughts.jsx
+++ b/src/components/WhatAreYourThoughts/WhatAreYourThoughts.jsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { Text, Button, useTheme, classNames } from "pi-ui";
+import { Text, Button, useTheme, classNames, DEFAULT_DARK_THEME_NAME } from "pi-ui";
 import styles from "./WhatAreYourThoughts.module.css";
 
 const WhatAreYourThoughts = ({ onLoginClick, onSignupClick }) => {
   const { themeName } = useTheme();
-  const isDarkTheme = themeName === "dark";
+  const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
   return (
     <div className={styles.wrapper}>
       <Text className={classNames(styles.text, isDarkTheme && styles.darkText)}>

--- a/src/components/WhatAreYourThoughts/WhatAreYourThoughts.jsx
+++ b/src/components/WhatAreYourThoughts/WhatAreYourThoughts.jsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { Text, Button, useTheme, classNames, DEFAULT_DARK_THEME_NAME } from "pi-ui";
+import {
+  Text,
+  Button,
+  useTheme,
+  classNames,
+  DEFAULT_DARK_THEME_NAME
+} from "pi-ui";
 import styles from "./WhatAreYourThoughts.module.css";
 
 const WhatAreYourThoughts = ({ onLoginClick, onSignupClick }) => {

--- a/src/containers/Comments/Comment/Comment.jsx
+++ b/src/containers/Comments/Comment/Comment.jsx
@@ -1,6 +1,12 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Text, classNames, useMediaQuery, useTheme } from "pi-ui";
+import {
+  Text,
+  classNames,
+  useMediaQuery,
+  useTheme,
+  DEFAULT_DARK_THEME_NAME
+} from "pi-ui";
 import styles from "./Comment.module.css";
 import DateTooltip from "src/components/DateTooltip";
 import Markdown from "src/components/Markdown";
@@ -52,7 +58,7 @@ const Comment = ({
   );
 
   const { themeName } = useTheme();
-  const isDarkTheme = themeName === "dark";
+  const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
   const showNewReplies =
     numOfNewHiddenReplies > 0 && !showReplies && !isFlatMode;
   const isThread = numOfReplies > 0 && !isFlatMode;

--- a/src/containers/Loader/LoaderScreen/LoaderScreen.jsx
+++ b/src/containers/Loader/LoaderScreen/LoaderScreen.jsx
@@ -1,5 +1,11 @@
 import React, { useEffect, useState } from "react";
-import { Message, useTheme, classNames } from "pi-ui";
+import {
+  Message,
+  useTheme,
+  classNames,
+  DEFAULT_LIGHT_THEME_NAME,
+  DEFAULT_DARK_THEME_NAME
+} from "pi-ui";
 import styles from "./LoaderScreen.module.css";
 import Logo from "src/components/Logo";
 import useLocalStorage from "src/hooks/utils/useLocalStorage";
@@ -27,8 +33,8 @@ const LoaderScreen = ({ error }) => {
   const [darkThemeOnLocalStorage] = useLocalStorage("darkTheme", false);
 
   useEffect(() => {
-    if (darkThemeOnLocalStorage && themeName === "light") {
-      setThemeName("dark");
+    if (darkThemeOnLocalStorage && themeName === DEFAULT_LIGHT_THEME_NAME) {
+      setThemeName(DEFAULT_DARK_THEME_NAME);
     }
   }, [darkThemeOnLocalStorage, setThemeName, themeName]);
 

--- a/src/containers/User/Detail/Credits/components/ProposalCreditsSection.jsx
+++ b/src/containers/User/Detail/Credits/components/ProposalCreditsSection.jsx
@@ -1,10 +1,10 @@
 import React from "react";
 import styles from "../Credits.module.css";
-import { Text, P, classNames, useTheme } from "pi-ui";
+import { Text, P, classNames, useTheme, DEFAULT_DARK_THEME_NAME } from "pi-ui";
 
 export default ({ proposalCredits, proposalCreditPrice }) => {
   const { themeName } = useTheme();
-  const isDarkTheme = themeName === "dark";
+  const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
   return (
     <div className={classNames(styles.block, "margin-top-l")}>
       <div className={styles.blockDetails}>

--- a/src/containers/User/Detail/Credits/components/RegistrationFeeSection.jsx
+++ b/src/containers/User/Detail/Credits/components/RegistrationFeeSection.jsx
@@ -1,6 +1,13 @@
 import React from "react";
 import styles from "../Credits.module.css";
-import { Text, P, Button, classNames, useTheme } from "pi-ui";
+import {
+  Text,
+  P,
+  Button,
+  classNames,
+  useTheme,
+  DEFAULT_DARK_THEME_NAME
+} from "pi-ui";
 
 export default ({
   isPaid,
@@ -11,7 +18,7 @@ export default ({
   openMarkAsPaidModal
 }) => {
   const { themeName } = useTheme();
-  const isDarkTheme = themeName === "dark";
+  const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
   return (
     <div className={styles.block}>
       <div className={styles.blockDetails}>

--- a/src/containers/User/Detail/InfoSection.jsx
+++ b/src/containers/User/Detail/InfoSection.jsx
@@ -1,4 +1,4 @@
-import { classNames, useTheme, P } from "pi-ui";
+import { classNames, useTheme, P, DEFAULT_DARK_THEME_NAME } from "pi-ui";
 import PropTypes from "prop-types";
 import React from "react";
 import styles from "./InfoSection.module.css";
@@ -13,7 +13,7 @@ const InfoSection = ({
   error
 }) => {
   const { themeName } = useTheme();
-  const isDarkTheme = themeName === "dark";
+  const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
   return (
     <div
       className={classNames(

--- a/yarn.lock
+++ b/yarn.lock
@@ -9129,9 +9129,9 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-"pi-ui@https://github.com/decred/pi-ui":
+"pi-ui@https://github.com/amassarwi/pi-ui#themesnames":
   version "1.0.0"
-  resolved "https://github.com/decred/pi-ui#96afd58d378d7fe541254198c47d0a51ec333d7a"
+  resolved "https://github.com/amassarwi/pi-ui#17b4ba32f1987d65dcb24127d2f10c1bc96583e1"
   dependencies:
     clamp-js-main "^0.11.5"
     lodash "^4.17.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9129,9 +9129,9 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-"pi-ui@https://github.com/amassarwi/pi-ui#themesnames":
+"pi-ui@https://github.com/decred/pi-ui":
   version "1.0.0"
-  resolved "https://github.com/amassarwi/pi-ui#17b4ba32f1987d65dcb24127d2f10c1bc96583e1"
+  resolved "https://github.com/decred/pi-ui#86083b26ae7925701a73179d70bf7e88d7d67e59"
   dependencies:
     clamp-js-main "^0.11.5"
     lodash "^4.17.15"


### PR DESCRIPTION
While working on decred/decrediton#2829 I noticed that decrediton is using different theme names as the default ones used in pi-ui & pigui, this is a bit problematic and may cause some styling bugs, as we check internally in pi-ui if default dark theme is used by checking the current theme name: `const isDarkTheme = themeName === "dark"`, and using different theme names as we do in decrediton would cause some pi-ui's components to show wrong styling.

So as solution https://github.com/decred/pi-ui/pull/304 exports two constants for default themes names: `DEFAULT_LIGHT_THEME_NAME` & `DEFAULT_DARK_THEME_NAME`, and uses them when it determines if default dark styling should be used internally in pi-ui's components. After this commit consumers of pi-ui lib would need to provide these default themes names if they are interested in default components' dark/light styling.

This diff adjusts `pigui` code base to work with the new exported default themes' names

### Dependencies

Needs https://github.com/decred/pi-ui/pull/304
