### PR TITLE
[cms] fix: endless loading on error in invoice page

### DIFF
--- a/src/containers/Invoice/Detail/hooks.js
+++ b/src/containers/Invoice/Detail/hooks.js
@@ -61,7 +61,6 @@ export function useInvoice(invoiceToken) {
           onFetchProposalsBatch(unfetchedProposalsTokens, false)
             .then(() => send(VERIFY))
             .catch((e) => send(REJECT, e));
-          return send(FETCH);
         }
         return send(RESOLVE, { invoice, proposals: values(proposalsByToken) });
       },


### PR DESCRIPTION
This diff fixes endless loading indicator when there's an error fetching
a proposal details with a wrong token in invoice page.

Partly fixes #2204 - will keep the issue open as we will need to prevent wrong tokens from being submitted by adding 
a validation for the proposal token column in invoice lineitems.