### PR TITLE
Add policy for the new backend APIs

### DIFF
--- a/src/components/AttachFileInput/AttachFileInput.jsx
+++ b/src/components/AttachFileInput/AttachFileInput.jsx
@@ -2,14 +2,11 @@ import React, { useCallback } from "react";
 import { classNames } from "pi-ui";
 import styles from "./AttachFileInput.module.css";
 import attachSVG from "./attach-file.svg";
-import usePolicy from "src/hooks/api/usePolicy";
 import ModalAttachFiles from "src/components/ModalAttachFiles";
 import useModalContext from "src/hooks/utils/useModalContext";
 
 const AttachFiles = ({ onChange, label, small, acceptedFiles, ...props }) => {
-  const { policy } = usePolicy();
   const [handleOpenModal, handleCloseModal] = useModalContext();
-
   const handleOnChange = useCallback(
     (v) => {
       onChange(v);
@@ -21,7 +18,6 @@ const AttachFiles = ({ onChange, label, small, acceptedFiles, ...props }) => {
   const openAttachModal = () => {
     handleOpenModal(ModalAttachFiles, {
       acceptedFiles,
-      policy,
       onChange: handleOnChange,
       onClose: handleCloseModal
     });

--- a/src/components/ModalAttachFiles/ModalAttachFiles.jsx
+++ b/src/components/ModalAttachFiles/ModalAttachFiles.jsx
@@ -10,7 +10,7 @@ const ModalAttachFiles = ({
   onChange,
   onClose
 }) => {
-  const { policy } = usePolicy();
+  const { policyPi: policy } = usePolicy();
   return (
     <Modal title={title} show={show} onClose={onClose}>
       <div className={styles.wrapper}>
@@ -19,7 +19,7 @@ const ModalAttachFiles = ({
           <P>
             Valid MIME types - image/png <br />
             Max image size - 512kb <br />
-            Max number of files - {policy.maximages}
+            Max number of files - {policy.imagefilecountmax}
           </P>
         )}
         <P className={styles.greyText}>

--- a/src/components/ModalStartVote/ModalStartVote.jsx
+++ b/src/components/ModalStartVote/ModalStartVote.jsx
@@ -51,7 +51,7 @@ const ModalStartVote = ({
   const { apiInfo } = useLoaderContext();
   const { theme } = useTheme();
   const {
-    policy: { minlinkbyperiod, minvoteduration, maxvoteduration }
+    policyTicketVote: { linkbyperiodmin, votedurationmin, votedurationmax }
   } = usePolicy();
   const successIconBgColor = getThemeProperty(
     theme,
@@ -71,9 +71,9 @@ const ModalStartVote = ({
       if (
         isRfp &&
         voteType === VOTE_TYPE_STANDARD &&
-        !isRfpReadyToVote(linkby, minlinkbyperiod)
+        !isRfpReadyToVote(linkby, linkbyperiodmin)
       ) {
-        const days = minlinkbyperiod / (24 * 3600);
+        const days = linkbyperiodmin / (24 * 3600);
         throw Error(
           `RFP deadline should meet the minimum period to start voting which is about ${days} days from when the vote starts`
         );
@@ -96,7 +96,7 @@ const ModalStartVote = ({
   );
 
   const initialValues = {
-    duration: getBlockDurationArray(minvoteduration, maxvoteduration)[0],
+    duration: getBlockDurationArray(votedurationmin, votedurationmax)[0],
     quorumPercentage: 20,
     passPercentage: 60
   };
@@ -174,8 +174,8 @@ const ModalStartVote = ({
                   vertical
                   options={getDurationOptions(
                     apiInfo.testnet,
-                    minvoteduration,
-                    maxvoteduration
+                    votedurationmin,
+                    votedurationmax
                   )}
                   value={values.duration}
                   onChange={handleChangeDuration}

--- a/src/components/ProposalForm/ProposalForm.jsx
+++ b/src/components/ProposalForm/ProposalForm.jsx
@@ -101,7 +101,7 @@ const ProposalForm = React.memo(function ProposalForm({
   const smallTablet = useMediaQuery("(max-width: 685px)");
   const { themeName } = useTheme();
   const {
-    policy: { minlinkbyperiod, maxlinkbyperiod }
+    policyTicketVote: { linkbyperiodmin, linkbyperiodmax }
   } = usePolicy();
   const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
   const isRfp = values.type === PROPOSAL_TYPE_RFP;
@@ -117,8 +117,8 @@ const ProposalForm = React.memo(function ProposalForm({
   const selectOptions = useMemo(() => getProposalTypeOptionsForSelect(), []);
 
   const deadlineRange = useMemo(
-    () => getRfpMinMaxDates(minlinkbyperiod, maxlinkbyperiod),
-    [maxlinkbyperiod, minlinkbyperiod]
+    () => getRfpMinMaxDates(linkbyperiodmin, linkbyperiodmax),
+    [linkbyperiodmin, linkbyperiodmax]
   );
 
   const handleSelectFiledChange = useCallback(

--- a/src/components/ProposalForm/helpers.js
+++ b/src/components/ProposalForm/helpers.js
@@ -13,15 +13,15 @@ const typesLabels = {
 
 /**
  * Returns the available dates range as objects { min,max } for RFP linkby
- * using policy provided values
- * @param {number} minlinkbyperiod min possible linkby period as seconds unix
- * @param {number} maxlinkbyperiod max possible linkby period as seconds unix
+ * using policy[ticketvote] provided values
+ * @param {number} linkbyperiodmin min possible linkby period as seconds unix
+ * @param {number} linkbyperiodmax max possible linkby period as seconds unix
  */
-export const getRfpMinMaxDates = (minlinkbyperiod, maxlinkbyperiod) => {
+export const getRfpMinMaxDates = (linkbyperiodmin, linkbyperiodmax) => {
   const currentTimeSec = new Date().getTime() / 1000;
   return {
-    min: formatUnixTimestampToObj(currentTimeSec + Number(minlinkbyperiod)),
-    max: formatUnixTimestampToObj(currentTimeSec + Number(maxlinkbyperiod))
+    min: formatUnixTimestampToObj(currentTimeSec + Number(linkbyperiodmin)),
+    max: formatUnixTimestampToObj(currentTimeSec + Number(linkbyperiodmax))
   };
 };
 

--- a/src/components/ProposalForm/hooks.js
+++ b/src/components/ProposalForm/hooks.js
@@ -4,13 +4,13 @@ import * as act from "src/actions";
 import { proposalValidation } from "./validation";
 
 export function useProposalForm() {
-  const { policy } = usePolicy();
+  const { policyPi } = usePolicy();
   const onFetchProposalsBatchWithoutState = useAction(
     act.onFetchProposalsBatchWithoutState
   );
   return {
-    proposalFormValidation: policy && proposalValidation(policy),
+    proposalFormValidation: policyPi && proposalValidation(policyPi),
     onFetchProposalsBatchWithoutState,
-    policy
+    policy: policyPi
   };
 }

--- a/src/components/ProposalForm/validation.js
+++ b/src/components/ProposalForm/validation.js
@@ -13,9 +13,9 @@ import {
 } from "src/constants";
 
 export const proposalValidation = ({
-  proposalnamesupportedchars,
-  maxproposalnamelength,
-  minproposalnamelength
+  namesupportedchars,
+  namelengthmax,
+  namelengthmin
 }) => (values) => {
   const errors = {};
   if (!values) {
@@ -48,9 +48,9 @@ export const proposalValidation = ({
   // name validation
   const nameErrors = validateProposalName(
     values.name,
-    proposalnamesupportedchars,
-    minproposalnamelength,
-    maxproposalnamelength
+    namesupportedchars,
+    namelengthmin,
+    namelengthmax
   );
   if (nameErrors) errors.name = nameErrors;
 
@@ -77,21 +77,21 @@ const validateRfpSubmissionToken = (rfpLink) => {
 
 const validateProposalName = (
   name,
-  proposalnamesupportedchars,
-  minproposalnamelength,
-  maxproposalnamelength
+  namesupportedchars,
+  namelengthmin,
+  namelengthmax
 ) => {
   if (!name) {
     return "Required";
   }
-  const nameRegex = buildRegexFromSupportedChars(proposalnamesupportedchars);
+  const nameRegex = buildRegexFromSupportedChars(namesupportedchars);
   if (!name.match(nameRegex)) {
-    return invalidMessage("name", proposalnamesupportedchars);
+    return invalidMessage("name", namesupportedchars);
   }
-  if (name.trim().length < minproposalnamelength) {
-    return minLengthMessage("name", minproposalnamelength);
+  if (name.trim().length < namelengthmin) {
+    return minLengthMessage("name", namelengthmin);
   }
-  if (name.trim().length > maxproposalnamelength) {
-    return maxLengthMessage("name", maxproposalnamelength);
+  if (name.trim().length > namelengthmax) {
+    return maxLengthMessage("name", namelengthmax);
   }
 };

--- a/src/containers/Config/Config.js
+++ b/src/containers/Config/Config.js
@@ -44,9 +44,7 @@ const Config = ({ children }) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [configOptions, setConfig] = useState(null);
-  const {
-    policy: { paywallenabled }
-  } = usePolicy();
+  const { policy } = usePolicy();
 
   useEffect(() => {
     async function initConfig() {
@@ -67,8 +65,8 @@ const Config = ({ children }) => {
     <ConfigProvider
       {...{
         ...configOptions,
-        enablePaywall: !!paywallenabled,
-        enableCredits: !!paywallenabled
+        enablePaywall: !!policy?.paywallenabled,
+        enableCredits: !!policy?.paywallenabled
       }}>
       {!loading && !error && configOptions && children}
       {error}

--- a/src/hooks/api/usePolicy.js
+++ b/src/hooks/api/usePolicy.js
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import * as act from "src/actions";
 import { useSelector, useAction } from "src/redux";
 import * as sel from "src/selectors";
+import isEmpty from "lodash/isEmpty";
 
 function usePolicy() {
   const policy = useSelector(sel.policy);
@@ -10,7 +11,7 @@ function usePolicy() {
   const [error, setError] = useState();
   useEffect(
     function handleSetValidationSchemaFromPolicy() {
-      if (!policy) {
+      if (isEmpty(policy)) {
         onFetchPolicy().catch((e) => {
           setError(e);
         });
@@ -18,7 +19,15 @@ function usePolicy() {
     },
     [policy, onFetchPolicy]
   );
-  return { policy, loading, error };
+
+  return {
+    policy: policy.www,
+    policyTicketVote: policy.ticketvote,
+    policyComments: policy.comments,
+    policyPi: policy.pi,
+    loading,
+    error
+  };
 }
 
 export default usePolicy;

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -33,6 +33,7 @@ const apiBase = "/api/";
 const apiRecords = `${apiBase}records/`;
 const apiTicketVote = `${apiBase}ticketvote/`;
 const apiComments = `${apiBase}comments/`;
+const apiPi = `${apiBase}pi/`;
 
 const getUrl = (path, version, api = apiBase) => {
   if (!path && !version) return api;
@@ -520,7 +521,17 @@ export const verifyKeyRequest = (csrf, userid, verificationtoken) =>
       )
     );
 
-export const policy = () => GET("/policy").then(getResponse);
+export const policyWWW = () => GET("/policy").then(getResponse);
+
+export const policyTicketVote = (csrf) =>
+  POST("/policy", csrf, {}, apiTicketVote).then(getResponse);
+
+export const policyComments = (csrf) =>
+  POST("/policy", csrf, {}, apiComments).then(getResponse);
+  
+export const policyPi = (csrf) =>
+  POST("/policy", csrf, {}, apiPi).then(getResponse);
+
 
 export const userProposals = (csrf, userid) =>
   POST("/userrecords", csrf, { userid }, apiRecords).then(getResponse);

--- a/src/validators/proposal.js
+++ b/src/validators/proposal.js
@@ -9,12 +9,12 @@ import {
 function checkProposalName(props, values) {
   const name = values.name.trim();
   return (
-    (props.policy.minproposalnamelength &&
-      name.length < props.policy.minproposalnamelength) ||
+    (props.policy.pi.namelengthmin &&
+      name.length < props.policy.pi.namelengthmin) ||
     (props.policy.maxproposalnamelength &&
-      name.length > props.policy.maxproposalnamelength) ||
-    (props.policy.proposalnamesupportedchars &&
-      !proposalNameValidator(name, props.policy.proposalnamesupportedchars))
+      name.length > props.policy.pi.namelengthmax) ||
+    (props.policy.pi.namesupportedchars &&
+      !proposalNameValidator(name, props.policy.pi.namesupportedchars))
   );
 }
 
@@ -31,8 +31,8 @@ const validate = (values, dispatch, props) => {
   if (checkProposalName(props, values)) {
     throw new SubmissionError({
       _error:
-        `The proposal name must be between ${props.policy.minproposalnamelength} and ${props.policy.maxproposalnamelength} characters long ` +
-        `and only contain the following characters: ${props.policy.proposalnamesupportedchars.join(
+        `The proposal name must be between ${props.policy.pi.namelengthmin} and ${props.policy.pi.namelengthmax} characters long ` +
+        `and only contain the following characters: ${props.policy.pi.namesupportedchars.join(
           " "
         )}`
     });
@@ -40,9 +40,9 @@ const validate = (values, dispatch, props) => {
   validateURL(values.description);
 
   if (values.files) {
-    if (values.files.length > props.policy.maximages) {
+    if (values.files.length > props.policy.pi.imagefilecountmax) {
       throw new SubmissionError({
-        _error: `Only ${props.policy.maximages} attachments are allowed.`
+        _error: `Only ${props.policy.pi.imagefilecountmax} attachments are allowed.`
       });
     }
 


### PR DESCRIPTION
With the new tlog design, APIs got split up for a more modular design. A change caused by this is that each API has its own policy now, and pgui was only using `www` policy for everything.

### Solution description

Calls all policy routes when pgui is in Pi mode (and not CMS), and modifies the `usePolicy` route to accomodate the changes and get correct policy from each component.

closes #2321 