### PR TITLE
Add active coloring for nav menu items

### DIFF
--- a/src/apps/cms/config.json
+++ b/src/apps/cms/config.json
@@ -17,6 +17,7 @@
     { "label": "My invoices", "path": "/invoices/me", "admin": false },
     { "label": "All Invoices", "path": "/invoices", "admin": false },
     { "label": "DCCs", "path": "/dccs", "admin": false },
-    { "label": "Search for users", "path": "/user/search", "admin": true }
+    { "label": "Search for users", "path": "/user/search", "admin": true },
+    { "label": "Account", "path": "/user", "admin": false }
   ]
 }

--- a/src/apps/politeia/config.json
+++ b/src/apps/politeia/config.json
@@ -15,6 +15,7 @@
   "navMenuPaths": [
     { "label": "Proposals", "path": "/", "admin": false },
     { "label": "Admin", "path": "/proposals/unvetted", "admin": true },
-    { "label": "Search for users", "path": "/user/search", "admin": true }
+    { "label": "Search for users", "path": "/user/search", "admin": true },
+    { "label": "Account", "path": "/user", "admin": false }
   ]
 }

--- a/src/components/HeaderNav/HeaderNav.jsx
+++ b/src/components/HeaderNav/HeaderNav.jsx
@@ -8,7 +8,7 @@ import {
   DEFAULT_DARK_THEME_NAME,
   DEFAULT_LIGHT_THEME_NAME
 } from "pi-ui";
-import React, { useEffect, useMemo, useCallback } from "react";
+import React, { useEffect, useMemo } from "react";
 import { NavLink, withRouter } from "react-router-dom";
 import useLocalStorage from "src/hooks/utils/useLocalStorage";
 import useNavigation from "src/hooks/api/useNavigation";
@@ -35,26 +35,29 @@ const HeaderNav = ({ history }) => {
   const menuItems = useMemo(
     () =>
       navMenuPaths.map(({ label, path, admin }, idx) => {
+        if (path === "/user") {
+          path += "/" + userid;
+        }
+        const isActive = window.location.pathname === path;
         const onMenuItemClick = (path) => () => history.push(path);
         return (
           ((admin && userIsAdmin) || !admin) && (
-            <DropdownItem key={`link-${idx}`} onClick={onMenuItemClick(path)}>
+            <DropdownItem
+              className={isActive ? styles.activeDropdownItem : null}
+              key={`link-${idx}`}
+              onClick={onMenuItemClick(path)}>
               {label}
             </DropdownItem>
           )
         );
       }),
-    [history, navMenuPaths, userIsAdmin]
+    [history, navMenuPaths, userIsAdmin, userid]
   );
 
   const [darkThemeOnLocalStorage, setDarkThemeOnLocalStorage] = useLocalStorage(
     "darkTheme",
     false
   );
-
-  const goToUserAccount = useCallback(() => {
-    history.push(`/user/${userid}`);
-  }, [history, userid]);
 
   useEffect(() => {
     if (darkThemeOnLocalStorage && themeName === DEFAULT_LIGHT_THEME_NAME) {
@@ -67,8 +70,8 @@ const HeaderNav = ({ history }) => {
       setDarkThemeOnLocalStorage(true);
       setThemeName(DEFAULT_DARK_THEME_NAME);
     } else {
-      setThemeName(DEFAULT_LIGHT_THEME_NAME);
       setDarkThemeOnLocalStorage(false);
+      setThemeName(DEFAULT_LIGHT_THEME_NAME);
     }
   };
 
@@ -90,7 +93,6 @@ const HeaderNav = ({ history }) => {
         closeOnItemClick={false}
         title={username}>
         {menuItems}
-        <DropdownItem onClick={goToUserAccount}>Account</DropdownItem>
         <DropdownItem onClick={onThemeToggleHandler}>
           <div className={styles.themeToggleWrapper}>
             <Toggle

--- a/src/components/HeaderNav/HeaderNav.module.css
+++ b/src/components/HeaderNav/HeaderNav.module.css
@@ -32,6 +32,10 @@
   border-right: 0.1rem solid var(--separator-color);
 }
 
+.activeDropdownItem {
+  color: var(--dropdown-item-active-color) !important;
+}
+
 .activeNavLink {
   border-bottom: 0.4rem solid var(--active-nav-border-color);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9263,7 +9263,7 @@ performance-now@^2.1.0:
 
 "pi-ui@https://github.com/decred/pi-ui":
   version "1.0.0"
-  resolved "https://github.com/decred/pi-ui#b80f61c5106b6018a51ba8e0fcbee7f9f8cf033a"
+  resolved "https://github.com/decred/pi-ui#8f5124149a6820726905956e894cd94e82719987"
   dependencies:
     clamp-js-main "^0.11.5"
     lodash "^4.17.15"


### PR DESCRIPTION
This PR implements an active coloring for dropdown menu items. It also passes the account path to the config for consistency; menu items that link to a url path are set on the config, so we can manage them as a group more easily.

edit: needs https://github.com/decred/pi-ui/pull/309

Closes #2192 