### PR TITLE
[cms/invoice-list] fix: use correct end date for january

### DIFF
--- a/src/containers/Invoice/helpers.js
+++ b/src/containers/Invoice/helpers.js
@@ -1,8 +1,7 @@
 import {
   getCurrentMonth,
   getCurrentYear,
-  getCurrentDateValue,
-  getCurrentDefaultMonthAndYear
+  getCurrentDateValue
 } from "src/helpers";
 import { INVOICE_STATUS_NEW, INVOICE_STATUS_UPDATED } from "./constants";
 import flow from "lodash/fp/flow";
@@ -128,7 +127,7 @@ export const getPreviousMonthsRange = (range) => {
       month: minMonth,
       year: minYear
     },
-    getCurrentDefaultMonthAndYear()
+    getInitialDateValue()
   ];
 };
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -447,11 +447,6 @@ export const getCurrentDateValue = () => {
 export const getDateFromYearAndMonth = ({ year, month }) =>
   new Date(year, month);
 
-export const getCurrentDefaultMonthAndYear = () => ({
-  month: getCurrentMonth() - 1,
-  year: getCurrentYear()
-});
-
 export const getYearOptions = (initial, lastYear) => {
   const isYearValid = (y) => y < lastYear + getCurrentMonth() - 1;
   return flow(range(), filter(isYearValid))(initial, lastYear + 1);


### PR DESCRIPTION
This is a quick fix for invoices filtering by date. Previously, on January, the default current month value was not being handled properly. This diff fixes it.

### Solution description

Simply used the correct function that already handles the date changes

### UI Changes Screenshot

before:
<img width="448" alt="Screen Shot 2021-01-04 at 11 53 36 AM" src="https://user-images.githubusercontent.com/22639213/103548152-2054a580-4e84-11eb-9adf-b7bed841b496.png">

after:
<img width="393" alt="Screen Shot 2021-01-04 at 11 54 04 AM" src="https://user-images.githubusercontent.com/22639213/103548148-1e8ae200-4e84-11eb-8bc2-722d956f8081.png">

