### PR TITLE
style: fix public header nav on mobile

### DIFF
--- a/src/components/HeaderNav/HeaderNav.module.css
+++ b/src/components/HeaderNav/HeaderNav.module.css
@@ -55,7 +55,7 @@ ul.dropdownList {
 }
 
 .publicWrapper {
-  padding: 0 2rem;
+  padding: 0 1rem;
   border-bottom: 0.2rem solid transparent;
 }
 


### PR DESCRIPTION

### UI Changes Screenshot
Before:
<img width="892" alt="Screen Shot 2021-01-15 at 7 57 42 PM" src="https://user-images.githubusercontent.com/22639213/104786547-f8aaea80-576b-11eb-9177-1b0e246e4bb2.png">

After:
<img width="898" alt="Screen Shot 2021-01-15 at 7 59 17 PM" src="https://user-images.githubusercontent.com/22639213/104786620-314ac400-576c-11eb-871a-4987dad84796.png">
