### PR TITLE
[cms] fix: endless loading inside proposal token empty cell

### DIFF
--- a/src/components/InvoiceDatasheet/wrappers.jsx
+++ b/src/components/InvoiceDatasheet/wrappers.jsx
@@ -69,7 +69,7 @@ export const proposalViewWrapper = (proposals, proposalsError) => ({
     []
   );
   const selectedProposal = findProposal(value);
-  const isLoading = isEmpty(proposals);
+  const isLoading = value && isEmpty(proposals);
   const invalidProposal = !isEmpty(value) && !selectedProposal && !isLoading;
   return (
     <>


### PR DESCRIPTION
This diff improves the `isLoading` check inside lineitems' proposal token cell, which
used to show loading indicator if no proposals available but that's not true because
we have the edge case where invoice has no proposal tokens which was causing the cell 
to show the loading endlessly.

This diff ensures that the loading indicator displayed only inside cells which have a proposal token to fetch.