### PR TITLE
deps: use latest table pagination from pi-ui

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9778,7 +9778,7 @@ performance-now@^2.1.0:
 
 "pi-ui@https://github.com/decred/pi-ui":
   version "1.0.0"
-  resolved "https://github.com/decred/pi-ui#8f5124149a6820726905956e894cd94e82719987"
+  resolved "https://github.com/decred/pi-ui#40eaa7017c21086a1d4dfd4d3cedc72da7838102"
   dependencies:
     clamp-js-main "^0.11.5"
     lodash "^4.17.15"


### PR DESCRIPTION
This Fixes #2219 by updating the Table component on pi-ui.

### Dependencies

https://github.com/decred/pi-ui/issues/311

### UI Changes Screenshot

Before:
![before](https://user-images.githubusercontent.com/22639213/100275664-0d72bb00-2f3f-11eb-9b8e-40f9bcc78707.png)

After:
<img width="1832" alt="Screen Shot 2021-01-07 at 11 02 32 AM" src="https://user-images.githubusercontent.com/22639213/103901453-ec71be00-50d7-11eb-96b4-80b8f8527266.png">
