### PR TITLE
fix: remove initial conditional fetch

### DIFF
--- a/src/hooks/api/useProposalsBatch.js
+++ b/src/hooks/api/useProposalsBatch.js
@@ -90,17 +90,11 @@ export default function useProposalsBatch({
 
   const onFetchProposalsBatch = useAction(act.onFetchProposalsBatch);
   const onFetchTokenInventory = useAction(act.onFetchTokenInventory);
-  const isInventoryEmpty = !Object.values(allByStatus).some((st) => st.length);
   const hasRemainingTokens = !isEmpty(remainingTokens);
 
   const [state, send] = useFetchMachine({
     actions: {
-      initial: () => {
-        if (isInventoryEmpty) {
-          return send(START);
-        }
-        return send(VERIFY);
-      },
+      initial: () => send(START),
       start: () => {
         if (hasRemainingTokens) return send(VERIFY);
         if (page && page === previousPage) return send(RESOLVE);


### PR DESCRIPTION
This PR fixes an issue we were having that a newly created proposal was blocking the inventory fetch and the admin proposals list wasn't being populated properly, only showing the new proposal. A page refresh fixed the issue.

**To test this:**  create a new proposal and go to the admin tab without a refresh. You should be able to see all unvetted proposals.