### PR TITLE
[cms/invoice] fix: remove empty proposals tokens on invoice lineitems diff

### DIFF
--- a/src/components/ModalDiff/ModalDiffInvoice.jsx
+++ b/src/components/ModalDiff/ModalDiffInvoice.jsx
@@ -27,7 +27,7 @@ const ModalDiffInvoice = ({ onClose, invoice, prevInvoice, ...props }) => {
     const tokens = invoice.input.lineitems.map(
       ({ proposaltoken }) => proposaltoken
     );
-    return uniq([...prevTokens, ...tokens]);
+    return uniq([...prevTokens, ...tokens]).filter((t) => t !== "");
   }, [invoice.input.lineitems, prevInput]);
 
   const { proposalsByToken, error } = useApprovedProposals(proposalsTokens);


### PR DESCRIPTION
When some lineitem is added to the invoice without a proposal token, the invoice diff tried to fetch an empty proposal token, which was leading to errors. This PR fixes it.
