### PR TITLE
[cms/invoice] fix: display correct value on invoice subtotal

### DIFF
--- a/src/components/InvoiceDatasheet/helpers.js
+++ b/src/components/InvoiceDatasheet/helpers.js
@@ -192,7 +192,7 @@ export const convertLineItemsToGrid = (
         grid: acc.grid.concat([tableLine.filter(Boolean)]),
         expenseTotal: acc.expenseTotal + newLine.expenses,
         laborTotal: acc.laborTotal + newLine.labor,
-        total: parseFloat(acc.total + lineSubTotal).toFixed(2)
+        total: parseFloat(+acc.total + lineSubTotal).toFixed(2)
       };
     },
     { grid: [], expenseTotal: 0, laborTotal: 0, total: 0 }


### PR DESCRIPTION
This PR fixes the invoice total calculation with decimal places. The `toFixed()` method returns a `string`, and this caused the JS (😠) to do a string concat instead of a number addition.

### UI Changes Screenshot

##### Before
<img width="1524" alt="Screen Shot 2020-11-26 at 11 42 31 AM" src="https://user-images.githubusercontent.com/22639213/100364198-8d029780-2fdc-11eb-8dd9-9472f7c18ce2.png">

##### After
<img width="1513" alt="Screen Shot 2020-11-26 at 11 43 54 AM" src="https://user-images.githubusercontent.com/22639213/100364322-bae7dc00-2fdc-11eb-950e-d43232dd99fa.png">
