### PR TITLE
[identity] fix: display visual feedback for errors

### DIFF
--- a/src/hooks/api/useUserIdentity.js
+++ b/src/hooks/api/useUserIdentity.js
@@ -7,7 +7,6 @@ export default function useUserIdentity() {
   const currentUserID = useSelector(sel.currentUserID);
   const currentUserUsername = useSelector(sel.currentUserUsername);
   const currentUserEmail = useSelector(sel.currentUserEmail);
-  const identityImportError = useSelector(sel.identityImportError);
   const identityImportSuccess = useSelector(sel.identityImportSuccess);
   const keyMismatch = useSelector(sel.keyMismatch);
   const updateUserKeyToken = useSelector(sel.currentUserKeyVerificationToken);
@@ -23,7 +22,6 @@ export default function useUserIdentity() {
     currentUserID,
     currentUserUsername,
     currentUserEmail,
-    identityImportError,
     identityImportSuccess,
     keyMismatch,
     updateUserKeyToken,

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -73,9 +73,6 @@ export const getCsrfIsNeeded = (state) =>
 
 export const shouldAutoVerifyKey = (state) => state.app.shouldVerifyKey;
 
-export const identityImportError = (state) =>
-  state.app.identityImportResult && state.app.identityImportResult.errorMsg;
-
 export const identityImportSuccess = (state) =>
   state.app.identityImportResult && state.app.identityImportResult.successMsg;
 

--- a/src/selectors/tests/app.test.js
+++ b/src/selectors/tests/app.test.js
@@ -12,11 +12,7 @@ describe("test app selector", () => {
     expect(sel.getCsrfIsNeeded(MOCK_STATE)).toBeTruthy();
   });
 
-  it("test selectors identityImportError and identityImportSuccess", () => {
-    expect(sel.identityImportError(MOCK_STATE)).toEqual(
-      MOCK_STATE.app.identityImportResult.errorMsg
-    );
-
+  it("test selector identityImportSuccess", () => {
     expect(sel.identityImportSuccess(MOCK_STATE)).toEqual(
       MOCK_STATE.app.identityImportResult.successMsg
     );


### PR DESCRIPTION
This diff fixes #2244, an issue that reported the lack of a visual feedback for errors when importing an identity. Previously, the modal always refreshed and no visual feedback was displayed.

### Solution description

The solution was to avoid the side effects caused by functions outside the form component, which caused the component to re-render before it shows up the error message.

### UI Changes Screenshot

Before:
![import-identity-error-before](https://user-images.githubusercontent.com/22639213/101949127-e3252c80-3bd1-11eb-91d9-bfd136386474.gif)

After:
![import-identity-error-after](https://user-images.githubusercontent.com/22639213/101949094-d99bc480-3bd1-11eb-99be-eb9313efd742.gif)
