### PR TITLE
Fixed Wrong cursor on Dark Mode toggle text

### DIFF
--- a/src/components/HeaderNav/HeaderNav.module.css
+++ b/src/components/HeaderNav/HeaderNav.module.css
@@ -62,6 +62,7 @@ ul.dropdownList {
 .themeToggleLabel {
   margin-left: 1rem;
   margin-top: 0.1rem;
+  cursor: pointer;
 }
 
 @media screen and (max-width: 1000px) {


### PR DESCRIPTION
### Issue no.
Closes #2402

### Problem
Wrong cursor on Dark Mode toggle text

### Solution description
Earlier when someone hovers on dark mode toggle text, the cursor was not pointer, but after adding the style -  <strong>cursor: pointer;</strong> in <strong>line no. 65</strong> under the class <strong>themeToggleLabel</strong> in <strong>HeaderNav.module.css</strong>, the cursor is now pointer.

### UI Changes Screenshot
#### Before
![before](https://user-images.githubusercontent.com/79463685/119682667-b18edd80-be60-11eb-9398-f844b2f89fb7.jpg)

#### Now
![After](https://user-images.githubusercontent.com/79463685/119682747-c1a6bd00-be60-11eb-9911-71f082c78ec7.jpg)

