### PR TITLE
[pi/paywall] style: minor visual tweaks

### DIFF
--- a/src/components/PaymentComponent/PaymentComponent.jsx
+++ b/src/components/PaymentComponent/PaymentComponent.jsx
@@ -4,7 +4,6 @@ import {
   H4,
   Text,
   useTheme,
-  useMediaQuery,
   DEFAULT_DARK_THEME_NAME
 } from "pi-ui";
 import PropTypes from "prop-types";
@@ -17,7 +16,6 @@ import styles from "./PaymentComponent.module.css";
 const PaymentComponent = ({ address, amount, extraSmall, status }) => {
   const { themeName } = useTheme();
   const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
-  const shouldPlaceTooltipBottom = useMediaQuery("(max-width: 675px)");
   return (
     <>
       <div
@@ -40,7 +38,7 @@ const PaymentComponent = ({ address, amount, extraSmall, status }) => {
           <CopyableText
             id="payment-address"
             truncate
-            tooltipPlacement={shouldPlaceTooltipBottom ? "bottom" : "right"}>
+            tooltipPlacement={"bottom"}>
             {address}
           </CopyableText>
           {!extraSmall && <PaymentStatusTag status={status} />}

--- a/src/components/PaymentFaucet/PaymentFaucet.jsx
+++ b/src/components/PaymentFaucet/PaymentFaucet.jsx
@@ -24,7 +24,7 @@ const PaymentFaucet = ({ address, amount, onFail = noop }) => {
   );
   return (
     isTestnet && (
-      <div className="paywall-faucet">
+      <div className={styles.paywallFaucet}>
         <P className="margin-top-m">
           This Politeia instance is running on Testnet, which means you can pay
           with the Decred faucet:

--- a/src/components/PaymentFaucet/PaymentFaucet.module.css
+++ b/src/components/PaymentFaucet/PaymentFaucet.module.css
@@ -2,6 +2,10 @@
   width: 100%;
 }
 
+.paywallFaucet {
+  max-width: 500px;
+}
+
 /* SMALL */
 @media screen and (max-width: 768px) {
   .transactionIdMessage {


### PR DESCRIPTION
This fixes #2257, an issue that reported an overflow on payment modal's width.

- place tooltip on bottom
- bound faucet component's width

### UI Changes

**Before:**
![before](https://user-images.githubusercontent.com/22639213/102271477-3bc03680-3efe-11eb-999d-cf1ae9520143.png)

**After:**
<img width="1721" alt="Screen Shot 2020-12-16 at 9 31 05 AM" src="https://user-images.githubusercontent.com/22639213/102349030-74552400-3f81-11eb-94df-e6687d9357cf.png">

