### PR TITLE
[pi/proposal] fix: always use proposal name on details page tab title

### DIFF
--- a/src/containers/Proposal/Detail/Detail.jsx
+++ b/src/containers/Proposal/Detail/Detail.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React from "react";
 import { Message } from "pi-ui";
 import get from "lodash/fp/get";
 import { withRouter } from "react-router-dom";
@@ -19,19 +19,16 @@ import {
   PublicActionsProvider
 } from "src/containers/Proposal/Actions";
 import { useProposalVote } from "../hooks";
-import { makeGetProposalName } from "src/selectors";
-import { useSelector } from "src/redux";
-import { useDocumentTitle } from "src/hooks/utils/useDocumentTitle";
+import useDocumentTitle from "src/hooks/utils/useDocumentTitle";
 import { GoBackLink } from "src/components/Router";
+
+const SetPageTitle = ({ title }) => {
+  useDocumentTitle(title);
+  return null;
+};
 
 const ProposalDetail = ({ Main, match }) => {
   const tokenFromUrl = get("params.token", match);
-  const proposalNameSelector = useMemo(
-    () => makeGetProposalName(tokenFromUrl),
-    [tokenFromUrl]
-  );
-  const proposalName = useSelector(proposalNameSelector);
-  useDocumentTitle(proposalName);
   const threadParentCommentID = get("params.commentid", match);
   const { proposal, loading, threadParentID, error } = useProposal(
     tokenFromUrl,
@@ -48,6 +45,7 @@ const ProposalDetail = ({ Main, match }) => {
     <>
       <Main className={styles.customMain} fillScreen>
         <GoBackLink />
+        {proposal && <SetPageTitle title={proposal.name} />}
         <UnvettedActionsProvider>
           <PublicActionsProvider>
             {error ? (


### PR DESCRIPTION
This PR fixes #2264, an issue regarding the correct use of the proposal name on tabs title. Previously, due to a race condition, when you navigated from another page to proposal details page, the browser's tab title was being replaced by the generic "Proposal Detail" title.

### UI Changes Screenshot

Before:
<img width="690" alt="Screen Shot 2021-01-07 at 10 25 50 AM" src="https://user-images.githubusercontent.com/22639213/103897842-d8778d80-50d2-11eb-9c5f-ba94eef8b102.png">

After:
<img width="699" alt="Screen Shot 2021-01-07 at 10 25 18 AM" src="https://user-images.githubusercontent.com/22639213/103897853-dad9e780-50d2-11eb-9ee6-011ca92be6e2.png">
