### PR TITLE
fix: make sure all vote data is consistent on redux state

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -1327,7 +1327,7 @@ export const onFetchVotesDetails = (token) =>
   withCsrf((dispatch, _, csrf) => {
     dispatch(act.REQUEST_VOTES_DETAILS({ token }));
     return api
-      .votesDetails(csrf, token)
+      .proposalVoteDetails(csrf, token)
       .then((response) =>
         dispatch(
           act.RECEIVE_VOTES_DETAILS({

--- a/src/containers/Proposal/Detail/hooks.js
+++ b/src/containers/Proposal/Detail/hooks.js
@@ -70,7 +70,7 @@ export function useProposal(token, proposalState, threadParentID) {
 
   const isMissingDetails = !(proposal && getDetailsFile(proposal.files));
   const isMissingVoteSummary = !(
-    voteSummaries[tokenShort] && 
+    voteSummaries[tokenShort] &&
     voteSummaries[tokenShort].details &&
     voteSummaries[tokenShort].votes
   );

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -638,6 +638,9 @@ export const proposalsBatchVoteSummary = (csrf, tokens) =>
 export const proposalVoteResults = (csrf, token) =>
   POST("/results", csrf, { token }, apiTicketVote).then(getResponse);
 
+export const proposalVoteDetails = (csrf, token) =>
+  POST("/details", csrf, { token }, apiTicketVote).then(getResponse);
+
 export const proposalSubmissions = (token) =>
   POST("/submissions", "", { token }, apiTicketVote).then(getResponse);
 
@@ -699,8 +702,6 @@ export const votesInventory = (status, page) =>
 export const recordsTimestamp = (csrf, token, version) =>
   POST("/timestamps", csrf, { token, version }, apiRecords).then(getResponse);
 
-export const votesDetails = (csrf, token) =>
-  POST("/details", csrf, { token }, apiTicketVote).then(getResponse);
 
 // CMS
 

--- a/src/reducers/models/proposalVotes.js
+++ b/src/reducers/models/proposalVotes.js
@@ -31,13 +31,13 @@ const proposalVotes = (state = DEFAULT_STATE, action) =>
         {
           [act.RECEIVE_PROPOSALS_VOTE_SUMMARY]: () => {
             const keys = Object.keys(action.payload.summaries);
-            const normalizedSummaries = keys.reduce(
-              (acc, key) => ({
-                ...acc,
-                [key.substring(0, 7)]: action.payload.summaries[key]
-              }),
-              {}
-            );
+            const normalizedSummaries = keys.reduce((acc, key) => ({
+              ...acc,
+              [key.substring(0, 7)]: {
+                ...state.byToken[key.substring(0, 7)],
+                ...action.payload.summaries[key]
+              }
+            }), {});
             return compose(
               update("byToken", (voteSummaries) => ({
                 ...voteSummaries,
@@ -47,25 +47,19 @@ const proposalVotes = (state = DEFAULT_STATE, action) =>
             )(state);
           },
           [act.RECEIVE_VOTES_DETAILS]: () => {
-            return update(
-              ["byToken", action.payload.token.substring(0, 7)],
-              (voteSummaries) => ({
-                ...voteSummaries,
-                details: {
-                  auths: action.payload.auths,
-                  details: action.payload.vote
-                }
-              })
-            )(state);
+            return update(["byToken", action.payload.token.substring(0, 7)], (voteSummary) => ({
+              ...voteSummary,
+              details: {
+                auths: action.payload.auths,
+                details: action.payload.vote
+              }
+            }))(state);
           },
           [act.RECEIVE_PROPOSAL_VOTE_RESULTS]: () => {
-            return update(
-              ["byToken", action.payload.token.substring(0, 7)],
-              (propVotes) => ({
-                ...propVotes,
-                votes: action.payload.votes
-              })
-            )(state);
+            return update(["byToken", action.payload.token.substring(0, 7)], (voteSummary) => ({
+              ...voteSummary,
+              votes: action.payload.votes
+            }))(state);
           },
           [act.RECEIVE_AUTHORIZE_VOTE]: () =>
             receiveVoteStatusChange(

--- a/src/selectors/api.js
+++ b/src/selectors/api.js
@@ -20,6 +20,7 @@ export const isApiRequestingPropVoteResults = getIsApiRequesting(
 export const isApiRequestingProposalsVoteSummary = getIsApiRequesting(
   "proposalsVoteSummary"
 );
+export const isApiRequestingVotesDetails = getIsApiRequesting("votesDetails");
 export const isApiRequestingEditUser = getIsApiRequesting("editUser");
 export const isApiRequestingProposalPaywall = getIsApiRequesting(
   "proposalPaywallDetails"
@@ -35,6 +36,11 @@ export const isApiRequestingLikeComment = get([
 export const proposalIsRequesting = or(
   isApiRequestingInit,
   isApiRequestingProposal
+);
+export const isApiRequestingVoteSummary = or(
+  isApiRequestingProposalsVoteSummary,
+  isApiRequestingPropVoteResults,
+  isApiRequestingVotesDetails
 );
 export const isApiRequestingRescanUserPayments = getIsApiRequesting(
   "rescanUserPayments"


### PR DESCRIPTION
This diff makes sure that all vote data is loaded properly and consistent on our `proposalVotes` state when accessing the details of a proposal with an ongoing/finished vote.