### PR TITLE
cms: Add sorting and ExportToCsv to proposal spending tables

### DIFF
--- a/src/containers/Invoice/ProposalBillingDetails/ProposalBillingDetails.jsx
+++ b/src/containers/Invoice/ProposalBillingDetails/ProposalBillingDetails.jsx
@@ -132,10 +132,11 @@ const ProposalBillingDetails = ({ TopBanner, PageDetails, Main, match }) => {
 
   const anyError = subContractorsError || error;
 
-  const proposalDetailsData = isDetailsLoaded && getDetailsData(
-    proposalBillingDetails.invoices,
-    subContractors
-  ).sort((a, b) => b.year - a.year || b.month - a.month);
+  const proposalDetailsData =
+    isDetailsLoaded &&
+    getDetailsData(proposalBillingDetails.invoices, subContractors).sort(
+      (a, b) => b.year - a.year || b.month - a.month
+    );
 
   return (
     <>

--- a/src/containers/Invoice/ProposalBillingDetails/ProposalBillingDetails.jsx
+++ b/src/containers/Invoice/ProposalBillingDetails/ProposalBillingDetails.jsx
@@ -182,8 +182,7 @@ const ProposalBillingDetails = ({ TopBanner, PageDetails, Main, match }) => {
                   totaldcr,
                   totalusd,
                   invoice
-                }) => {
-                  return {
+                }) => ({
                     month: `${month}/${year}`,
                     username: user.props.children,
                     contractorrate,
@@ -193,8 +192,7 @@ const ProposalBillingDetails = ({ TopBanner, PageDetails, Main, match }) => {
                     totaldcr,
                     totalusd,
                     invoice: invoice.props.children
-                  };
-                }
+                })
               )}
               fields={[
                 "month",

--- a/src/containers/Invoice/ProposalBillingDetails/ProposalBillingDetails.jsx
+++ b/src/containers/Invoice/ProposalBillingDetails/ProposalBillingDetails.jsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from "react";
 import { withRouter } from "react-router-dom";
-import { Spinner, Card, Table, H3, Message } from "pi-ui";
+import { Spinner, Card, Table, H3, Message, Link as PiLink } from "pi-ui";
 import { useProposalBillingDetails } from "./hooks";
 import { GoBackLink } from "src/components/Router";
 import get from "lodash/fp/get";
 import Link from "src/components/Link";
+import ExportToCsv from "src/components/ExportToCsv";
 import { usdFormatter, formatCentsToUSD } from "src/utils";
 import { fromMinutesToHours } from "src/helpers";
 import {
@@ -48,14 +49,16 @@ const getDetailsData = (invoices, subContractors) =>
         input.lineitems
       );
       let detailsData = {
-        User: <Link to={`/user/${userid}`}>{username}</Link>,
-        "Contractor Rate": usdFormatter.format(input.contractorrate / 100),
-        "Exchange Rate": usdFormatter.format(input.exchangerate / 100),
-        "Labor (hours)": fromMinutesToHours(totalLabor),
-        "Expense (USD)": usdFormatter.format(totalExpenses),
-        "Total (DCR)": totalDcr.toFixed(8),
-        "Total (USD)": usdFormatter.format(totalUsd / 100),
-        Invoice: <Link to={`/invoices/${token}`}>{token}</Link>
+        month: input.month,
+        year: input.year,
+        user: <Link to={`/user/${userid}`}>{username}</Link>,
+        contractorrate: usdFormatter.format(input.contractorrate / 100),
+        exchangerate: usdFormatter.format(input.exchangerate / 100),
+        labor: fromMinutesToHours(totalLabor),
+        expensetotal: usdFormatter.format(totalExpenses),
+        totaldcr: totalDcr.toFixed(8),
+        totalusd: usdFormatter.format(totalUsd / 100),
+        invoice: <Link to={`/invoices/${token}`}>{token}</Link>
       };
       if (subContractorTotalLabor && !totalExpenses) {
         const subContractorTotal = getSubContractorTotal(input.lineitems);
@@ -67,28 +70,28 @@ const getDetailsData = (invoices, subContractors) =>
         );
         detailsData = {
           ...detailsData,
-          "Total (USD)": (
+          totalusd: (
             <SubContractorReference
               value={usdFormatter.format(subContractorTotal / 100)}
               username={username}
               userid={id}
             />
           ),
-          "Total (DCR)": (
+          totaldcr: (
             <SubContractorReference
               value={subContractorTotalDcr.toFixed(8)}
               username={username}
               userid={id}
             />
           ),
-          "Labor (hours)": (
+          labor: (
             <SubContractorReference
               value={fromMinutesToHours(subContractorTotalLabor)}
               username={username}
               userid={id}
             />
           ),
-          "Contractor Rate": (
+          contractorrate: (
             <SubContractorReference
               value={usdFormatter.format(subContractorRate / 100)}
               username={username}
@@ -128,6 +131,12 @@ const ProposalBillingDetails = ({ TopBanner, PageDetails, Main, match }) => {
     proposalBillingDetails && !loading && !loadingSubContractors;
 
   const anyError = subContractorsError || error;
+
+  const proposalDetailsData = isDetailsLoaded && getDetailsData(
+    proposalBillingDetails.invoices,
+    subContractors
+  ).sort((a, b) => b.year - a.year || b.month - a.month);
+
   return (
     <>
       <TopBanner>
@@ -155,12 +164,51 @@ const ProposalBillingDetails = ({ TopBanner, PageDetails, Main, match }) => {
           <Card paddingSize="small" className={styles.tableWrapper}>
             <Table
               className={styles.table}
-              data={getDetailsData(
-                proposalBillingDetails.invoices,
-                subContractors
-              )}
+              data={proposalDetailsData}
               headers={TABLE_HEADERS}
+              linesPerPage={50}
             />
+            <ExportToCsv
+              data={proposalDetailsData.map(
+                ({
+                  month,
+                  year,
+                  user,
+                  contractorrate,
+                  exchangerate,
+                  labor,
+                  expensetotal,
+                  totaldcr,
+                  totalusd,
+                  invoice
+                }) => {
+                  return {
+                    month: `${month}/${year}`,
+                    username: user.props.children,
+                    contractorrate,
+                    exchangerate,
+                    labor,
+                    expensetotal,
+                    totaldcr,
+                    totalusd,
+                    invoice: invoice.props.children
+                  };
+                }
+              )}
+              fields={[
+                "month",
+                "username",
+                "contractorrate",
+                "exchangerate",
+                "labor",
+                "expensetotal",
+                "totaldcr",
+                "totalusd",
+                "invoice"
+              ]}
+              filename="proposal_details.csv">
+              <PiLink className="cursor-pointer">Export To Csv</PiLink>
+            </ExportToCsv>
             <H3 className={styles.totalText}>
               Total: {formatCentsToUSD(proposalBillingDetails.totalbilled)}
             </H3>

--- a/src/containers/Invoice/ProposalBillingDetails/helpers.js
+++ b/src/containers/Invoice/ProposalBillingDetails/helpers.js
@@ -8,6 +8,8 @@ import get from "lodash/fp/get";
 export { getInvoiceTotalExpenses } from "../helpers";
 
 export const TABLE_HEADERS = [
+  "Month",
+  "Year",
   "User",
   "Contractor Rate",
   "Exchange Rate",

--- a/src/containers/User/Detail/ProposalsOwned/ProposalBilling.jsx
+++ b/src/containers/User/Detail/ProposalsOwned/ProposalBilling.jsx
@@ -60,18 +60,17 @@ const BillingInfo = ({ lineItems }) => {
           Labor,
           Expenses,
           Total
-        })  => {
-          return {
-            Username: Username.props.children,
-            Date,
-            Domain,
-            Subdomain,
-            Description,
-            Labor,
-            Expenses,
-            Total
-          };
-        })}
+        })  => ({
+          Username: Username.props.children,
+          Date,
+          Domain,
+          Subdomain,
+          Description,
+          Labor,
+          Expenses,
+          Total
+          })
+        )}
         fields={[
           "Username",
           "Date",

--- a/src/containers/User/Detail/ProposalsOwned/ProposalBilling.jsx
+++ b/src/containers/User/Detail/ProposalsOwned/ProposalBilling.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
-import { Card, Table, Text, Spinner, H3 } from "pi-ui";
+import { Card, Table, Text, Spinner, H3, Link as PiLink } from "pi-ui";
 import Link from "src/components/Link";
+import ExportToCsv from "src/components/ExportToCsv";
 import { useProposalsOwnedBilling } from "./hooks";
 import styles from "./ProposalsOwned.module.css";
 import { usdFormatter } from "src/utils";
@@ -20,7 +21,8 @@ const BillingInfo = ({ lineItems }) => {
   let total = 0;
   if (lineItems.length === 0)
     return <H3 className="margin-top-m">No billings for this proposal yet</H3>;
-  const data = lineItems.map(
+  const sortedLineItems = lineItems.sort((a, b) => b.year - a.year || b.month - a.month);
+  const data = sortedLineItems.map(
     ({
       userid,
       month,
@@ -46,7 +48,43 @@ const BillingInfo = ({ lineItems }) => {
   );
   return (
     <div className="margin-top-m">
-      <Table headers={headers} data={data} />
+      <Table headers={headers} data={data} linesPerPage={50}/>
+      <ExportToCsv
+        data={data.map(
+          ({
+          Username,
+          Date,
+          Domain,
+          Subdomain,
+          Description,
+          Labor,
+          Expenses,
+          Total
+        })  => {
+          return {
+            Username: Username.props.children,
+            Date,
+            Domain,
+            Subdomain,
+            Description,
+            Labor,
+            Expenses,
+            Total
+          };
+        })}
+        fields={[
+          "Username",
+          "Date",
+          "Domain",
+          "Subdomain",
+          "Description",
+          "Labor",
+          "Expenses",
+          "Total"
+        ]}
+        filename="proposal_details.csv">
+        <PiLink className="cursor-pointer">Export To Csv</PiLink>
+      </ExportToCsv>
       <H3 className={styles.totalText}>Total: {usdFormatter.format(total)}</H3>
     </div>
   );


### PR DESCRIPTION
Closes #2179 
This adds sorting by month/year and exporting to the admin proposal spending summary table and the user account proposals owned spending details table.