### PR TITLE
fix: bundle/timestamp structure download fix

### DIFF
--- a/src/components/ModalSearchVotes/ModalSearchVotes.jsx
+++ b/src/components/ModalSearchVotes/ModalSearchVotes.jsx
@@ -4,17 +4,10 @@ import { Formik } from "formik";
 import { useSearchVotes } from "./hooks";
 import styles from "./ModalSearchVotes.module.css";
 import validationSchema from "./validation";
-import DownloadJSON from "src/components/DownloadJSON";
-import useTimestamps from "src/hooks/api/useTimestamps";
 
 function findTicket(ticketToken, votes) {
   return votes.find((v) => v && v.ticket === ticketToken);
 }
-const getTimestampsFileName = (proposalToken, ticketToken) =>
-  `timestamps-${proposalToken.substring(0, 7)}-ticket-${ticketToken.substring(
-    0,
-    7
-  )}`;
 
 const ModalSearchVotes = ({ show, onClose, proposal }) => {
   const [ticketFound, setTicketFound] = useState(null);
@@ -22,7 +15,6 @@ const ModalSearchVotes = ({ show, onClose, proposal }) => {
     proposal.censorshiprecord.token,
     show
   );
-  const { onFetchTicketVoteTimestamps } = useTimestamps();
   function updateFoundTicket(ticket) {
     setTicketFound({
       Ticket: ticket.ticket,
@@ -102,18 +94,6 @@ const ModalSearchVotes = ({ show, onClose, proposal }) => {
             data={[ticketFound]}
             headers={resultsTableHeaders}
             disablePagination
-          />
-          <DownloadJSON
-            label="Download Ticket Vote Timestamps"
-            fileName={getTimestampsFileName(
-              proposal.censorshiprecord.token,
-              ticketFound.Ticket
-            )}
-            isAsync={true}
-            content={[]}
-            beforeDownload={() =>
-              onFetchTicketVoteTimestamps(proposal.censorshiprecord.token)
-            }
           />
         </>
       )}

--- a/src/components/RecordWrapper/RecordWrapper.jsx
+++ b/src/components/RecordWrapper/RecordWrapper.jsx
@@ -281,9 +281,9 @@ export const DownloadVotes = ({
   serverpublickey
 }) => {
   const bundle = {
-    auths: voteSummary.details.auths,
-    details: voteSummary.details.details,
-    votes: voteSummary.votes,
+    auths: voteSummary?.details?.auths,
+    details: voteSummary?.details?.details,
+    votes: voteSummary?.votes,
     serverpublickey
   };
   return <DownloadJSON fileName={fileName} label={label} content={bundle} />;

--- a/src/containers/Comments/Download/DownloadComments.jsx
+++ b/src/containers/Comments/Download/DownloadComments.jsx
@@ -13,7 +13,7 @@ const DownloadComments = ({ recordToken, className, label }) => {
       label={label}
       fileName={`${recordToken}-comments`}
       content={{
-        ...comments,
+        comments: comments,
         serverpublickey: apiInfo.pubkey
       }}
       className={className}

--- a/src/containers/Comments/Download/DownloadComments.jsx
+++ b/src/containers/Comments/Download/DownloadComments.jsx
@@ -13,7 +13,7 @@ const DownloadComments = ({ recordToken, className, label }) => {
       label={label}
       fileName={`${recordToken}-comments`}
       content={{
-        comments: comments,
+        comments: comments.sort((a, b) => a.commentid - b.commentid),
         serverpublickey: apiInfo.pubkey
       }}
       className={className}

--- a/src/containers/Comments/Download/hooks.js
+++ b/src/containers/Comments/Download/hooks.js
@@ -48,8 +48,8 @@ export function useDownloadCommentsTimestamps(recordToken) {
     takeRight(commentIds.length - TIMESTAMPS_PAGE_SIZE)(commentIds)
   ];
 
-  const getProgressPercentage = (timestamps) =>
-    (Object.keys(timestamps.length * 100) / commentsLength).toFixed(2);
+  const getProgressPercentage = (timestamps) => timestamps ?
+    (Object.keys(timestamps.length * 100) / commentsLength).toFixed(2) : 0;
 
   const makeTimestampsBundle = (timestamps) =>
     JSON.stringify(
@@ -59,6 +59,10 @@ export function useDownloadCommentsTimestamps(recordToken) {
       null,
       2
     );
+
+  useEffect(() => {
+    setProgress(getProgressPercentage(timestamps?.comments));
+  }, [getProgressPercentage, timestamps]);
 
   const [
     state,
@@ -83,7 +87,6 @@ export function useDownloadCommentsTimestamps(recordToken) {
         onFetchCommentsTimestamps(recordToken, fetch)
           .then(({ comments }) => {
             setTimestamps({ comments });
-            setProgress(getProgressPercentage(comments));
             setRemaining(next);
             return send(VERIFY);
           })
@@ -111,7 +114,6 @@ export function useDownloadCommentsTimestamps(recordToken) {
                   ...resp.comments
                 }
               });
-              setProgress(getProgressPercentage(comments));
               setRemaining(next);
               return send(VERIFY);
             })

--- a/src/containers/Comments/Download/hooks.js
+++ b/src/containers/Comments/Download/hooks.js
@@ -7,7 +7,6 @@ import take from "lodash/fp/take";
 import takeRight from "lodash/fp/takeRight";
 import useFetchMachine from "src/hooks/utils/useFetchMachine";
 import fileDownload from "js-file-download";
-import { useLoader } from "src/containers/Loader";
 import {
   handleSaveCommentsTimetamps,
   loadCommentsTimestamps
@@ -28,7 +27,6 @@ export function useDownloadComments(token) {
 
 const TIMESTAMPS_PAGE_SIZE = 100;
 export function useDownloadCommentsTimestamps(recordToken) {
-  const { apiInfo } = useLoader();
   const [timestamps, setTimestamps] = useState(null);
   const [remaining, setRemaining] = useState([]);
   const [progress, setProgress] = useState(0);
@@ -56,8 +54,7 @@ export function useDownloadCommentsTimestamps(recordToken) {
   const makeTimestampsBundle = (timestamps) =>
     JSON.stringify(
       {
-        comments: timestamps.comments,
-        serverpublickey: apiInfo.pubkey
+        comments: timestamps.comments
       },
       null,
       2
@@ -136,8 +133,7 @@ export function useDownloadCommentsTimestamps(recordToken) {
     error: state.error,
     progress: progress,
     timestamps: {
-      comments: state.timestamps?.comments,
-      serverpublickey: apiInfo.pubkey
+      comments: state.timestamps?.comments
     }
   };
 }

--- a/src/containers/Comments/Download/hooks.js
+++ b/src/containers/Comments/Download/hooks.js
@@ -1,4 +1,4 @@
-import { createContext, useContext, useMemo, useState, useEffect } from "react";
+import { createContext, useContext, useMemo, useState, useEffect, useCallback } from "react";
 import * as sel from "src/selectors";
 import * as act from "src/actions";
 import { useSelector, useAction } from "src/redux";
@@ -48,8 +48,10 @@ export function useDownloadCommentsTimestamps(recordToken) {
     takeRight(commentIds.length - TIMESTAMPS_PAGE_SIZE)(commentIds)
   ];
 
-  const getProgressPercentage = (timestamps) => timestamps ?
-    (Object.keys(timestamps.length * 100) / commentsLength).toFixed(2) : 0;
+  const getProgressPercentage = useCallback((timestamps) => timestamps ?
+    (Object.keys(timestamps.length * 100) / commentsLength).toFixed(2) : 0,
+    [commentsLength]
+  );
 
   const makeTimestampsBundle = (timestamps) =>
     JSON.stringify(

--- a/src/containers/Proposal/Download/DownloadVotesTimestamps.jsx
+++ b/src/containers/Proposal/Download/DownloadVotesTimestamps.jsx
@@ -9,7 +9,10 @@ const DownloadVotesTimestampsWrapper = ({ label, recordToken, votesCount }) => {
   const [start, setStart] = useState(false);
 
   const ts = loadVotesTimestamps(recordToken);
-  const hasLoadedTimestamps = ts?.length === votesCount;
+  const hasProofs = ts?.votes?.reduce((acc, v) => 
+    acc && v.proofs.length > 0, true
+  );
+  const hasLoadedTimestamps = ts?.votes?.length === votesCount && hasProofs;
 
   return start || hasLoadedTimestamps ? (
     <DownloadVotesTimestamps

--- a/src/containers/Proposal/Download/DownloadVotesTimestamps.jsx
+++ b/src/containers/Proposal/Download/DownloadVotesTimestamps.jsx
@@ -9,7 +9,7 @@ const DownloadVotesTimestampsWrapper = ({ label, recordToken, votesCount }) => {
   const [start, setStart] = useState(false);
 
   const ts = loadVotesTimestamps(recordToken);
-  const hasProofs = ts?.votes?.reduce((acc, v) => 
+  const hasProofs = ts?.votes?.reduce((acc, v) =>
     acc && v.proofs.length > 0, true
   );
   const hasLoadedTimestamps = ts?.votes?.length === votesCount && hasProofs;

--- a/src/containers/Proposal/Download/hooks.js
+++ b/src/containers/Proposal/Download/hooks.js
@@ -26,7 +26,7 @@ export function useDownloadVoteTimestamps(token, votesCount) {
     actions: {
       initial: () => {
         const ts = loadVotesTimestamps(token);
-        const hasProofs = ts?.votes?.reduce((acc, v) => 
+        const hasProofs = ts?.votes?.reduce((acc, v) =>
           acc && v.proofs.length > 0, true
         );
         if (ts?.votes?.length === votesCount && hasProofs) {

--- a/src/containers/Proposal/Download/hooks.js
+++ b/src/containers/Proposal/Download/hooks.js
@@ -57,7 +57,7 @@ export function useDownloadVoteTimestamps(token, votesCount) {
         return send(FETCH);
       },
       verify: () => {
-        if (timestamps?.length === votesCount) {
+        if (timestamps?.votes?.length === votesCount) {
           // all timestamps loaded, resolve
           handleSaveVotesTimetamps(token, timestamps);
           setProgress(100);
@@ -76,7 +76,7 @@ export function useDownloadVoteTimestamps(token, votesCount) {
                   ...resp.votes
                 ]
               });
-              setProgress(((timestamps.length * 100) / votesCount).toFixed(2));
+              setProgress(((timestamps.votes.length * 100) / votesCount).toFixed(2));
               setPage(page + 1);
               return send(VERIFY);
             })

--- a/src/containers/Proposal/Download/hooks.js
+++ b/src/containers/Proposal/Download/hooks.js
@@ -36,7 +36,11 @@ export function useDownloadVoteTimestamps(token, votesCount) {
         // fetch first page of vote timestamps
         onFetchTicketVoteTimestamps(token, page)
           .then((resp) => {
-            setTimestamps(resp.votes);
+            setTimestamps({
+              auths: resp.auths,
+              details: resp.details,
+              votes: resp.votes
+            });
             setProgress(((resp.votes.length * 100) / votesCount).toFixed(2));
             setPage(page + 1);
             return send(VERIFY);
@@ -58,11 +62,17 @@ export function useDownloadVoteTimestamps(token, votesCount) {
         } else {
           onFetchTicketVoteTimestamps(token, page)
             .then((resp) => {
-              if (resp.votes) {
-                setTimestamps([...timestamps, ...resp.votes]);
-              } else {
-                return send(REJECT, "fetching outbound vote pages");
-              }
+              setTimestamps({
+                auths: [
+                  ...timestamps.auths,
+                  ...resp.auths
+                ],
+                details: resp.details,
+                votes: [
+                  ...timestamps.votes,
+                  ...resp.votes
+                ]
+              });
               setProgress(((timestamps.length * 100) / votesCount).toFixed(2));
               setPage(page + 1);
               return send(VERIFY);

--- a/src/containers/Proposal/Download/hooks.js
+++ b/src/containers/Proposal/Download/hooks.js
@@ -33,20 +33,27 @@ export function useDownloadVoteTimestamps(token, votesCount) {
         return;
       },
       start: () => {
-        // fetch first page of vote timestamps
-        onFetchTicketVoteTimestamps(token, page)
+        // fetch unpaginated data from vote timestamps
+        onFetchTicketVoteTimestamps(token)
           .then((resp) => {
             setTimestamps({
               auths: resp.auths,
-              details: resp.details,
-              votes: resp.votes
+              details: resp.details
             });
-            setProgress(((resp.votes.length * 100) / votesCount).toFixed(2));
-            setPage(page + 1);
-            return send(VERIFY);
+            // fetch first page of vote timestamps
+            onFetchTicketVoteTimestamps(token, page)
+              .then((resp) => {
+                setTimestamps({
+                  ...timestamps,
+                  votes: resp.votes
+                });
+                setProgress(((resp.votes.length * 100) / votesCount).toFixed(2));
+                setPage(page + 1);
+                return send(VERIFY);
+              })
+              .catch((e) => send(REJECT, e));
           })
           .catch((e) => send(REJECT, e));
-
         return send(FETCH);
       },
       verify: () => {
@@ -63,11 +70,7 @@ export function useDownloadVoteTimestamps(token, votesCount) {
           onFetchTicketVoteTimestamps(token, page)
             .then((resp) => {
               setTimestamps({
-                auths: [
-                  ...timestamps.auths,
-                  ...resp.auths
-                ],
-                details: resp.details,
+                ...timestamps,
                 votes: [
                   ...timestamps.votes,
                   ...resp.votes

--- a/src/containers/Proposal/Download/hooks.js
+++ b/src/containers/Proposal/Download/hooks.js
@@ -7,6 +7,7 @@ import {
   handleSaveVotesTimetamps,
   loadVotesTimestamps
 } from "src/lib/local_storage";
+import { useEffect } from "react";
 
 export function useDownloadVoteTimestamps(token, votesCount) {
   const [votes, setVotes] = useState(null);
@@ -17,6 +18,13 @@ export function useDownloadVoteTimestamps(token, votesCount) {
   const onFetchTicketVoteTimestamps = useAction(
     act.onFetchTicketVoteTimestamps
   );
+
+  const getProgressPercentage = (total) => total ?
+    ((total * 100) / votesCount).toFixed(2) : 0;
+
+  useEffect(() => {
+    setProgress(getProgressPercentage(votes?.length));
+  }, [getProgressPercentage, votes]);
 
   const [
     state,
@@ -47,7 +55,6 @@ export function useDownloadVoteTimestamps(token, votesCount) {
             onFetchTicketVoteTimestamps(token, page)
               .then((resp) => {
                 setVotes([...resp.votes]);
-                setProgress(((resp.votes?.length * 100) / votesCount).toFixed(2));
                 setPage(page + 1);
                 return send(VERIFY);
               })
@@ -59,7 +66,6 @@ export function useDownloadVoteTimestamps(token, votesCount) {
       verify: () => {
         if (votes?.length === votesCount) {
           // all timestamps loaded, resolve
-          setProgress(100);
           handleSaveVotesTimetamps(token, { auths, details, votes });
           fileDownload(
             JSON.stringify({ auths, details, votes }, null, 2),
@@ -74,7 +80,6 @@ export function useDownloadVoteTimestamps(token, votesCount) {
                 ...votes,
                 ...resp.votes
               ]);
-              setProgress(((votes?.length * 100) / votesCount).toFixed(2));
               setPage(page + 1);
               return send(VERIFY);
             })

--- a/src/containers/Proposal/Download/hooks.js
+++ b/src/containers/Proposal/Download/hooks.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import * as act from "src/actions";
 import fileDownload from "js-file-download";
 import { useAction } from "src/redux";
@@ -7,7 +7,6 @@ import {
   handleSaveVotesTimetamps,
   loadVotesTimestamps
 } from "src/lib/local_storage";
-import { useEffect } from "react";
 
 export function useDownloadVoteTimestamps(token, votesCount) {
   const [votes, setVotes] = useState(null);
@@ -19,8 +18,10 @@ export function useDownloadVoteTimestamps(token, votesCount) {
     act.onFetchTicketVoteTimestamps
   );
 
-  const getProgressPercentage = (total) => total ?
-    ((total * 100) / votesCount).toFixed(2) : 0;
+  const getProgressPercentage = useCallback((total) => total ?
+    ((total * 100) / votesCount).toFixed(2) : 0,
+    [votesCount]
+  );
 
   useEffect(() => {
     setProgress(getProgressPercentage(votes?.length));

--- a/src/reducers/models/proposalVotes.js
+++ b/src/reducers/models/proposalVotes.js
@@ -34,14 +34,14 @@ const proposalVotes = (state = DEFAULT_STATE, action) =>
             const normalizedSummaries = keys.reduce((acc, key) => ({
               ...acc,
               [key.substring(0, 7)]: action.payload.summaries[key]
-            }), {}) 
+            }), {});
             return compose(
               update("byToken", (voteSummaries) => ({
                 ...voteSummaries,
                 ...normalizedSummaries
               })),
               set("bestBlock", action.payload.bestblock)
-            )(state)
+            )(state);
           },
           [act.RECEIVE_VOTES_DETAILS]: () => {
             return update(["byToken", action.payload.token.substring(0, 7)], (voteSummaries) => ({
@@ -50,13 +50,13 @@ const proposalVotes = (state = DEFAULT_STATE, action) =>
                 auths: action.payload.auths,
                 details: action.payload.vote
               }
-            }))(state)
+            }))(state);
           },
           [act.RECEIVE_PROPOSAL_VOTE_RESULTS]: () => {
             return update(["byToken", action.payload.token.substring(0, 7)], (propVotes) => ({
               ...propVotes,
               votes: action.payload.votes
-            }))(state)
+            }))(state);
           },
           [act.RECEIVE_AUTHORIZE_VOTE]: () =>
             receiveVoteStatusChange(
@@ -75,7 +75,7 @@ const proposalVotes = (state = DEFAULT_STATE, action) =>
               state,
               action.payload.tokens,
               PROPOSAL_VOTING_ACTIVE
-            ),
+            )
         }[action.type] || (() => state)
       )();
 

--- a/src/reducers/models/proposalVotes.js
+++ b/src/reducers/models/proposalVotes.js
@@ -14,7 +14,7 @@ const DEFAULT_STATE = {
 };
 
 const receiveVoteStatusChange = (state, token, newStatus) =>
-  update(["byToken", token], (voteSummary) => ({
+  update(["byToken", token.substring(0, 7)], (voteSummary) => ({
     ...voteSummary,
     status: newStatus
   }))(state);
@@ -29,22 +29,35 @@ const proposalVotes = (state = DEFAULT_STATE, action) =>
     ? state
     : (
         {
-          [act.RECEIVE_PROPOSALS_VOTE_SUMMARY]: () =>
-            compose(
+          [act.RECEIVE_PROPOSALS_VOTE_SUMMARY]: () => {
+            const keys = Object.keys(action.payload.summaries);
+            const normalizedSummaries = keys.reduce((acc, key) => ({
+              ...acc,
+              [key.substring(0, 7)]: action.payload.summaries[key]
+            }), {}) 
+            return compose(
               update("byToken", (voteSummaries) => ({
                 ...voteSummaries,
-                ...action.payload.summaries
+                ...normalizedSummaries
               })),
               set("bestBlock", action.payload.bestblock)
-            )(state),
-          [act.RECEIVE_VOTES_DETAILS]: () =>
-            update(["byToken", action.payload.token], (voteSummaries) => ({
+            )(state)
+          },
+          [act.RECEIVE_VOTES_DETAILS]: () => {
+            return update(["byToken", action.payload.token.substring(0, 7)], (voteSummaries) => ({
               ...voteSummaries,
               details: {
                 auths: action.payload.auths,
                 details: action.payload.vote
               }
-            }))(state),
+            }))(state)
+          },
+          [act.RECEIVE_PROPOSAL_VOTE_RESULTS]: () => {
+            return update(["byToken", action.payload.token.substring(0, 7)], (propVotes) => ({
+              ...propVotes,
+              votes: action.payload.votes
+            }))(state)
+          },
           [act.RECEIVE_AUTHORIZE_VOTE]: () =>
             receiveVoteStatusChange(
               state,
@@ -63,11 +76,6 @@ const proposalVotes = (state = DEFAULT_STATE, action) =>
               action.payload.tokens,
               PROPOSAL_VOTING_ACTIVE
             ),
-          [act.RECEIVE_PROPOSAL_VOTE_RESULTS]: () =>
-            update(["byToken", action.payload.token], (propVotes) => ({
-              ...propVotes,
-              votes: action.payload.votes
-            }))(state)
         }[action.type] || (() => state)
       )();
 


### PR DESCRIPTION
This diff fixes the comment bundle/timestamp structure, and the votes timestamp structure, available for download from the GUI. It also solves a type error that might occur when votesummary details is not yet loaded.

edit: This PR now also normalizes `proposalVotes` state. We were saving both full token state and short token state, which would lead to inconsistencies on our single source of truth.