### PR TITLE
Add docs/release-notes.

### DIFF
--- a/docs/release-notes/v1.0.0.md
+++ b/docs/release-notes/v1.0.0.md
@@ -1,0 +1,35 @@
+politeiagui v1.0.0
+====
+
+This release of politeiagui corresponds to the politeia
+[v1.0.0](https://github.com/decred/politeia/releases/tag/v1.0.0) release. It
+introduces the politeiagui changes required to support the new politeia backend
+and APIs.
+
+## proposals-archive
+
+The previous politeia instance has been archived and now resides at
+[proposals-archive.decred.org](https://proposals-archive.decred.org). A large
+amount of proposal data from these archived proposals has been hardcoded into
+politeiagui so that they are still displayed in the proposal list views of
+politeiagui. This hardcoding is a temporary measure and will be removed in a
+future release once the archived proposals are no longer active.  
+
+# Changelog
+
+This release consists of 13 commits with a total of 147 files changed, 9,642
+additional lines of code, and 2,374 deleted lines of code.
+
+tlog: pi adjustments for new tlog api [(decred/politeiagui#2306)](https://github.com/decred/politeiagui/pull/2306)
+fix: bundle/timestamp structure download fix [(decred/politeiagui#2313)](https://github.com/decred/politeiagui/pull/2313)
+Error handling: add PiUserPluginError to map `piuser` plugin error codes [(decred/politeiagui#2320)](https://github.com/decred/politeiagui/pull/2320)
+feat: include registration fee to the purchases history table [(decred/politeiagui#2322)](https://github.com/decred/politeiagui/pull/2322)
+Fix proposals state after status change [(decred/politeiagui#2326)](https://github.com/decred/politeiagui/pull/2326)
+Add policy for the new backend APIs [(decred/politeiagui#2327)](https://github.com/decred/politeiagui/pull/2327)
+fix: make sure all vote data is consistent on redux state [(decred/politeiagui#2315)](https://github.com/decred/politeiagui/pull/2315)
+Fix first comment display and report as spam button [(decred/politeiagui#2329)](https://github.com/decred/politeiagui/pull/2329)
+fix: get RFP submissions vote summaries using short token [(decred/politeiagui#2323)](https://github.com/decred/politeiagui/pull/2323)
+fix: fix edit state to work with short tokens [(decred/politeiagui#2331)](https://github.com/decred/politeiagui/pull/2331)
+fix: remove initial conditional fetch [(decred/politeiagui#2332)](https://github.com/decred/politeiagui/pull/2332)
+fix: update abandoned list properly [(decred/politeiagui#2333)](https://github.com/decred/politeiagui/pull/2333)
+feat: show proposals-archive [(decred/politeiagui#2340)](https://github.com/decred/politeiagui/pull/2340)

--- a/docs/release-notes/v1.0.1.md
+++ b/docs/release-notes/v1.0.1.md
@@ -1,0 +1,47 @@
+politeiagui v1.0.1
+====
+
+This patch release fixes various bugs in politeiagui.
+
+## Changelog
+
+This patch release consists of 29 commits from 4 contributor which total to 140
+files changed, 10,394 additional lines of code, and 4,842 deleted lines of
+code.
+
+Fix archived proposal comments link [(decred/politeiagui#2342)](https://github.com/decred/politeiagui/pull/2342)  
+fix: Censor comments bugs [(decred/politeiagui#2347)](https://github.com/decred/politeiagui/pull/2347)  
+fix: duplicte policy calls. [(decred/politeiagui#2343)](https://github.com/decred/politeiagui/pull/2343)  
+fix: trim email on login [(decred/politeiagui#2348)](https://github.com/decred/politeiagui/pull/2348)  
+deps: sync pi-ui [(decred/politeiagui#2355)](https://github.com/decred/politeiagui/pull/2355)  
+fix: VersionPicker prop type console warning. [(decred/politeiagui#2356)](https://github.com/decred/politeiagui/pull/2356)  
+README: dd e2e tests section. [(decred/politeiagui#2363)](https://github.com/decred/politeiagui/pull/2363)  
+README: typo [(decred/politeiagui#2366)](https://github.com/decred/politeiagui/pull/2366)  
+Simplify unvetted record URL. [(decred/politeiagui#2352)](https://github.com/decred/politeiagui/pull/2352)  
+fix: link see in context and view all to the right place [(decred/politeiagui#2360)](https://github.com/decred/politeiagui/pull/2360)  
+feat: scroll to single comment thread comment area [(decred/politeiagui#2368)](https://github.com/decred/politeiagui/pull/2368)  
+fix: align view all link and flat mode toggle left [(decred/politeiagui#2367)](https://github.com/decred/politeiagui/pull/2367)  
+fet: add rfp submission info tooltip [(decred/politeiagui#2370)](https://github.com/decred/politeiagui/pull/2370)  
+fix: `yarn test`. [(decred/politeiagui#2364)](https://github.com/decred/politeiagui/pull/2364)  
+copy: updte About Politeia. [(decred/politeiagui#2378)](https://github.com/decred/politeiagui/pull/2378)  
+fet: add hook to verify if user has totp verified [(decred/politeiagui#2373)](https://github.com/decred/politeiagui/pull/2373)  
+e2e: Add `setup-test-users.sh` to setup test users. [(decred/politeiagui#2381)](https://github.com/decred/politeiagui/pull/2381)  
+build(deps): upgra[(decred/politeiagui#2391)](https://github.com/decred/politeiagui/pull/2391)  
+e2e: make tests green again. [(decred/politeiagui#2383)](https://github.com/decred/politeiagui/pull/2383)  
+Fix comments bugs [(decred/politeiagui#2384)](https://github.com/decred/politeiagui/pull/2384)  
+fix: Initial Load Flickering. [(decred/politeiagui#2395)](https://github.com/decred/politeiagui/pull/2395)  
+fix: Paywall button flickering on initial load [(decred/politeiagui#2398)](https://github.com/decred/politeiagui/pull/2398)  
+fix: show user not found error [(decred/politeiagui#2396)](https://github.com/decred/politeiagui/pull/2396)  
+Fix download timestamps link and versions diff [(decred/politeiagui#2401)](https://github.com/decred/politeiagui/pull/2401)  
+fix: delete search results on logout [(decred/politeiagui#2405)](https://github.com/decred/politeiagui/pull/2405)  
+fix: Admin list tabs. [(decred/politeiagui#2406)](https://github.com/decred/politeiagui/pull/2406)  
+fix: `New Proposal` button is disabled when paywall is off. [(decred/politeiagui#2409)](https://github.com/decred/politeiagui/pull/2409)  
+feat: normalize redux state with short tokens [(decred/politeiagui#2365)](https://github.com/decred/politeiagui/pull/2365)  
+fix: remove expensive results call from proposal details page [(decred/politeiagui#2411)](https://github.com/decred/politeiagui/pull/2411)  
+
+## Code Contributors (alphabetical order)
+
+- Amir Massarwa
+- Luke Powell
+- Thiago Figueiredo
+- Tiago Alves Dulce


### PR DESCRIPTION
This diff creates a `docs/release-notes` directory in the repo and adds
the release notes for the `v1.0.0` and `v1.0.1` releases to it.

This release notes structure ensures that the release notes are not lost
in the event that we ever move away from github and is consistent with
how other decred repositories (dcrd, dcrpool, vspd, dcrlnd, politeia)
handle release documentation.