### PR TITLE
[cms/invoice] fix: invoice datasheet paste tweaks

### DIFF
--- a/src/components/InvoiceDatasheet/helpers.js
+++ b/src/components/InvoiceDatasheet/helpers.js
@@ -120,7 +120,7 @@ export const convertLineItemsToGrid = (
           value: newLine.type,
           error: rowErrors && rowErrors.type,
           valueViewer: () =>
-            typeValue && capitalizeFirstLetter(typeValue.description),
+            typeValue ? capitalizeFirstLetter(typeValue.description) : "",
           dataEditor: selectWrapper(
             policyLineItemTypes.map((op) => ({
               value: op.type,

--- a/src/components/InvoiceDatasheet/wrappers.jsx
+++ b/src/components/InvoiceDatasheet/wrappers.jsx
@@ -69,12 +69,16 @@ export const proposalViewWrapper = (proposals, proposalsError) => ({
     []
   );
   const selectedProposal = findProposal(value);
-  const isLoading = !isEmpty(value) && !selectedProposal && !proposalsError;
+  const isLoading = isEmpty(proposals);
+  const invalidProposal = !isEmpty(value) && !selectedProposal && !isLoading;
   return (
     <>
       {isLoading && <Spinner invert />}
       {proposalsError && (
         <span className={highlightChar}>{proposalsError.toString()}</span>
+      )}
+      {invalidProposal && (
+        <span className={highlightChar}>Invalid proposal token</span>
       )}
       {selectedProposal && <span>{selectedProposal.label}</span>}
     </>


### PR DESCRIPTION
Some users reported that the pasting experience is not working as expected for the **proposal** lineitem. When some user typed an invalid proposal token (by pasting external datasheet items), a loading icon appears and is displayed until the user selects a valid proposal token, or paste a valid one.

Also, if the user pastes an invalid **type** lineitem, the page breaks.

### Solution description

The solution was simple: just display a message telling if the fields are invalid.

### UI Changes Screenshot
Before:
**Type lineitem**
<img width="1422" alt="Screen Shot 2020-12-02 at 5 29 50 PM" src="https://user-images.githubusercontent.com/22639213/100927731-0d853480-34c4-11eb-8a0a-73338e484972.png">

**Proposal lineitem**
<img width="1198" alt="Screen Shot 2020-12-02 at 5 31 39 PM" src="https://user-images.githubusercontent.com/22639213/100927929-4fae7600-34c4-11eb-8252-2e0ed26795bf.png">


After:
<img width="1126" alt="Screen Shot 2020-12-02 at 5 25 19 PM" src="https://user-images.githubusercontent.com/22639213/100927276-6ef8d380-34c3-11eb-83f5-d6bbbe5ef5f9.png">