### PR TITLE
[login] fix: force lowercase email on form

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -411,7 +411,10 @@ export const verifyUserPayment = () =>
   GET("/v1/user/verifypayment").then(getResponse);
 
 export const login = (csrf, email, password) =>
-  POST("/login", csrf, { email, password: digest(password) }).then(getResponse);
+  POST("/login", csrf, {
+    email: email.toLowerCase(),
+    password: digest(password)
+  }).then(getResponse);
 
 // XXXX: this route hasn't been merged into the master of the backend.
 // Pull request: https://github.com/decred/politeia/pull/940


### PR DESCRIPTION
Closes #2216

The same is done by piwww when creating a new user:
https://github.com/decred/politeia/blob/a3a16ab8550dd07fb6f6271af4cb4b0fe52ae6f3/politeiawww/user.go#L370