### PR TITLE
[cms/header] style: disable 'All Invoices' option for non-contractors

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -40,12 +40,15 @@ export const requestApiInfo = (fetchUser = true) => (dispatch) => {
     });
 };
 
-export const onRequestMe = () => (dispatch) => {
+export const onRequestMe = () => (dispatch, getState) => {
   dispatch(act.REQUEST_ME());
+  const isCMS = sel.isCMS(getState());
   return api
     .me()
     .then((response) => {
       dispatch(act.RECEIVE_ME(response));
+      // fetch CMS user details if needed
+      isCMS && response.userid && dispatch(onFetchUser(response.userid));
     })
     .catch((error) => {
       dispatch(act.RECEIVE_ME(null, error));
@@ -230,7 +233,9 @@ export const onLogin = ({ email, password }) =>
           return response;
         });
       })
-      .then(() => dispatch(onRequestMe()))
+      .then(() => {
+        dispatch(onRequestMe());
+      })
       .catch((error) => {
         dispatch(act.RECEIVE_LOGIN(null, error));
         throw error;

--- a/src/apps/cms/config.json
+++ b/src/apps/cms/config.json
@@ -14,10 +14,30 @@
   "testnetGitRepository": "",
   "mainnetGitRepository": "",
   "navMenuPaths": [
-    { "label": "My invoices", "path": "/invoices/me", "admin": false },
-    { "label": "All Invoices", "path": "/invoices", "admin": false },
-    { "label": "DCCs", "path": "/dccs", "admin": false },
-    { "label": "Search for users", "path": "/user/search", "admin": true },
-    { "label": "Account", "path": "/user", "admin": false }
+    {
+      "label": "My invoices",
+      "path": "/invoices/me",
+      "admin": false,
+      "dccRequired": false
+    },
+    {
+      "label": "All Invoices",
+      "path": "/invoices",
+      "admin": false,
+      "dccRequired": true
+    },
+    { "label": "DCCs", "path": "/dccs", "admin": false, "dccRequired": false },
+    {
+      "label": "Search for users",
+      "path": "/user/search",
+      "admin": true,
+      "dccRequired": false
+    },
+    {
+      "label": "Account",
+      "path": "/user",
+      "admin": false,
+      "dccRequired": false
+    }
   ]
 }

--- a/src/components/HeaderNav/HeaderNav.jsx
+++ b/src/components/HeaderNav/HeaderNav.jsx
@@ -18,6 +18,7 @@ import ProposalCreditsIndicator from "../ProposalCreditsIndicator";
 import { ConfigFilter } from "src/containers/Config";
 import ModalLogout from "src/components/ModalLogout";
 import styles from "./HeaderNav.module.css";
+import { isUserValidContractor } from "src/containers/DCC";
 
 const HeaderNav = ({ history }) => {
   const { user, username } = useNavigation();
@@ -32,18 +33,25 @@ const HeaderNav = ({ history }) => {
       onClose: handleCloseModal
     });
 
+  const isValidContractor = isUserValidContractor(user);
+
   const menuItems = useMemo(
     () =>
-      navMenuPaths.map(({ label, path, admin }, idx) => {
+      navMenuPaths.map(({ label, path, admin, dccRequired }, idx) => {
         if (path === "/user") {
           path += "/" + userid;
         }
         const isActive = window.location.pathname === path;
         const onMenuItemClick = (path) => () => history.push(path);
+        const showItem = (admin && userIsAdmin) || !admin;
+        const isDisabled = !userIsAdmin && dccRequired && !isValidContractor;
         return (
-          ((admin && userIsAdmin) || !admin) && (
+          showItem && (
             <DropdownItem
-              className={isActive ? styles.activeDropdownItem : null}
+              className={classNames(
+                isActive && styles.activeDropdownItem,
+                isDisabled && styles.disabledDropdownItem
+              )}
               key={`link-${idx}`}
               onClick={onMenuItemClick(path)}>
               {label}
@@ -51,7 +59,7 @@ const HeaderNav = ({ history }) => {
           )
         );
       }),
-    [history, navMenuPaths, userIsAdmin, userid]
+    [history, navMenuPaths, userIsAdmin, userid, isValidContractor]
   );
 
   const [darkThemeOnLocalStorage, setDarkThemeOnLocalStorage] = useLocalStorage(

--- a/src/components/HeaderNav/HeaderNav.jsx
+++ b/src/components/HeaderNav/HeaderNav.jsx
@@ -43,15 +43,12 @@ const HeaderNav = ({ history }) => {
         }
         const isActive = window.location.pathname === path;
         const onMenuItemClick = (path) => () => history.push(path);
-        const showItem = (admin && userIsAdmin) || !admin;
         const isDisabled = !userIsAdmin && dccRequired && !isValidContractor;
+        const showItem = ((admin && userIsAdmin) || !admin) && !isDisabled;
         return (
           showItem && (
             <DropdownItem
-              className={classNames(
-                isActive && styles.activeDropdownItem,
-                isDisabled && styles.disabledDropdownItem
-              )}
+              className={classNames(isActive && styles.activeDropdownItem)}
               key={`link-${idx}`}
               onClick={onMenuItemClick(path)}>
               {label}

--- a/src/components/HeaderNav/HeaderNav.module.css
+++ b/src/components/HeaderNav/HeaderNav.module.css
@@ -36,11 +36,6 @@
   color: var(--dropdown-item-active-color) !important;
 }
 
-.disabledDropdownItem {
-  color: var(--btn-disabled-text-color) !important;
-  pointer-events: none;
-}
-
 .activeNavLink {
   border-bottom: 0.4rem solid var(--active-nav-border-color);
 }

--- a/src/components/HeaderNav/HeaderNav.module.css
+++ b/src/components/HeaderNav/HeaderNav.module.css
@@ -36,6 +36,11 @@
   color: var(--dropdown-item-active-color) !important;
 }
 
+.disabledDropdownItem {
+  color: var(--btn-disabled-text-color) !important;
+  pointer-events: none;
+}
+
 .activeNavLink {
   border-bottom: 0.4rem solid var(--active-nav-border-color);
 }

--- a/src/containers/DCC/helpers.js
+++ b/src/containers/DCC/helpers.js
@@ -5,13 +5,12 @@ import {
   DCC_STATUS_DRAFTS,
   DCC_TYPE_ISSUANCE,
   DCC_TYPE_REVOCATION,
-  DCC_DOMAIN_INVALID,
   DCC_DOMAIN_DEVELOPER,
+  DCC_FULL_USER_CONTRACTOR_TYPES,
   CONTRACTOR_TYPE_NOMINEE,
   CONTRACTOR_TYPE_REVOKED,
   CONTRACTOR_TYPE_SUPERVISOR,
-  CONTRACTOR_TYPE_SUBCONTRACTOR,
-  CONTRACTOR_TYPE_INVALID
+  CONTRACTOR_TYPE_SUBCONTRACTOR
 } from "./constants";
 import isEmpty from "lodash/isEmpty";
 import some from "lodash/fp/some";
@@ -223,11 +222,7 @@ export const isDccSupportOpposeAvailable = (userid, dcc) =>
  * @param {Number} domain
  */
 export const isUserValidContractor = (user) =>
-  user &&
-  user.domain !== DCC_DOMAIN_INVALID &&
-  user.contractortype !== CONTRACTOR_TYPE_REVOKED &&
-  user.contractortype !== CONTRACTOR_TYPE_NOMINEE &&
-  user.contractortype !== CONTRACTOR_TYPE_INVALID;
+  user && DCC_FULL_USER_CONTRACTOR_TYPES.includes(user.contractortype);
 
 /**
  * Returns if cms user is a developer

--- a/src/hooks/api/useUserDetail.js
+++ b/src/hooks/api/useUserDetail.js
@@ -14,8 +14,9 @@ export default function useUserDetail(userID) {
   const user = useSelector(userSelector);
   const isAdmin = useSelector(sel.currentUserIsAdmin);
   const onFetchUser = useAction(act.onFetchUser);
+  const isRequestingUser = useSelector(sel.isApiRequestingUser);
   const userMissingData = !user || (user && !user.identities);
-  const needsFetch = !!uid && userMissingData;
+  const needsFetch = !!uid && userMissingData && !isRequestingUser;
   const args = [uid];
   const [loading, error] = useAPIAction(onFetchUser, args, needsFetch);
 


### PR DESCRIPTION
Noticed that users without a DCC were able to navigate to `/invoices/all` using the header dropdown. But when the user navigates to it, it shows the following message:
> Error: You are not authorized to perform this action.

This PR adds a DCC checker for NavHeader in order to prevent that behavior.

### UI Changes
<img width="1084" alt="Screen Shot 2020-11-25 at 4 34 49 PM" src="https://user-images.githubusercontent.com/22639213/100273884-44939d00-2f3c-11eb-96ef-5da6e8ba5319.png">
 
