### PR TITLE
fix: get RFP submissions vote summaries using short token

### DIFF
--- a/src/components/ProposalsList/ProposalItem.jsx
+++ b/src/components/ProposalsList/ProposalItem.jsx
@@ -35,7 +35,7 @@ import { useRouter } from "src/components/Router";
 
 const ProposalItem = ({
   proposal,
-  proposal: { comments, name, censorshiprecord },
+  proposal: { commentsCount, name, censorshiprecord },
   voteSummary
 }) => {
   const { history } = useRouter();
@@ -75,7 +75,7 @@ const ProposalItem = ({
           </Link>
           <CommentsLink
             showIcon={false}
-            numOfComments={comments}
+            numOfComments={commentsCount}
             url={commentsURL}
             className={styles.commentsLink}
           />

--- a/src/components/ProposalsList/ProposalsList.jsx
+++ b/src/components/ProposalsList/ProposalsList.jsx
@@ -40,7 +40,9 @@ const ProposalsList = ({ data: { proposals, voteSummaries } }) => {
               key={index}
               proposal={proposal}
               voteSummary={
-                voteSummaries[proposals[index].censorshiprecord.token]
+                voteSummaries[
+                  proposals[index]?.censorshiprecord.token.substring(0, 7)
+                ]
               }
             />
           ))

--- a/src/containers/Proposal/Detail/hooks.js
+++ b/src/containers/Proposal/Detail/hooks.js
@@ -63,7 +63,10 @@ export function useProposal(token, proposalState, threadParentID) {
   const rfpSubmissions = rfpLinks &&
     proposal.linkby && {
       proposals: values(pick(proposals, rfpLinks)),
-      voteSummaries: pick(voteSummaries, rfpLinks)
+      voteSummaries: pick(
+        voteSummaries,
+        rfpLinks.map((l) => l.substring(0, 7))
+      )
     };
 
   const isRfp = proposal && !!proposal.linkby;

--- a/src/containers/Proposal/helpers.js
+++ b/src/containers/Proposal/helpers.js
@@ -25,13 +25,16 @@ import {
   NOJS_ROUTE_PREFIX,
   PROPOSAL_VOTING_REJECTED,
   PROPOSAL_VOTING_INELIGIBLE,
-  INELIGIBLE
+  INELIGIBLE,
+  PROPOSAL_PAGE_SIZE
 } from "../../constants";
 import { getTextFromIndexMd } from "src/helpers";
 import set from "lodash/fp/set";
 import values from "lodash/fp/values";
 import pick from "lodash/pick";
 import isEmpty from "lodash/fp/isEmpty";
+import take from "lodash/fp/take";
+import takeRight from "lodash/fp/takeRight";
 import get from "lodash/fp/get";
 
 /**
@@ -365,7 +368,7 @@ export const getProposalRfpLinks = (proposal, rfpSubmissions, proposals) => {
   return hasRfpSubmissions
     ? { ...proposal, rfpSubmissions }
     : isSubmissionWithProposals
-    ? { ...proposal, proposedFor: proposals[proposal.linkto].name }
+    ? { ...proposal, proposedFor: proposals[proposal.linkto]?.name }
     : proposal;
 };
 
@@ -402,3 +405,13 @@ export const getProposalLink = (proposal, isJsEnabled) =>
         proposal.state
       )
     : "";
+
+/**
+ * Returns a [batch, rest] pair given the batch page size from tokens array
+ * @param {*} tokens
+ * @param {*} pageSize
+ */
+export const getTokensForProposalsPagination = (
+  tokens,
+  pageSize = PROPOSAL_PAGE_SIZE
+) => [take(pageSize)(tokens), takeRight(tokens.length - pageSize)(tokens)];

--- a/src/hooks/api/useProposalsBatch.js
+++ b/src/hooks/api/useProposalsBatch.js
@@ -17,8 +17,6 @@ import uniq from "lodash/fp/uniq";
 import map from "lodash/fp/map";
 import reduce from "lodash/fp/reduce";
 import flow from "lodash/fp/flow";
-import take from "lodash/fp/take";
-import takeRight from "lodash/fp/takeRight";
 import isEmpty from "lodash/fp/isEmpty";
 import keys from "lodash/fp/keys";
 import difference from "lodash/fp/difference";
@@ -30,7 +28,8 @@ import {
 } from "src/constants";
 import {
   getRfpLinkedProposals,
-  getProposalStatusLabel
+  getProposalStatusLabel,
+  getTokensForProposalsPagination
 } from "src/containers/Proposal/helpers";
 
 const getRfpLinks = (proposals) =>
@@ -51,11 +50,6 @@ const getRfpSubmissions = (proposals) =>
 
 const getUnfetchedTokens = (proposals, tokens) =>
   difference(tokens)(keys(proposals));
-
-const getTokensForProposalsPagination = (
-  tokens,
-  pageSize = PROPOSAL_PAGE_SIZE
-) => [take(pageSize)(tokens), takeRight(tokens.length - pageSize)(tokens)];
 
 const getCurrentPage = (tokens) => {
   return tokens ? Math.floor(+tokens.length / INVENTORY_PAGE_SIZE) : 0;


### PR DESCRIPTION
This diff closes #2316, a bug that caused RFP Submissions to not be displayed.

### Solution description

The `voteSummaries` filter for the RFP submissions was not considering the possibility of having short tokens. This diff fixes it.

### Dependencies

Depends on #2315 