### PR TITLE
Add codestats for subcontractors

### DIFF
--- a/src/containers/Invoice/Detail/CodeStats.jsx
+++ b/src/containers/Invoice/Detail/CodeStats.jsx
@@ -1,6 +1,7 @@
 import React, { Fragment, useState, memo } from "react";
-import { H4, Text, Spinner, classNames } from "pi-ui";
+import { H4, H5, Text, Spinner, classNames } from "pi-ui";
 import Link from "src/components/Link";
+import useUserDetail from "src/hooks/api/useUserDetail";
 import { useCodeStats, useFetchCodeStats } from "./hooks";
 import styles from "./Detail.module.css";
 
@@ -94,8 +95,8 @@ const CodeStatDetails = ({
   );
 };
 
-export const FetchCodeStats = ({ userid, start, end }) => {
-  const { loading, error } = useFetchCodeStats(userid, start, end);
+export const FetchCodeStats = ({ id, start, end }) => {
+  const { loading, error } = useFetchCodeStats(id, start, end);
   return loading ? (
     <Spinner />
   ) : error ? (
@@ -103,18 +104,15 @@ export const FetchCodeStats = ({ userid, start, end }) => {
   ) : null;
 };
 
-const CodeStats = ({ userid, start, end }) => {
-  const { codestats } = useCodeStats(userid, start, end);
+const IndividualCodeStats = ({ id, start, end }) => {
+  const { user } = useUserDetail(id);
+  const { codestats } = useCodeStats(id, start, end);
   const shouldPrintTable = codestats && codestats.length > 0;
   const shouldPrintEmptyMessage = codestats && codestats.length === 0;
   return (
     <>
-      <div className={classNames(styles.titleLinkWrapper, "margin-top-m")}>
-        <H4>Past 3 months code stats</H4>
-        {!codestats && (
-          <FetchCodeStats userid={userid} start={start} end={end} />
-        )}
-      </div>
+      {!codestats && <FetchCodeStats id={id} start={start} end={end} />}
+      <H5 className="margin-top-s">{user && user.username}</H5>
       {shouldPrintTable ? (
         <div className={styles.codeStats}>
           <Headers />
@@ -124,9 +122,27 @@ const CodeStats = ({ userid, start, end }) => {
         </div>
       ) : (
         shouldPrintEmptyMessage && (
-          <Text>No code stats for the past 3 months</Text>
+          <Text>No code stats for this user in the past 3 months</Text>
         )
       )}
+    </>
+  );
+};
+
+const CodeStats = ({ ids, start, end }) => {
+  return (
+    <>
+      <div
+        className={classNames(
+          styles.titleLinkWrapper,
+          "margin-top-m",
+          "margin-bottom-s"
+        )}>
+        <H4>Past 3 months code stats</H4>
+      </div>
+      {ids.map((id) => (
+        <IndividualCodeStats key={id} id={id} start={start} end={end} />
+      ))}
     </>
   );
 };

--- a/src/containers/Invoice/Detail/Detail.jsx
+++ b/src/containers/Invoice/Detail/Detail.jsx
@@ -28,9 +28,7 @@ const InvoiceDetail = ({ Main, match }) => {
   } = useInvoice(invoiceToken);
 
   const { subContractors, error: subContractorsError } = useSubContractors();
-
   let subContractorsInLineItems;
-
   if (invoice && subContractors) {
     const linesSubContractors = invoice.input.lineitems.map(
       (lineitem) => lineitem.subuserid

--- a/src/containers/Invoice/Detail/Detail.jsx
+++ b/src/containers/Invoice/Detail/Detail.jsx
@@ -11,6 +11,7 @@ import { GoBackLink } from "src/components/Router";
 import Stats from "./Stats";
 import get from "lodash/fp/get";
 import { useDocumentTitle } from "src/hooks/utils/useDocumentTitle";
+import useSubContractors from "src/hooks/api/useSubContractors";
 import { presentationalInvoiceName } from "../helpers";
 
 const InvoiceDetail = ({ Main, match }) => {
@@ -25,6 +26,8 @@ const InvoiceDetail = ({ Main, match }) => {
     proposals,
     proposalsError
   } = useInvoice(invoiceToken);
+
+  const { subContractors, error: subContractorsError } = useSubContractors();
 
   const isAuthor =
     currentUser && invoice && invoice.userid === currentUser.userid;
@@ -63,6 +66,8 @@ const InvoiceDetail = ({ Main, match }) => {
               />
               {isAdmin && (
                 <Stats
+                  subContractors={subContractors}
+                  subContractorsError={subContractorsError}
                   invoiceToken={invoice.censorshiprecord.token}
                   userid={invoice.userid}
                   start={start}

--- a/src/containers/Invoice/Detail/Detail.jsx
+++ b/src/containers/Invoice/Detail/Detail.jsx
@@ -29,6 +29,17 @@ const InvoiceDetail = ({ Main, match }) => {
 
   const { subContractors, error: subContractorsError } = useSubContractors();
 
+  let subContractorsInLineItems;
+
+  if (invoice && subContractors) {
+    const linesSubContractors = invoice.input.lineitems.map(
+      (lineitem) => lineitem.subuserid
+    );
+    subContractorsInLineItems = subContractors.filter((sc) => {
+      return linesSubContractors.includes(sc.id);
+    });
+  }
+
   const isAuthor =
     currentUser && invoice && invoice.userid === currentUser.userid;
   const isAdmin = currentUser && currentUser.isadmin;
@@ -66,7 +77,7 @@ const InvoiceDetail = ({ Main, match }) => {
               />
               {isAdmin && (
                 <Stats
-                  subContractors={subContractors}
+                  subContractors={subContractorsInLineItems}
                   subContractorsError={subContractorsError}
                   invoiceToken={invoice.censorshiprecord.token}
                   userid={invoice.userid}

--- a/src/containers/Invoice/Detail/InvoiceDetails.jsx
+++ b/src/containers/Invoice/Detail/InvoiceDetails.jsx
@@ -1,5 +1,5 @@
 import React, { useState, memo } from "react";
-import { Spinner, Text, H4, Table, Link as UiLink } from "pi-ui";
+import { Spinner, Text, H4, Table, Link as UiLink, classNames } from "pi-ui";
 import Link from "src/components/Link";
 import { useInvoices } from "./hooks";
 import { formatCentsToUSD } from "src/utils";
@@ -35,7 +35,7 @@ const InvoiceDetails = ({ token, userid, start, end }) => {
   const shouldPrintEmptyMessage = invoices && invoices.length === 0;
   return (
     <>
-      <div className={styles.titleLinkWrapper}>
+      <div className={classNames(styles.titleLinkWrapper, "margin-bottom-s")}>
         <H4>Past 3 months invoices</H4>
         {!invoices && <FetchInvoices />}
         <UiLink className={styles.uilink} onClick={toggleShowStats}>

--- a/src/containers/Invoice/Detail/Stats.jsx
+++ b/src/containers/Invoice/Detail/Stats.jsx
@@ -6,8 +6,19 @@ import styles from "./Detail.module.css";
 import { isUserDeveloper } from "src/containers/DCC/helpers";
 import useUserDetail from "src/hooks/api/useUserDetail";
 
-const Stats = ({ invoiceToken, userid, start, end }) => {
+const Stats = ({
+  subContractors,
+  subContractorsError,
+  invoiceToken,
+  userid,
+  start,
+  end
+}) => {
   const { user } = useUserDetail(userid);
+  const subcontractorsids = subContractors
+    ? subContractors.map((sc) => sc.id)
+    : [];
+
   return (
     <Card paddingSize="small">
       <H2 className={styles.statsTitle}>Stats</H2>
@@ -17,9 +28,14 @@ const Stats = ({ invoiceToken, userid, start, end }) => {
         token={invoiceToken}
         userid={userid}
       />
-      {isUserDeveloper(user) && (
-        <CodeStats userid={userid} start={start} end={end} />
+      {isUserDeveloper(user) && !subContractorsError && (
+        <CodeStats
+          ids={[...subcontractorsids, userid]}
+          start={start}
+          end={end}
+        />
       )}
+      {subContractorsError && { subContractorsError }}
     </Card>
   );
 };

--- a/src/containers/Invoice/Detail/hooks.js
+++ b/src/containers/Invoice/Detail/hooks.js
@@ -100,22 +100,18 @@ export function useInvoices(currentInvoice, userid, start, end) {
   };
 }
 
-export function useFetchCodeStats(userid, start, end) {
+export function useFetchCodeStats(id, start, end) {
   const onFetchUserCodeStats = useAction(act.onFetchUserCodeStats);
 
-  const [loading, error] = useAPIAction(onFetchUserCodeStats, [
-    userid,
-    start,
-    end
-  ]);
+  const [loading, error] = useAPIAction(onFetchUserCodeStats, [id, start, end]);
 
   return { loading, error };
 }
 
-export function useCodeStats(userid, start, end) {
+export function useCodeStats(id, start, end) {
   const codeStatsSelector = useMemo(
-    () => sel.makeGetCodeStatsByUserID(userid, start, end),
-    [userid, start, end]
+    () => sel.makeGetCodeStatsByUserID(id, start, end),
+    [id, start, end]
   );
   const codestats = useSelector(codeStatsSelector);
 


### PR DESCRIPTION
Closes #2293 

### Solution description

I added some code to get the subcontractors that are listed in the invoice and hit the `/codestats` endpoint with their ids.

### UI Changes Screenshot

**Without subcontractors (stays the same):** 

![image](https://user-images.githubusercontent.com/13955303/106473360-76683900-6482-11eb-8776-1baf54d72bf6.png)


**With subcontractors:**

![image](https://user-images.githubusercontent.com/13955303/106473412-81bb6480-6482-11eb-9efe-065366f3621f.png)


