### PR TITLE
[cms/accounts] fix: fetch only owned props on proposals owned tab

### DIFF
--- a/src/containers/User/Detail/ProposalsOwned/ProposalsOwned.jsx
+++ b/src/containers/User/Detail/ProposalsOwned/ProposalsOwned.jsx
@@ -6,7 +6,9 @@ import isEmpty from "lodash/fp/isEmpty";
 import styles from "./ProposalsOwned.module.css";
 
 const ProposalsOwned = ({ proposalsOwned }) => {
-  const { proposalsByToken, isLoading, error } = useApprovedProposals();
+  const { proposalsByToken, isLoading, error } = useApprovedProposals(
+    proposalsOwned
+  );
   const loading = (isLoading || isEmpty(proposalsByToken)) && !error;
 
   return loading ? (


### PR DESCRIPTION
This prevents Proposals Owned tab to fetch unnecessary info regarding other proposals.