### PR TITLE
[gitbe-archive] fix: default title to empty string when there's no prev version

### DIFF
--- a/src/components/VersionPicker/hooks.js
+++ b/src/components/VersionPicker/hooks.js
@@ -76,7 +76,7 @@ export function useVersionPicker(version, token) {
       newText: getProposalText(proposal),
       oldText: getProposalText(prevProposal),
       newTitle: proposal.name,
-      oldTitle: prevProposal.name
+      oldTitle: prevProposal ? prevProposal.name : ""
     };
   }
 


### PR DESCRIPTION
Closes https://github.com/decred/politeiagui/issues/2388

### UI Changes Screenshot

<img width="839" alt="Screen Shot 2021-05-20 at 11 15 05" src="https://user-images.githubusercontent.com/13955303/118994978-28a60c80-b95d-11eb-81f5-f41bc73a92bc.png">

