### PR TITLE
[cms] Fix past invoice and code stats dates

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -354,7 +354,12 @@ export const onFetchUserCodeStats = (userid, start, end) =>
       .codeStats(csrf, userid, start, end)
       .then((response) =>
         dispatch(
-          act.RECEIVE_CODE_STATS({ userid, codestats: response.repostats })
+          act.RECEIVE_CODE_STATS({
+            userid,
+            codestats: response.repostats,
+            start,
+            end
+          })
         )
       )
       .catch((error) => {

--- a/src/containers/Invoice/Detail/Detail.jsx
+++ b/src/containers/Invoice/Detail/Detail.jsx
@@ -34,6 +34,16 @@ const InvoiceDetail = ({ Main, match }) => {
   // set tab title
   useDocumentTitle(presentationalInvoiceName(invoice));
 
+  let start = 0;
+  let end = 0;
+  if (invoice) {
+    const endDate = new Date(invoice.input.year, invoice.input.month);
+    const startDate = new Date(invoice.input.year, invoice.input.month);
+    startDate.setMonth(startDate.getMonth() - 3);
+    end = endDate.getTime() / 1000;
+    start = startDate.getTime() / 1000;
+  }
+
   return (
     <>
       <Main fillScreen>
@@ -55,6 +65,8 @@ const InvoiceDetail = ({ Main, match }) => {
                 <Stats
                   invoiceToken={invoice.censorshiprecord.token}
                   userid={invoice.userid}
+                  start={start}
+                  end={end}
                 />
               )}
             </>

--- a/src/containers/Invoice/Detail/Stats.jsx
+++ b/src/containers/Invoice/Detail/Stats.jsx
@@ -6,24 +6,19 @@ import styles from "./Detail.module.css";
 import { isUserDeveloper } from "src/containers/DCC/helpers";
 import useUserDetail from "src/hooks/api/useUserDetail";
 
-const Stats = ({ invoiceToken, userid }) => {
+const Stats = ({ invoiceToken, userid, start, end }) => {
   const { user } = useUserDetail(userid);
-  const end = new Date();
-  const start = new Date();
-  start.setMonth(start.getMonth() - 3);
-  const starttimestamp = Math.round(start.valueOf() / 1000);
-  const endtimestamp = Math.round(end.valueOf() / 1000);
   return (
     <Card paddingSize="small">
       <H2 className={styles.statsTitle}>Stats</H2>
       <InvoiceDetails
-        start={starttimestamp}
-        end={endtimestamp}
+        start={start}
+        end={end}
         token={invoiceToken}
         userid={userid}
       />
       {isUserDeveloper(user) && (
-        <CodeStats userid={userid} start={starttimestamp} end={endtimestamp} />
+        <CodeStats userid={userid} start={start} end={end} />
       )}
     </Card>
   );

--- a/src/containers/Invoice/Detail/hooks.js
+++ b/src/containers/Invoice/Detail/hooks.js
@@ -112,10 +112,10 @@ export function useFetchCodeStats(userid, start, end) {
   return { loading, error };
 }
 
-export function useCodeStats(userid) {
+export function useCodeStats(userid, start, end) {
   const codeStatsSelector = useMemo(
-    () => sel.makeGetCodeStatsByUserID(userid),
-    [userid]
+    () => sel.makeGetCodeStatsByUserID(userid, start, end),
+    [userid, start, end]
   );
   const codestats = useSelector(codeStatsSelector);
 

--- a/src/hooks/utils/useAPIAction.js
+++ b/src/hooks/utils/useAPIAction.js
@@ -7,20 +7,28 @@ function useApplyAction(action, args = DEFAULT_ARGS, enabled = true) {
   const [error, setError] = useState(false);
   const [response, setResponse] = useState(null);
   useEffect(() => {
+    let mounted = true;
     async function executeAction() {
-      setLoading(true);
+      if (mounted) setLoading(true);
       try {
         const res = await action.apply(null, args);
-        setLoading(false);
-        setResponse(res);
+        if (mounted) {
+          setLoading(false);
+          setResponse(res);
+        }
       } catch (e) {
-        setLoading(false);
-        setError(e);
+        if (mounted) {
+          setLoading(false);
+          setError(e);
+        }
       }
     }
     if (enabled) {
       executeAction();
     }
+    return function cleanup() {
+      mounted = false;
+    };
   }, [action, args, enabled]);
   return [loading, error, response];
 }

--- a/src/reducers/models/codestats.js
+++ b/src/reducers/models/codestats.js
@@ -11,8 +11,11 @@ const codestats = (state = DEFAULT_STATE, action) =>
     : (
         {
           [act.RECEIVE_CODE_STATS]: () => {
-            const { userid, codestats } = action.payload;
-            return set(["byUserID", userid], codestats)(state);
+            const { userid, codestats, start, end } = action.payload;
+            return set(
+              ["byUserID", userid, "" + start + end],
+              codestats
+            )(state);
           },
           [act.RECEIVE_CMS_LOGOUT]: () => DEFAULT_STATE
         }[action.type] || (() => state)

--- a/src/selectors/models/codestats.js
+++ b/src/selectors/models/codestats.js
@@ -2,6 +2,10 @@ import { createSelector } from "reselect";
 import get from "lodash/fp/get";
 
 export const codeStatsByUserID = get(["codestats", "byUserID"]);
-
-export const makeGetCodeStatsByUserID = (userID) =>
+export const userCodeStats = (userID) =>
   createSelector(codeStatsByUserID, get(userID));
+
+export const makeGetCodeStatsByUserID = (userID, start, end) =>
+  createSelector(userCodeStats(userID), (userCodeStats) =>
+    userCodeStats ? userCodeStats["" + start + end] : null
+  );


### PR DESCRIPTION
Closes https://github.com/decred/politeiagui/issues/2260

This PR also caches the codestats by the concatenation of the start and end timestamps to prevent multiple requests and clears the annoying warning like the one below by adding a boolean to verify whether the component is mounted or not, that is cleaned after every `useEffect` of the `useAPIAction` hook.

<img width="423" alt="Screen Shot 2021-01-04 at 14 54 32" src="https://user-images.githubusercontent.com/13955303/103565952-ff01b280-4e9f-11eb-87b1-265930af3519.png">