### PR TITLE
Fix proposals state after status change

### DIFF
--- a/src/reducers/models/proposals.js
+++ b/src/reducers/models/proposals.js
@@ -180,8 +180,8 @@ const proposals = (state = DEFAULT_STATE, action) =>
               set("newProposalToken", action.payload.censorshiprecord.token)
             )(state);
           },
-          [act.RECEIVE_SETSTATUS_PROPOSAL]: () => {
-            return compose(
+          [act.RECEIVE_SETSTATUS_PROPOSAL]: () =>
+            compose(
               updateProposalRfpLinks(action.payload.proposal),
               set(
                 ["byToken", proposalToken(action.payload.proposal)],
@@ -213,8 +213,7 @@ const proposals = (state = DEFAULT_STATE, action) =>
                   [mapStatusToName[action.payload.proposal.status]]: newArr
                 };
               })
-            )(state);
-          },
+            )(state),
           [act.RECEIVE_USER_PROPOSALS]: () =>
             compose(
               update("byToken", (proposals) => ({

--- a/src/reducers/models/proposals.js
+++ b/src/reducers/models/proposals.js
@@ -113,17 +113,14 @@ const updateProposalRfpLinks = (proposal) => (state) => {
 const updateInventory = (payload) => (allProps) => {
   return {
     ...allProps,
-    ...Object.keys(payload).reduce(
-      (res, status) => {
-        const propsStatus = allProps[status] ? allProps[status] : [];
-        const payloadStatus = payload[status] ? payload[status] : [];
-        return ({
-          ...res,
-          [status]: [...new Set([...propsStatus, ...payloadStatus])]
-        });
-      },
-      {}
-    )
+    ...Object.keys(payload).reduce((res, status) => {
+      const propsStatus = allProps[status] ? allProps[status] : [];
+      const payloadStatus = payload[status] ? payload[status] : [];
+      return {
+        ...res,
+        [status]: [...new Set([...propsStatus, ...payloadStatus])]
+      };
+    }, {})
   };
 };
 
@@ -201,16 +198,20 @@ const proposals = (state = DEFAULT_STATE, action) =>
                 )
               ),
               update(["allByRecordStatus"], (props) => {
-                const statusTokensArray = props[mapStatusToName[action.payload.proposal.status]];
-                const proposalToken = action.payload.proposal.censorshiprecord.token;
-                const newArr = statusTokensArray ? [...statusTokensArray, proposalToken] : [proposalToken];
+                const statusTokensArray =
+                  props[mapStatusToName[action.payload.proposal.status]];
+                const proposalToken =
+                  action.payload.proposal.censorshiprecord.token;
+                const newArr = statusTokensArray
+                  ? [...statusTokensArray, proposalToken]
+                  : [proposalToken];
                 return {
                   ...props,
-                  [mapStatusToName[action.payload.oldStatus]]: props[mapStatusToName[action.payload.oldStatus]].filter(
-                  (p) => p !== proposalToken
-                  ),
+                  [mapStatusToName[action.payload.oldStatus]]: props[
+                    mapStatusToName[action.payload.oldStatus]
+                  ].filter((p) => p !== proposalToken),
                   [mapStatusToName[action.payload.proposal.status]]: newArr
-              };
+                };
               })
             )(state);
           },


### PR DESCRIPTION
Closes https://github.com/decred/politeiagui/issues/2324

### Solution description

The previous implementation of `RECEIVE_SETSTATUS_PROPOSAL` was replacing the `allByRecordStatus` object by an array of tokens, which is wrong. I fixed it so it updates the object keys correctly. Also removing duplicates on `updateInventory `