### PR TITLE
fix: tweaks on invoice datasheet and user detail

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -447,7 +447,7 @@ export const onFetchInvoice = (token, version = null) => (dispatch) => {
     });
 };
 
-export const onFetchUser = (userId) => (dispatch) => {
+export const onFetchUser = (userId) => (dispatch, getState) => {
   dispatch(act.REQUEST_USER(userId));
   const regexp = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
   const valid = regexp.test(userId);
@@ -456,7 +456,7 @@ export const onFetchUser = (userId) => (dispatch) => {
     dispatch(act.RECEIVE_USER(null, error));
     throw error;
   }
-
+  const isCMS = sel.isCMS(getState());
   return api
     .user(userId)
     .then((response) =>
@@ -464,7 +464,10 @@ export const onFetchUser = (userId) => (dispatch) => {
         act.RECEIVE_USER({
           user: {
             ...response.user,
-            userid: userId
+            userid: userId,
+            // cmsinfo is used to identify whether
+            // user details request is for cms or pi
+            cmsinfo: isCMS
           }
         })
       )

--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -465,9 +465,7 @@ export const onFetchUser = (userId) => (dispatch, getState) => {
           user: {
             ...response.user,
             userid: userId,
-            // cmsinfo is used to identify whether
-            // user details request is for cms or pi
-            cmsinfo: isCMS
+            isCMS // used to identify whether user details request is for cms or pi
           }
         })
       )

--- a/src/components/InvoiceDatasheet/helpers.js
+++ b/src/components/InvoiceDatasheet/helpers.js
@@ -102,6 +102,9 @@ export const convertLineItemsToGrid = (
       const subContractorValue = isSubContractorReadonly
         ? subUser && subUser.username
         : newLine.subuserid;
+      const typeValue = policyLineItemTypes.find(
+        (t) => t.type === newLine.type
+      );
       const laborHours = +fromMinutesToHours(newLine.labor);
       const expenses = +fromUSDCentsToUSDUnits(newLine.expenses);
       const subRate = +fromUSDCentsToUSDUnits(newLine.subrate);
@@ -116,6 +119,8 @@ export const convertLineItemsToGrid = (
           readOnly,
           value: newLine.type,
           error: rowErrors && rowErrors.type,
+          valueViewer: () =>
+            typeValue && capitalizeFirstLetter(typeValue.description),
           dataEditor: selectWrapper(
             policyLineItemTypes.map((op) => ({
               value: op.type,
@@ -245,7 +250,7 @@ export const convertGridToLineItems = (grid) => {
 
 export const createTableHeaders = () => [
   { readOnly: true, value: "", width: "2rem" },
-  { value: "Type", readOnly: true, width: "4rem" },
+  { value: "Type", readOnly: true, width: "10rem" },
   { value: "Domain", readOnly: true, width: "12rem" },
   { value: "Subdomain", readOnly: true, width: "14rem" },
   { value: "Description", readOnly: true, width: "30rem" },

--- a/src/containers/Invoice/Edit/Edit.jsx
+++ b/src/containers/Invoice/Edit/Edit.jsx
@@ -36,7 +36,10 @@ const EditInvoice = ({ match }) => {
       }
     : null;
 
-  const { proposals, error: proposalsError } = useApprovedProposals();
+  const {
+    nonRfpProposals: proposals,
+    error: proposalsError
+  } = useApprovedProposals();
   return (
     <Card className="container margin-bottom-l">
       {error ? (

--- a/src/containers/Invoice/Edit/Edit.jsx
+++ b/src/containers/Invoice/Edit/Edit.jsx
@@ -37,7 +37,7 @@ const EditInvoice = ({ match }) => {
     : null;
 
   const {
-    nonRfpProposals: proposals,
+    proposalsNotRFP: proposals,
     error: proposalsError
   } = useApprovedProposals();
   return (

--- a/src/containers/Invoice/New/New.jsx
+++ b/src/containers/Invoice/New/New.jsx
@@ -6,7 +6,7 @@ import useApprovedProposals from "src/hooks/api/useApprovedProposals";
 
 const NewInvoice = () => {
   const { onSubmitInvoice } = useNewInvoice();
-  const { proposals, error } = useApprovedProposals();
+  const { nonRfpProposals: proposals, error } = useApprovedProposals();
 
   return (
     <Card className="container margin-bottom-l">

--- a/src/containers/Invoice/New/New.jsx
+++ b/src/containers/Invoice/New/New.jsx
@@ -6,7 +6,7 @@ import useApprovedProposals from "src/hooks/api/useApprovedProposals";
 
 const NewInvoice = () => {
   const { onSubmitInvoice } = useNewInvoice();
-  const { nonRfpProposals: proposals, error } = useApprovedProposals();
+  const { proposalsNotRFP: proposals, error } = useApprovedProposals();
 
   return (
     <Card className="container margin-bottom-l">

--- a/src/containers/User/Detail/Detail.jsx
+++ b/src/containers/User/Detail/Detail.jsx
@@ -76,6 +76,7 @@ const UserDetail = ({
       if (tabLabel === tabValues.CREDITS && !isAdminOrTheUser) return true;
       if (tabLabel === tabValues.MANAGE_DCC && !isAdminOrTheUser) return true;
       if (tabLabel === tabValues.INVOICES && !isAdmin) return true;
+      if (tabLabel === tabValues.DRAFTS && !isUserPageOwner) return true;
       if (
         tabLabel === tabValues.PROPOSALS_OWNED &&
         (!isUserPageOwner || !ownsProposals)

--- a/src/containers/User/Detail/InfoSection.jsx
+++ b/src/containers/User/Detail/InfoSection.jsx
@@ -1,4 +1,10 @@
-import { classNames, useTheme, P, DEFAULT_DARK_THEME_NAME } from "pi-ui";
+import {
+  classNames,
+  useTheme,
+  P,
+  DEFAULT_DARK_THEME_NAME,
+  Spinner
+} from "pi-ui";
 import PropTypes from "prop-types";
 import React from "react";
 import styles from "./InfoSection.module.css";
@@ -10,7 +16,8 @@ const InfoSection = ({
   alignLabelCenter,
   className,
   noMargin,
-  error
+  error,
+  isLoading
 }) => {
   const { themeName } = useTheme();
   const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
@@ -27,12 +34,14 @@ const InfoSection = ({
         style={alignLabelCenter && { alignSelf: "center" }}>
         {label}:
       </span>
-      {error ? (
+      {isLoading ? (
+        <Spinner invert />
+      ) : error ? (
         <P className={styles.infoError}>{error.toString()}</P>
       ) : !isEmpty(info) ? (
         <span className={styles.info}>{info}</span>
       ) : (
-        !error && <span className={styles.noInfo}>No information provided</span>
+        <span className={styles.noInfo}>No information provided</span>
       )}
     </div>
   );

--- a/src/containers/User/Detail/ManageContractor/ManageContractor.jsx
+++ b/src/containers/User/Detail/ManageContractor/ManageContractor.jsx
@@ -36,7 +36,7 @@ const ManageContractor = ({ userID, isUserPageOwner }) => {
           <ManageDccForm user={user} onUpdate={onUpdateDccInfo} />
         </div>
       )}
-      {!loading && user.cmsinfo && (
+      {!loading && user.isCMS && (
         <UserView
           user={user}
           showGitHubName={isDeveloper || !isEmpty(user.githubname)}

--- a/src/containers/User/Detail/ManageContractor/ManageContractor.jsx
+++ b/src/containers/User/Detail/ManageContractor/ManageContractor.jsx
@@ -29,7 +29,6 @@ const ManageContractor = ({ userID, isUserPageOwner }) => {
   const canEditDccInfo = isAdmin && !showDccForm;
   const canEditContractorInfo = isUserPageOwner && !showContractorInfoForm;
 
-  console.log("user", user, !loading);
   return (
     <Card className={classNames("container", "margin-bottom-m")}>
       {canEditDccInfo && (
@@ -37,7 +36,7 @@ const ManageContractor = ({ userID, isUserPageOwner }) => {
           <ManageDccForm user={user} onUpdate={onUpdateDccInfo} />
         </div>
       )}
-      {!loading && (
+      {!loading && user.cmsinfo && (
         <UserView
           user={user}
           showGitHubName={isDeveloper || !isEmpty(user.githubname)}

--- a/src/containers/User/Detail/ManageContractor/ManageContractor.jsx
+++ b/src/containers/User/Detail/ManageContractor/ManageContractor.jsx
@@ -7,7 +7,6 @@ import useContractor from "../hooks/useContractor";
 import isEmpty from "lodash/isEmpty";
 
 const ManageContractor = ({ userID, isUserPageOwner }) => {
-  const [showDccForm, setShowDccForm] = useState(true);
   const [showContractorInfoForm, setShowContractorInfoForm] = useState(true);
 
   const {
@@ -16,10 +15,13 @@ const ManageContractor = ({ userID, isUserPageOwner }) => {
     onUpdateDccInfo,
     isDeveloper,
     onUpdateContractorInfo,
-    requireGitHubName
+    requireGitHubName,
+    loading
   } = useContractor(userID);
 
-  const onToggleDccEdit = () => setShowDccForm(!showDccForm);
+  const [showDccForm, setShowDccForm] = useState(isAdmin);
+
+  const onToggleDccEdit = () => setShowDccForm(isAdmin && !showDccForm);
   const onToggleContractorInfoEdit = () =>
     setShowContractorInfoForm(!showContractorInfoForm);
 
@@ -27,6 +29,7 @@ const ManageContractor = ({ userID, isUserPageOwner }) => {
   const canEditDccInfo = isAdmin && !showDccForm;
   const canEditContractorInfo = isUserPageOwner && !showContractorInfoForm;
 
+  console.log("user", user, !loading);
   return (
     <Card className={classNames("container", "margin-bottom-m")}>
       {canEditDccInfo && (
@@ -34,18 +37,20 @@ const ManageContractor = ({ userID, isUserPageOwner }) => {
           <ManageDccForm user={user} onUpdate={onUpdateDccInfo} />
         </div>
       )}
-      <UserView
-        user={user}
-        showGitHubName={isDeveloper || !isEmpty(user.githubname)}
-        requireGitHubName={requireGitHubName && isUserPageOwner}
-        hideDccInfo={canEditDccInfo}
-        hideContractorInfo={canEditContractorInfo}
-        enableEditMode={enableEditMode}
-        showDccForm={showDccForm}
-        showContractorInfoForm={showContractorInfoForm}
-        onToggleDccEdit={onToggleDccEdit}
-        onToggleContractorInfoEdit={onToggleContractorInfoEdit}
-      />
+      {!loading && (
+        <UserView
+          user={user}
+          showGitHubName={isDeveloper || !isEmpty(user.githubname)}
+          requireGitHubName={requireGitHubName && isUserPageOwner}
+          hideDccInfo={canEditDccInfo}
+          hideContractorInfo={canEditContractorInfo}
+          showDccForm={isAdmin}
+          showContractorInfoForm={showContractorInfoForm}
+          onToggleDccEdit={onToggleDccEdit}
+          onToggleContractorInfoEdit={onToggleContractorInfoEdit}
+          enableEditMode={enableEditMode}
+        />
+      )}
       {canEditContractorInfo && (
         <EditContractorForm
           onEdit={onUpdateContractorInfo}

--- a/src/containers/User/Detail/ManageContractor/ManageDccForm.jsx
+++ b/src/containers/User/Detail/ManageContractor/ManageDccForm.jsx
@@ -146,6 +146,7 @@ const ManageDccForm = ({ onUpdate, user }) => {
                 />
                 <InfoSection
                   label="Supervisors"
+                  isLoading={loadingSupervisors}
                   info={
                     <Select
                       placeholder="Select Supervisor"
@@ -161,6 +162,7 @@ const ManageDccForm = ({ onUpdate, user }) => {
                 <InfoSection
                   label="Owned Proposals"
                   error={approvedProposalsError}
+                  isLoading={loadingOwnedProposals}
                   info={
                     <Select
                       placeholder="Select Proposals"

--- a/src/containers/User/Detail/ManageContractor/UserView.jsx
+++ b/src/containers/User/Detail/ManageContractor/UserView.jsx
@@ -89,11 +89,14 @@ const ManageContractorUserView = ({
   onToggleContractorInfoEdit
 }) => {
   const { domain, contractortype, supervisoruserids = [] } = user;
-  const { proposalsByToken, isLoading, error } = useApprovedProposals();
+  const { proposalsByToken, isLoading, error } = useApprovedProposals(
+    user.proposalsowned
+  );
   const ownedProposals = getOwnedProposals(
     user.proposalsowned,
     proposalsByToken
   );
+
   const { supervisors, error: supervisorsError } = useSupervisors();
   const {
     policy: { supporteddomains }

--- a/src/containers/User/Detail/ManageContractor/UserView.jsx
+++ b/src/containers/User/Detail/ManageContractor/UserView.jsx
@@ -11,17 +11,23 @@ const UserDccInfo = ({
   domain,
   userSupervisors,
   proposalsOwned,
-  proposalsError,
-  isLoadingProposals,
   showEdit,
   onToggleDccEdit,
   supervisorsError
 }) => {
+  const {
+    proposalsByToken,
+    isLoading,
+    error: proposalsError
+  } = useApprovedProposals(proposalsOwned);
+
+  const ownedProposals = getOwnedProposals(proposalsOwned, proposalsByToken);
+
   const supervisors = userSupervisors.length
     ? userSupervisors.join(", ")
     : "No supervisors";
-  const proposals = proposalsOwned.length
-    ? proposalsOwned.join(", ")
+  const proposals = ownedProposals.length
+    ? ownedProposals.join(", ")
     : "No owned proposals";
   return (
     <>
@@ -37,15 +43,16 @@ const UserDccInfo = ({
         <InfoSection
           label="Owned Proposals"
           error={proposalsError}
-          info={isLoadingProposals ? <Spinner invert /> : proposals}
+          isLoading={isLoading}
+          info={proposals}
         />
       </div>
       {showEdit && (
         <Button
           className="margin-bottom-m"
           onClick={onToggleDccEdit}
-          kind={isLoadingProposals ? "disabled" : "primary"}>
-          {isLoadingProposals ? <Spinner invert /> : "Edit"}
+          kind={isLoading ? "disabled" : "primary"}>
+          {isLoading ? <Spinner invert /> : "Edit"}
         </Button>
       )}
     </>
@@ -89,13 +96,6 @@ const ManageContractorUserView = ({
   onToggleContractorInfoEdit
 }) => {
   const { domain, contractortype, supervisoruserids = [] } = user;
-  const { proposalsByToken, isLoading, error } = useApprovedProposals(
-    user.proposalsowned
-  );
-  const ownedProposals = getOwnedProposals(
-    user.proposalsowned,
-    proposalsByToken
-  );
 
   const { supervisors, error: supervisorsError } = useSupervisors();
   const {
@@ -114,9 +114,7 @@ const ManageContractorUserView = ({
         <UserDccInfo
           contractorType={typeOptions[contractortype]}
           domain={getDomainName(contractorDomains, domain)}
-          proposalsOwned={ownedProposals}
-          proposalsError={error}
-          isLoadingProposals={isLoading}
+          proposalsOwned={user.proposalsowned}
           userSupervisors={getSupervisorsNames(supervisors, supervisoruserids)}
           supervisorsError={supervisorsError}
           showEdit={showDccForm}

--- a/src/hooks/api/useApprovedProposals.js
+++ b/src/hooks/api/useApprovedProposals.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { isEmpty } from "src/helpers";
 import useProposalsBatch from "./useProposalsBatch";
 import { difference, keys } from "lodash";
@@ -24,9 +24,15 @@ export default function useApprovedProposals(initialTokens) {
 
   const isLoading = isEmpty(proposals) || !proposalsTokens.approved;
 
+  const nonRfpProposals = useMemo(
+    () => proposals && Object.values(proposals).filter((p) => !p.linkby),
+    [proposals]
+  );
+
   return {
     proposals: Object.values(proposals),
     proposalsByToken: proposals,
+    nonRfpProposals,
     isLoading,
     remainingTokens
   };

--- a/src/hooks/api/useApprovedProposals.js
+++ b/src/hooks/api/useApprovedProposals.js
@@ -1,5 +1,4 @@
 import { useEffect, useState, useMemo } from "react";
-import { isEmpty } from "src/helpers";
 import useProposalsBatch from "./useProposalsBatch";
 import { difference, keys } from "lodash";
 
@@ -7,22 +6,27 @@ const PAGE_SIZE = 20;
 
 export default function useApprovedProposals(initialTokens) {
   const [remainingTokens, setRemainingTokens] = useState(initialTokens);
-  const { proposals, proposalsTokens } = useProposalsBatch(remainingTokens, {
-    fetchRfpLinks: false,
-    fetchVoteSummaries: false
-  });
+  const { proposals, proposalsTokens, loading, verifying } = useProposalsBatch(
+    remainingTokens,
+    {
+      fetchRfpLinks: false,
+      fetchVoteSummaries: false
+    }
+  );
+
+  const isLoading = loading || verifying;
 
   useEffect(() => {
-    const tokens =
-      proposalsTokens.approved &&
-      difference(proposalsTokens.approved, keys(proposals)).splice(
-        0,
-        PAGE_SIZE
-      );
-    setRemainingTokens(tokens);
-  }, [proposalsTokens, proposals]);
-
-  const isLoading = isEmpty(proposals) || !proposalsTokens.approved;
+    if (!isLoading) {
+      const tokens =
+        proposalsTokens.approved &&
+        difference(proposalsTokens.approved, keys(proposals)).splice(
+          0,
+          PAGE_SIZE
+        );
+      setRemainingTokens(tokens);
+    }
+  }, [proposals, proposalsTokens.approved, isLoading]);
 
   const nonRfpProposals = useMemo(
     () => proposals && Object.values(proposals).filter((p) => !p.linkby),

--- a/src/hooks/api/useApprovedProposals.js
+++ b/src/hooks/api/useApprovedProposals.js
@@ -28,7 +28,7 @@ export default function useApprovedProposals(initialTokens) {
     }
   }, [proposals, proposalsTokens.approved, isLoading]);
 
-  const nonRfpProposals = useMemo(
+  const proposalsNotRFP = useMemo(
     () => proposals && Object.values(proposals).filter((p) => !p.linkby),
     [proposals]
   );
@@ -36,7 +36,7 @@ export default function useApprovedProposals(initialTokens) {
   return {
     proposals: Object.values(proposals),
     proposalsByToken: proposals,
-    nonRfpProposals,
+    proposalsNotRFP,
     isLoading,
     remainingTokens
   };

--- a/src/pages/Routes.jsx
+++ b/src/pages/Routes.jsx
@@ -14,6 +14,7 @@ import PageProposalsUnvetted from "./Proposals/UnvettedList";
 import PageProposalNew from "./Proposals/New";
 import PageProposalEdit from "./Proposals/Edit";
 import useOnboardModal from "src/hooks/utils/useOnboardModal";
+import PageUserDetail from "./User/Detail";
 
 const Routes = ({ location }) => {
   useOnboardModal();
@@ -28,6 +29,14 @@ const Routes = ({ location }) => {
             component={PageProposalsPublicList}
           />
           {commonRoutes}
+          {/* User Route */}
+          <Route
+            path="/user/:userid"
+            title="User Detail"
+            exact
+            key="user-detail-route"
+            component={PageUserDetail}
+          />
           {/* Record routes */}
           <AdminAuthenticatedRoute
             path={"/proposals/unvetted"}

--- a/src/pages/RoutesCMS.jsx
+++ b/src/pages/RoutesCMS.jsx
@@ -23,6 +23,7 @@ import PageProposalBillingDetails from "./Invoices/ProposalBillingDetails";
 import PageDccDetail from "./DCCs/Detail";
 import PageDccList from "./DCCs/List";
 import PageDccNew from "./DCCs/New";
+import PageUserDetail from "./User/Detail";
 
 const Redirect = withRouter(({ to, history, location }) => {
   useEffect(() => {
@@ -56,6 +57,15 @@ const Routes = ({ location }) => {
             <Redirect to="/user/signup" />
           </Route>
           {commonRoutes}
+
+          {/* User Route */}
+          <AuthenticatedRoute
+            path="/user/:userid"
+            title="User Detail"
+            exact
+            key="user-detail-route"
+            component={PageUserDetail}
+          />
 
           {/* Record routes */}
           <AuthenticatedRoute

--- a/src/pages/commonRoutes.js
+++ b/src/pages/commonRoutes.js
@@ -1,12 +1,10 @@
 import React from "react";
 import {
-  Route,
   AdminAuthenticatedRoute,
   AuthenticatedRoute,
   NotAuthenticatedRoute
 } from "src/containers/Routes";
 
-import PageUserDetail from "./User/Detail";
 import PageUserLogin from "./User/Login";
 import PageUserPrivacyPolicy from "./User/PrivacyPolicy";
 import PageUserRequestResendVerificationEmail from "./User/RequestResendVerificationEmail";
@@ -77,14 +75,9 @@ const commonRoutes = [
     exact
     key="search-user-route"
     component={PageUserSearch}
-  />,
-  <Route
-    path="/user/:userid"
-    title="User Detail"
-    exact
-    key="user-detail-route"
-    component={PageUserDetail}
   />
+  // user detail page was removed because cms requires
+  // authentication to fetch users info
 ];
 
 export default commonRoutes;


### PR DESCRIPTION
This diff is a batch of minor fixes:

- redirects not logged in users to home page on CMS when accessing user details page (#2154).
- remove RFP proposals from invoice form (#2155)
- show type as text on invoice lineitems (#2159)
- show draft tab only for owners (#2174)

Closes #2154 
Closes #2155 
Closes #2159 
Closes #2173
Closes #2174 
Closes #2199 