### PR TITLE
[cms/dcc]: avoid infinite loading state on dcc details

### DIFF
--- a/src/containers/DCC/Detail/hooks.js
+++ b/src/containers/DCC/Detail/hooks.js
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import * as sel from "src/selectors";
 import * as act from "src/actions";
 import { useSelector, useAction } from "src/redux";
-import useAPIAction from "src/hooks/utils/useAPIAction";
+import useFetchOnce from "src/hooks/utils/useFetchOnce";
 
 export function useDcc(dccToken) {
   const dccSelector = useMemo(() => sel.makeGetDccByToken(dccToken), [
@@ -11,8 +11,7 @@ export function useDcc(dccToken) {
   const dcc = useSelector(dccSelector);
   const onFetchDcc = useAction(act.onFetchDcc);
 
-  const requestParams = useMemo(() => [dccToken], [dccToken]);
-  const [loading, error] = useAPIAction(onFetchDcc, requestParams, !dcc);
+  const [loading, error] = useFetchOnce(onFetchDcc, [dccToken], !dcc);
 
   return { dcc, loading, error };
 }

--- a/src/hooks/utils/useFetchOnce.js
+++ b/src/hooks/utils/useFetchOnce.js
@@ -1,0 +1,27 @@
+import useFetchMachine, { FETCH, RESOLVE, REJECT } from "./useFetchMachine";
+
+const DEFAULT_ARGS = [];
+
+/**
+ * useFetchOnce hook uses the fetch machine to control loading and error states for
+ * given action(args) if enabled.
+ * @param {function} action
+ * @param {array} args
+ * @param {boolean} enabled
+ */
+function useFetchOnce(action, args = DEFAULT_ARGS, enabled = true) {
+  const [state, send] = useFetchMachine({
+    actions: {
+      initial: () => {
+        if (!enabled) return;
+        action(...(args || []))
+          .then(() => send(RESOLVE))
+          .catch((e) => send(REJECT, { error: e }));
+        return send(FETCH);
+      }
+    }
+  });
+  return [state.loading, state.error];
+}
+
+export default useFetchOnce;


### PR DESCRIPTION
This diff fixes the infinite loading issue on DCC details. This happens when you access the dcc details page without fetching the dcc list.

### Solution description
Basically, I used a new `useFetchOnce` hook, which replaces the `useAPIAction` previously used. Now we can control the loading and error states just by using the fetch state machine.

#### Use Cases
Whenever we want to fetch an action only once, we can now use the `useFetchOnce` hook. Now we don't need to memoize the args for fetching, because the state machine forces an action to happen only once, at the initial state.

Example:
```javascript
const [loading, error] = useFetchOnce(action, args, isEnabled);
```

The following diagram represents the useFetchOnce's fetch machine state transitions:

![state-machine-fetch-once (1)](https://user-images.githubusercontent.com/22639213/109306990-bec70c80-781e-11eb-9b80-7d1279e138d3.png)

