### PR TITLE
fix: use short token when displaying legacy proposal.

### DIFF
--- a/src/containers/Proposal/hooks/useProposalURLs.js
+++ b/src/containers/Proposal/hooks/useProposalURLs.js
@@ -16,7 +16,7 @@ export default function useProposalURLs(
   const { javascriptEnabled } = useConfig();
   // TODO: remove legacy
   const legacyProposals = useSelector(sel.legacyProposals);
-  const isLegacy = legacyProposals.includes(proposalToken);
+  const isLegacy = legacyProposals.includes(shortRecordToken(proposalToken));
   const proposalURL = !isLegacy
     ? getProposalUrl(proposalToken, javascriptEnabled, isLegacy)
     : `${ARCHIVE_URL}proposals/${shortRecordToken(proposalToken)}`;


### PR DESCRIPTION
With this diff all archive proposals seem to have the right URL for the comments section:
![image](https://user-images.githubusercontent.com/10324528/120905159-d6e9cb80-c658-11eb-9805-01d1cffefec5.png)
