### PR TITLE
feat: include registration fee to the purchases history table

### DIFF
--- a/src/containers/Comments/Download/hooks.js
+++ b/src/containers/Comments/Download/hooks.js
@@ -1,4 +1,11 @@
-import { createContext, useContext, useMemo, useState, useEffect, useCallback } from "react";
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+  useEffect,
+  useCallback
+} from "react";
 import * as sel from "src/selectors";
 import * as act from "src/actions";
 import { useSelector, useAction } from "src/redux";
@@ -48,8 +55,11 @@ export function useDownloadCommentsTimestamps(recordToken) {
     takeRight(commentIds.length - TIMESTAMPS_PAGE_SIZE)(commentIds)
   ];
 
-  const getProgressPercentage = useCallback((timestamps) => timestamps ?
-    (Object.keys(timestamps.length * 100) / commentsLength).toFixed(2) : 0,
+  const getProgressPercentage = useCallback(
+    (timestamps) =>
+      timestamps
+        ? (Object.keys(timestamps.length * 100) / commentsLength).toFixed(2)
+        : 0,
     [commentsLength]
   );
 

--- a/src/containers/Proposal/Download/DownloadVotesTimestamps.jsx
+++ b/src/containers/Proposal/Download/DownloadVotesTimestamps.jsx
@@ -9,8 +9,9 @@ const DownloadVotesTimestampsWrapper = ({ label, recordToken, votesCount }) => {
   const [start, setStart] = useState(false);
 
   const ts = loadVotesTimestamps(recordToken);
-  const hasProofs = ts?.votes?.reduce((acc, v) =>
-    acc && v.proofs.length > 0, true
+  const hasProofs = ts?.votes?.reduce(
+    (acc, v) => acc && v.proofs.length > 0,
+    true
   );
   const hasLoadedTimestamps = ts?.votes?.length === votesCount && hasProofs;
 

--- a/src/containers/Proposal/Download/hooks.js
+++ b/src/containers/Proposal/Download/hooks.js
@@ -18,8 +18,8 @@ export function useDownloadVoteTimestamps(token, votesCount) {
     act.onFetchTicketVoteTimestamps
   );
 
-  const getProgressPercentage = useCallback((total) => total ?
-    ((total * 100) / votesCount).toFixed(2) : 0,
+  const getProgressPercentage = useCallback(
+    (total) => (total ? ((total * 100) / votesCount).toFixed(2) : 0),
     [votesCount]
   );
 
@@ -35,8 +35,9 @@ export function useDownloadVoteTimestamps(token, votesCount) {
     actions: {
       initial: () => {
         const ts = loadVotesTimestamps(token);
-        const hasProofs = ts?.votes?.reduce((acc, v) =>
-          acc && v.proofs.length > 0, true
+        const hasProofs = ts?.votes?.reduce(
+          (acc, v) => acc && v.proofs.length > 0,
+          true
         );
         if (ts?.votes?.length === votesCount && hasProofs) {
           return send(RESOLVE, ts);
@@ -50,7 +51,7 @@ export function useDownloadVoteTimestamps(token, votesCount) {
         // fetch unpaginated data from vote timestamps
         onFetchTicketVoteTimestamps(token)
           .then((resp) => {
-            setAuths([ ...resp.auths ]);
+            setAuths([...resp.auths]);
             setDetails({ ...resp.details });
             // fetch first page of vote timestamps
             onFetchTicketVoteTimestamps(token, page)
@@ -77,10 +78,7 @@ export function useDownloadVoteTimestamps(token, votesCount) {
           // more timestamps remaining, fetch next page
           onFetchTicketVoteTimestamps(token, page)
             .then((resp) => {
-              setVotes([
-                ...votes,
-                ...resp.votes
-              ]);
+              setVotes([...votes, ...resp.votes]);
               setPage(page + 1);
               return send(VERIFY);
             })

--- a/src/containers/User/Detail/Credits/components/CreditHistorySection.jsx
+++ b/src/containers/User/Detail/Credits/components/CreditHistorySection.jsx
@@ -4,6 +4,8 @@ import {
   getTableContentFromPurchases,
   tableHeaders
 } from "../helpers.js";
+import { PAYWALL_STATUS_PAID } from "src/constants";
+import usePaywall from "src/hooks/api/usePaywall";
 import { useCredits } from "../hooks.js";
 import { Table, Text, Link, useMediaQuery } from "pi-ui";
 import ExportToCsv from "src/components/ExportToCsv.jsx";
@@ -16,8 +18,22 @@ export default ({ proposalCreditPrice, user }) => {
     proposalPaywallPaymentTxid,
     proposalPaywallPaymentAmount
   } = useCredits(userID);
+  const {
+    paywallTxNotBefore,
+    paywallAmount,
+    paywallTxId,
+    userPaywallStatus
+  } = usePaywall(userID);
+  const paywallPayment = {
+    datePurchased: paywallTxNotBefore,
+    numberPurchased: 1,
+    price: paywallAmount,
+    txId: paywallTxId,
+    type: "fee"
+  };
+  const allPurchases = PAYWALL_STATUS_PAID === userPaywallStatus ? [...proposalCreditsPurchases, paywallPayment] : proposalCreditsPurchases;
   const data = getTableContentFromPurchases(
-    proposalCreditsPurchases,
+    allPurchases,
     {
       confirmations: proposalPaywallPaymentConfirmations,
       txID: proposalPaywallPaymentTxid,
@@ -34,7 +50,7 @@ export default ({ proposalCreditPrice, user }) => {
       style={!extraSmall ? { overflowX: "scroll" } : {}}>
       <Text className="margin-right-xs">Credit History</Text>
       <ExportToCsv
-        data={getCsvData(proposalCreditsPurchases)}
+        data={getCsvData(allPurchases)}
         fields={["numberPurchased", "price", "txId", "datePurchased", "type"]}
         filename="payment_history">
         <Link style={{ cursor: "pointer" }}>Export to csv</Link>

--- a/src/containers/User/Detail/Credits/components/CreditHistorySection.jsx
+++ b/src/containers/User/Detail/Credits/components/CreditHistorySection.jsx
@@ -31,7 +31,10 @@ export default ({ proposalCreditPrice, user }) => {
     txId: paywallTxId,
     type: "fee"
   };
-  const allPurchases = PAYWALL_STATUS_PAID === userPaywallStatus ? [...proposalCreditsPurchases, paywallPayment] : proposalCreditsPurchases;
+  const allPurchases =
+    PAYWALL_STATUS_PAID === userPaywallStatus
+      ? [...proposalCreditsPurchases, paywallPayment]
+      : proposalCreditsPurchases;
   const data = getTableContentFromPurchases(
     allPurchases,
     {

--- a/src/containers/User/Detail/Credits/helpers.js
+++ b/src/containers/User/Detail/Credits/helpers.js
@@ -26,12 +26,11 @@ const getRowDataForPurchase = (purchase) => ({
   "DCRs Paid": purchase.price
     ? (purchase.price * purchase.numberPurchased).toFixed(1)
     : 0,
-  Transaction:
-    manuallyCleared.includes(purchase.txId) ? (
-      purchase.txId
-    ) : (
-      <DcrTransactionLink txID={purchase.txId} />
-    ),
+  Transaction: manuallyCleared.includes(purchase.txId) ? (
+    purchase.txId
+  ) : (
+    <DcrTransactionLink txID={purchase.txId} />
+  ),
   Status: purchase.confirming ? (
     <StatusTag type="bluePending" text="Waiting for confirmations" />
   ) : (
@@ -49,7 +48,8 @@ export const getTableContentFromPurchases = (
   purchases,
   pendingTransaction,
   creditPrice
-) => orderBy(
+) =>
+  orderBy(
     ["timestamp"],
     ["desc"]
   )(

--- a/src/containers/User/Detail/Credits/helpers.js
+++ b/src/containers/User/Detail/Credits/helpers.js
@@ -18,14 +18,16 @@ export const tableHeaders = [
   "Date"
 ];
 
-const getRowDataForCreditsPurchase = (purchase) => ({
-  Type: "Credits",
+const manuallyCleared = ["created_by_dbutil", "cleared_by_admin"];
+
+const getRowDataForPurchase = (purchase) => ({
+  Type: purchase.type === "fee" ? "Registration Fee" : "Credits",
   Amount: purchase.numberPurchased,
   "DCRs Paid": purchase.price
     ? (purchase.price * purchase.numberPurchased).toFixed(1)
     : 0,
   Transaction:
-    purchase.txId === "created_by_dbutil" ? (
+    manuallyCleared.includes(purchase.txId) ? (
       purchase.txId
     ) : (
       <DcrTransactionLink txID={purchase.txId} />
@@ -44,18 +46,17 @@ const getRowDataForCreditsPurchase = (purchase) => ({
 });
 
 export const getTableContentFromPurchases = (
-  proposalCreditPurchases,
+  purchases,
   pendingTransaction,
   creditPrice
-) =>
-  orderBy(
+) => orderBy(
     ["timestamp"],
     ["desc"]
   )(
-    proposalCreditPurchases.map(getRowDataForCreditsPurchase).concat(
+    purchases.map(getRowDataForPurchase).concat(
       pendingTransaction && pendingTransaction.txID
         ? [
-            getRowDataForCreditsPurchase({
+            getRowDataForPurchase({
               numberPurchased: Math.round(
                 (pendingTransaction.amount * 1) / (creditPrice * 100000000)
               ),
@@ -80,7 +81,7 @@ export const getCsvData = (data) =>
       datePurchased: d.datePurchased
         ? formatUnixTimestamp(d.datePurchased)
         : "",
-      price: d.type === "fee" ? "" : d.price,
+      price: d.price,
       type: d.type === "fee" ? "registration fee" : "credits"
     }));
 

--- a/src/hooks/api/usePaywall.js
+++ b/src/hooks/api/usePaywall.js
@@ -10,9 +10,10 @@ function usePaywall(userID) {
   const paywallAddress = useSelector(sel.currentUserPaywallAddress);
   const paywallAmount = useSelector(sel.currentUserPaywallAmount);
   const paywallTxNotBefore = useSelector(sel.currentUserPaywallTxNotBefore);
+  const paywallTxId = useSelector(sel.currentUserPaywallTxid);
   const userIsPaidSelector = useMemo(() => sel.makeGetUserIsPaid(uuid), [uuid]);
   const userPaywallStatusSelector = useMemo(
-    () => sel.makeGetPaywallAddress(uuid),
+    () => sel.makeGetUserPaywallStatus(uuid),
     [uuid]
   );
   const userIsPaid = useSelector(userIsPaidSelector);
@@ -24,6 +25,7 @@ function usePaywall(userID) {
     currentUserEmail,
     paywallAddress,
     paywallAmount,
+    paywallTxId,
     paywallTxNotBefore,
     userPaywallStatus,
     isPaid: userIsPaid,

--- a/src/reducers/models/proposalVotes.js
+++ b/src/reducers/models/proposalVotes.js
@@ -31,10 +31,13 @@ const proposalVotes = (state = DEFAULT_STATE, action) =>
         {
           [act.RECEIVE_PROPOSALS_VOTE_SUMMARY]: () => {
             const keys = Object.keys(action.payload.summaries);
-            const normalizedSummaries = keys.reduce((acc, key) => ({
-              ...acc,
-              [key.substring(0, 7)]: action.payload.summaries[key]
-            }), {});
+            const normalizedSummaries = keys.reduce(
+              (acc, key) => ({
+                ...acc,
+                [key.substring(0, 7)]: action.payload.summaries[key]
+              }),
+              {}
+            );
             return compose(
               update("byToken", (voteSummaries) => ({
                 ...voteSummaries,
@@ -44,19 +47,25 @@ const proposalVotes = (state = DEFAULT_STATE, action) =>
             )(state);
           },
           [act.RECEIVE_VOTES_DETAILS]: () => {
-            return update(["byToken", action.payload.token.substring(0, 7)], (voteSummaries) => ({
-              ...voteSummaries,
-              details: {
-                auths: action.payload.auths,
-                details: action.payload.vote
-              }
-            }))(state);
+            return update(
+              ["byToken", action.payload.token.substring(0, 7)],
+              (voteSummaries) => ({
+                ...voteSummaries,
+                details: {
+                  auths: action.payload.auths,
+                  details: action.payload.vote
+                }
+              })
+            )(state);
           },
           [act.RECEIVE_PROPOSAL_VOTE_RESULTS]: () => {
-            return update(["byToken", action.payload.token.substring(0, 7)], (propVotes) => ({
-              ...propVotes,
-              votes: action.payload.votes
-            }))(state);
+            return update(
+              ["byToken", action.payload.token.substring(0, 7)],
+              (propVotes) => ({
+                ...propVotes,
+                votes: action.payload.votes
+              })
+            )(state);
           },
           [act.RECEIVE_AUTHORIZE_VOTE]: () =>
             receiveVoteStatusChange(


### PR DESCRIPTION
Closes #2317 

### Solution description

Now using the `usePaywall` hook to add registration paywall info to the history table.

### Dependencies

Depends on https://github.com/decred/politeia/pull/1386

### UI Changes Screenshot

<img width="921" alt="Screen Shot 2021-04-05 at 17 53 43" src="https://user-images.githubusercontent.com/13955303/113625895-dff9f480-9637-11eb-8ba7-2d7376a8806c.png">
