### PR TITLE
[cms] fix: make user selector searchable on admin invoices

### DIFF
--- a/src/components/InvoiceFilters/InvoiceFilterForm.jsx
+++ b/src/components/InvoiceFilters/InvoiceFilterForm.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { Formik } from "formik";
+import { Formik, Form } from "formik";
 import CheckboxGroupField from "src/components/CheckboxGroupField";
 import MonthPickerField from "src/components/MonthPickerField";
 import {
@@ -27,7 +27,8 @@ const InvoiceFilterForm = ({
   onChange,
   children,
   disableUserFilter,
-  isAdminPage
+  isAdminPage,
+  onSubmit = () => {}
 }) => {
   const filtersKey = isAdminPage ? "invoiceFiltersAdmin" : "invoiceFilters";
   return (
@@ -35,7 +36,8 @@ const InvoiceFilterForm = ({
       initialValues={
         JSON.parse(localStorage.getItem(filtersKey)) ||
         DefaultInitialValues(isAdminPage)
-      }>
+      }
+      onSubmit={onSubmit}>
       {(formikProps) => {
         const { values, setFieldValue } = formikProps;
         const handleChangeUserSelector = (options) => {
@@ -58,7 +60,7 @@ const InvoiceFilterForm = ({
         adminFilterOptions.push(adminFilterOptions.shift());
         return (
           <>
-            <form className={styles.form}>
+            <Form className={styles.form}>
               <div className={styles.topFilters}>
                 <MonthPickerField
                   years={getInvoiceMinMaxYearAndMonth()}
@@ -99,7 +101,7 @@ const InvoiceFilterForm = ({
                 formikProps={formikProps}
                 isAdminPage={isAdminPage}
               />
-            </form>
+            </Form>
             {children && children(values)}
           </>
         );

--- a/src/containers/User/Search/SearchSelector.jsx
+++ b/src/containers/User/Search/SearchSelector.jsx
@@ -22,6 +22,11 @@ const SearchSelector = ({ onChange, value, className, styles: extStyles }) => {
       options={options}
       styles={extStyles}
       isSearchable
+      noOptionsMessage={() =>
+        inputValue === ""
+          ? "Insert a username or email"
+          : "No options available"
+      }
       escapeClearsValue
     />
   );

--- a/src/containers/User/Search/SearchSelector.jsx
+++ b/src/containers/User/Search/SearchSelector.jsx
@@ -13,7 +13,7 @@ const SearchSelector = ({ onChange, value, className, styles: extStyles }) => {
   }));
   return (
     <Select
-      placeholder="Search User"
+      placeholder="Search by User"
       className={classNames(styles.select, className)}
       value={value}
       onInputChange={(newV) => setInputValue(newV)}
@@ -21,6 +21,8 @@ const SearchSelector = ({ onChange, value, className, styles: extStyles }) => {
       isMulti
       options={options}
       styles={extStyles}
+      isSearchable
+      escapeClearsValue
     />
   );
 };

--- a/src/pages/Invoices/AdminList.jsx
+++ b/src/pages/Invoices/AdminList.jsx
@@ -1,17 +1,11 @@
 import React from "react";
-import { useMediaQuery } from "pi-ui";
 import MultipleContentPage from "src/components/layout/MultipleContentPage";
 import ListAdminInvoices from "src/containers/Invoice/List/List";
 
-const PageListAdminInvoices = () => {
-  const mobile = useMediaQuery("(max-width: 760px)");
-  return (
-    <MultipleContentPage
-      disableScrollToTop
-      topBannerHeight={mobile ? 160 : 140}>
-      {(props) => <ListAdminInvoices {...props} />}
-    </MultipleContentPage>
-  );
-};
+const PageListAdminInvoices = () => (
+  <MultipleContentPage disableScrollToTop topBannerHeight={160}>
+    {(props) => <ListAdminInvoices {...props} />}
+  </MultipleContentPage>
+);
 
 export default PageListAdminInvoices;


### PR DESCRIPTION
This diff closes #2210, an issue that reported an unexpected behavior on User Search on admin invoices page where users were not being loaded.

### Solution description

The only thing was to pass the `isSearchable` prop to the `SearchSelector` component, and do some minor tweaks in order to make the selector good to go.

### UI Changes
<img width="1487" alt="Screen Shot 2020-11-24 at 2 31 56 PM" src="https://user-images.githubusercontent.com/22639213/100130739-dda1b580-2e61-11eb-926d-eb28f8d67234.png">
