### PR TITLE
Fix comments bugs

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -976,7 +976,8 @@ export const onCommentVote = (currentUserID, token, commentid, vote, state) =>
         dispatch(act.RECEIVE_SYNC_LIKE_COMMENT({ token, commentid, vote }));
       })
       .catch((error) => {
-        dispatch(act.RESET_SYNC_LIKE_COMMENT({ token }));
+        // xxx: why reset on error?
+        // dispatch(act.RESET_SYNC_LIKE_COMMENT({ token }));
         dispatch(act.RECEIVE_LIKE_COMMENT(null, error));
       });
   });

--- a/src/components/Likes/Likes.jsx
+++ b/src/components/Likes/Likes.jsx
@@ -6,7 +6,6 @@ import {
   useTheme,
   Text,
   getThemeProperty,
-  useHover,
   Spinner,
   classNames
 } from "pi-ui";
@@ -25,16 +24,14 @@ const Likes = ({
   apiLoading
 }) => {
   const [loading, setLoading] = useState(false);
-  const [likeRef, isLikeHovered] = useHover();
-  const [dislikeRef, isDislikeHovered] = useHover();
   const { theme } = useTheme();
   const defaultColor = getThemeProperty(theme, "comment-like-color");
   const activeColor = getThemeProperty(theme, "comment-like-color-active");
   const liked = isLiked(option);
   const disliked = isDisliked(option);
-  const likeColor = liked || isLikeHovered ? activeColor : defaultColor;
+  const likeColor = liked ? activeColor : defaultColor;
   const dislikeColor =
-    disliked || isDislikeHovered ? activeColor : defaultColor;
+    disliked ? activeColor : defaultColor;
 
   useEffect(() => {
     if (apiLoading) {
@@ -74,7 +71,7 @@ const Likes = ({
 
   return (
     <div
-      className={classNames("align-center", disabled && styles.likeDisabled)}>
+      className={"align-center"}>
       {loading && apiLoading ? (
         <div className={styles.likeBoxSpinner}>
           <Spinner invert />
@@ -83,8 +80,7 @@ const Likes = ({
         <>
           <div className={styles.leftLikeBox}>
             <button
-              ref={likeRef}
-              className={styles.likeBtn}
+              className={classNames(styles.likeBtn, disabled && styles.likeDisabled)}
               data-testid="like-btn"
               onClick={handleLike}>
               <Icon
@@ -97,8 +93,7 @@ const Likes = ({
           </div>
           <div className={styles.rightLikeBox}>
             <button
-              ref={dislikeRef}
-              className={styles.likeBtn}
+              className={classNames(styles.likeBtn, disabled && styles.likeDisabled)}
               data-testid="dislike-btn"
               onClick={handleDislike}>
               <Icon

--- a/src/components/Likes/Likes.module.css
+++ b/src/components/Likes/Likes.module.css
@@ -33,10 +33,10 @@
   color: var(--color-gray) !important;
 }
 
-.likeDisabled .likeBtn {
+.likeDisabled {
   cursor: not-allowed;
 }
 
-.likeBtn:hover > svg {
-  fill: black;
+.likeBtn:not(.likeDisabled):hover svg > g > path {
+  fill: var(--comment-like-color-active) !important;
 }

--- a/src/containers/Comments/Comment/Comment.jsx
+++ b/src/containers/Comments/Comment/Comment.jsx
@@ -45,7 +45,6 @@ const Comment = ({
   censorable,
   isFlatMode,
   seeInContextLink,
-  loadingLikeAction,
   ...props
 }) => {
   const extraSmall = useMediaQuery("(max-width: 560px)");
@@ -100,7 +99,6 @@ const Comment = ({
           <div className={styles.likesWrapper}>
             <Likes
               disabled={disableLikesClick}
-              apiLoading={!!loadingLikeAction}
               upLikes={likesUpCount}
               downLikes={likesDownCount}
               option={likeOption}

--- a/src/containers/Comments/Comment/CommentWrapper.jsx
+++ b/src/containers/Comments/Comment/CommentWrapper.jsx
@@ -172,7 +172,6 @@ const CommentWrapper = ({
 
   const isLikeCommentDisabled =
     loadingLikes ||
-    !!loadingLikeAction ||
     readOnly ||
     (userLoggedIn &&
       (identityError || paywallMissing || currentUser.username === username));

--- a/src/containers/Comments/helpers.js
+++ b/src/containers/Comments/helpers.js
@@ -38,7 +38,7 @@ export const getSort = (sortOption) => {
     [commentSortOptions.SORT_BY_OLD]: orderBy(["timestamp"], ["asc"]),
     [commentSortOptions.SORT_BY_TOP]: orderBy(
       ["resultvotes", "timestamp"],
-      ["desc", "desc"]
+      ["desc", "asc"]
     )
   };
 
@@ -50,7 +50,7 @@ export const getSort = (sortOption) => {
 
 export const sortComments = (sortOption, comments) => {
   const sorter = getSort(sortOption);
-  return sorter(comments);
+  return sorter(comments.map(comment => ({ ...comment, resultvotes: comment.upvotes - comment.downvotes })));
 };
 
 /**

--- a/src/containers/Comments/hooks.js
+++ b/src/containers/Comments/hooks.js
@@ -111,9 +111,9 @@ export function useComments(recordToken, proposalState) {
         (cl) => cl.commentid === commentID
       );
       if (actionData) {
-        return actionData.action;
+        return actionData.vote;
       }
-      return actionData ? actionData.action : 0;
+      return actionData ? actionData.vote : 0;
     },
     [commentsLikes]
   );

--- a/src/reducers/models/comments.js
+++ b/src/reducers/models/comments.js
@@ -64,6 +64,7 @@ const comments = (state = DEFAULT_STATE, action) =>
             const oldVote = oldCommentVote ? oldCommentVote.vote : 0;
 
             const newCommentLike = {
+              ...oldCommentVote,
               token,
               commentid,
               vote: vote === oldVote ? 0 : vote
@@ -76,21 +77,45 @@ const comments = (state = DEFAULT_STATE, action) =>
 
             const updateCommentVotes = (comment) => {
               if (comment.commentid !== commentid) return comment;
-              const oldActionEqualsNewAction = oldVote === vote;
 
-              const calcPerActionVotes = (v) => (value = 0) => {
-                if (vote === v) {
-                  if (oldActionEqualsNewAction) return --value;
-                  return ++value;
+              let newUpvotes = comment.upvotes;
+              let newDownvotes = comment.downvotes;
+              // if prev vote equals vote, reset the vote
+              if (oldVote === vote) {
+                if (vote > 0) {
+                  // means upvote, reset upvotes and leave downvotes
+                  newUpvotes--;
+                } else {
+                  // means downvote, reset downvotes and leave upvotes
+                  newDownvotes--;
                 }
-                if (oldVote === v) return --value;
-                return value;
-              };
+              } else if (oldVote !== 0) {
+                // if prev vote and vote are different and oldVote is different than 0, decrement prev vote and increment vote
+                if (vote > 0) {
+                  // means upvote, inc upvote and dec downvote
+                  newUpvotes++;
+                  newDownvotes--;
+                } else {
+                  // means downvote, dec upvote and inc downvote
+                  newUpvotes--;
+                  newDownvotes++;
+                }
+              } else if (vote > 0) {
+                // if oldVote is 0 (no option selected), just increment the vote option
+                newUpvotes++;
+              } else {
+                newDownvotes++;
+              }
 
-              return compose(
-                update("upvotes", calcPerActionVotes(1)),
-                update("downvotes", calcPerActionVotes(-1))
-              )(comment);
+              console.log("ooopa");
+              console.log(oldVote);
+              console.log(vote);
+
+              return {
+                ...comment,
+                upvotes: newUpvotes,
+                downvotes: newDownvotes
+              };
             };
 
             return compose(

--- a/src/reducers/models/comments.js
+++ b/src/reducers/models/comments.js
@@ -16,6 +16,39 @@ const DEFAULT_STATE = {
   commentsLikes: { byToken: {}, backup: null }
 };
 
+const calcVotes = (comment, oldVote, vote) => {
+  let newUpvotes = comment.upvotes;
+  let newDownvotes = comment.downvotes;
+  // if prev vote equals vote, reset the vote
+  if (oldVote === vote) {
+    if (vote > 0) {
+      // means upvote, reset upvotes and leave downvotes
+      newUpvotes--;
+    } else {
+      // means downvote, reset downvotes and leave upvotes
+      newDownvotes--;
+    }
+  } else if (oldVote !== 0) {
+    // if prev vote and vote are different and oldVote is different than 0, decrement prev vote and increment vote
+    if (vote > 0) {
+      // means upvote, inc upvote and dec downvote
+      newUpvotes++;
+      newDownvotes--;
+    } else {
+      // means downvote, dec upvote and inc downvote
+      newUpvotes--;
+      newDownvotes++;
+    }
+  } else if (vote > 0) {
+    // if oldVote is 0 (no option selected), just increment the vote option
+    newUpvotes++;
+  } else {
+    newDownvotes++;
+  }
+
+  return { newUpvotes, newDownvotes };
+};
+
 const comments = (state = DEFAULT_STATE, action) =>
   action.error
     ? state
@@ -78,38 +111,7 @@ const comments = (state = DEFAULT_STATE, action) =>
             const updateCommentVotes = (comment) => {
               if (comment.commentid !== commentid) return comment;
 
-              let newUpvotes = comment.upvotes;
-              let newDownvotes = comment.downvotes;
-              // if prev vote equals vote, reset the vote
-              if (oldVote === vote) {
-                if (vote > 0) {
-                  // means upvote, reset upvotes and leave downvotes
-                  newUpvotes--;
-                } else {
-                  // means downvote, reset downvotes and leave upvotes
-                  newDownvotes--;
-                }
-              } else if (oldVote !== 0) {
-                // if prev vote and vote are different and oldVote is different than 0, decrement prev vote and increment vote
-                if (vote > 0) {
-                  // means upvote, inc upvote and dec downvote
-                  newUpvotes++;
-                  newDownvotes--;
-                } else {
-                  // means downvote, dec upvote and inc downvote
-                  newUpvotes--;
-                  newDownvotes++;
-                }
-              } else if (vote > 0) {
-                // if oldVote is 0 (no option selected), just increment the vote option
-                newUpvotes++;
-              } else {
-                newDownvotes++;
-              }
-
-              console.log("ooopa");
-              console.log(oldVote);
-              console.log(vote);
+              const { newUpvotes, newDownvotes } = calcVotes(comment, oldVote, vote);
 
               return {
                 ...comment,

--- a/src/reducers/models/comments.js
+++ b/src/reducers/models/comments.js
@@ -129,6 +129,7 @@ const comments = (state = DEFAULT_STATE, action) =>
               )
             )(state);
           },
+          // xxx: is this really needed?
           [act.RESET_SYNC_LIKE_COMMENT]: () => {
             const { backup: commentsBackup } = state.comments;
             const { backup: commentsLikesBackup } = state.commentsLikes;

--- a/src/reducers/models/comments.js
+++ b/src/reducers/models/comments.js
@@ -44,10 +44,10 @@ const comments = (state = DEFAULT_STATE, action) =>
             )(state);
           },
           [act.RECEIVE_LIKED_COMMENTS]: () => {
-            const { token, commentslikes } = action.payload;
+            const { token, votes } = action.payload;
             return set(
               ["commentsLikes", "byToken", token],
-              commentslikes
+              votes
             )(state);
           },
           [act.RECEIVE_SYNC_LIKE_COMMENT]: () => {
@@ -60,7 +60,9 @@ const comments = (state = DEFAULT_STATE, action) =>
               commentLike.token === token;
             const oldCommentVote =
               commentsLikes && commentsLikes.find(isTargetCommentLike);
+
             const oldVote = oldCommentVote ? oldCommentVote.vote : 0;
+
             const newCommentLike = {
               token,
               commentid,
@@ -72,14 +74,9 @@ const comments = (state = DEFAULT_STATE, action) =>
               "commentid"
             );
 
-            const updateCommentResultAndTotalVotes = (comment) => {
+            const updateCommentVotes = (comment) => {
               if (comment.commentid !== commentid) return comment;
               const oldActionEqualsNewAction = oldVote === vote;
-
-              const calcNewTotalVotes = (value) =>
-                value + (oldActionEqualsNewAction ? -1 : oldVote === 0 ? 1 : 0);
-              const calcNewResultVotes = (value) =>
-                value + (oldActionEqualsNewAction ? -oldVote : vote - oldVote);
 
               const calcPerActionVotes = (v) => (value = 0) => {
                 if (vote === v) {
@@ -91,8 +88,6 @@ const comments = (state = DEFAULT_STATE, action) =>
               };
 
               return compose(
-                update("totalvotes", calcNewTotalVotes),
-                update("resultvotes", calcNewResultVotes),
                 update("upvotes", calcPerActionVotes(1)),
                 update("downvotes", calcPerActionVotes(-1))
               )(comment);
@@ -103,7 +98,7 @@ const comments = (state = DEFAULT_STATE, action) =>
               set(["commentsLikes", "byToken", token], newCommentsLikes),
               set(["comments", "backup"], comments),
               update(["comments", "byToken", token], (value) =>
-                value.map(updateCommentResultAndTotalVotes)
+                value.map(updateCommentVotes)
               )
             )(state);
           },


### PR DESCRIPTION
Closes #2374 
Closes #2375

This was a tough one to debug...

![](https://media.giphy.com/media/k75ngU7xpje0M/source.gif)

### Solution description

**Comment sorting (#2374)**
Comment sorting was wrong because `resultvotes` wasn't being updated properly in the comments reducer. I moved it from there to the `Container` level because we don't need to store it at all since we can easily calculate it using up and downvotes.

**Wrong vote color (Scenario 1 on #2375)**
The `useComments` hook was passing `actionData.data` as the vote option to the Likes component but the right property is `vote`. Changing it to `actionData.vote` fixed the issue.

**Wrong vote count (Scenario 2 on #2375)**
The `RECEIVE_LIKED_COMMENTS` action on comments reducer was using a wrong property name to store commentsLikes.

**Unnecessary component updates**
While working on this issue I noticed some unnecessary updates when hovering the vote button. See:
![multipleupdatecomment](https://user-images.githubusercontent.com/13955303/117516755-590aa580-af70-11eb-841d-1a5e061a4b08.gif)

This was happening because we were using a javascript approach with the [useHover](https://github.com/decred/pi-ui/blob/master/src/hooks/useHover.js) hook from `pi-ui`. In this specific case I could come up with a CSS-only solution to deal with hover and prevent unnecessary component updates.

![hovercommentsimproved](https://user-images.githubusercontent.com/13955303/117516905-df26ec00-af70-11eb-85ad-08fa267b9466.gif)

**Wrong behavior on error (tested max number of vote changes)**
I would like a review from @victorgcramos on this one because he was the last one to touch this piece of code. I don't get why we need `RESET_SYNC_LIKE_COMMENT` and why we are dispatching it on error. This was leading to some weird errors when hitting the max number of votes error.

**Improve code comments**
The function that was calculating `upvotes` and `downvotes` based on the user previous vote had one edge case wrong and was very hard to understand/debug. I refactored it and add some comments.

**Comment vote UX (https://github.com/decred/politeiagui/issues/2375#issuecomment-833826426)**
Removed the not-allowed symbol during api loading and added a 500ms debounce in the voting functions so the user can't spam the button.
