### PR TITLE
Remove unnecessary duplicate requests

### DIFF
--- a/src/hooks/api/useProposalsBatch.js
+++ b/src/hooks/api/useProposalsBatch.js
@@ -21,6 +21,7 @@ import isEmpty from "lodash/fp/isEmpty";
 import isUndefined from "lodash/fp/isUndefined";
 import keys from "lodash/fp/keys";
 import difference from "lodash/fp/difference";
+import assign from "lodash/fp/assign";
 import { INVENTORY_PAGE_SIZE, PROPOSAL_PAGE_SIZE } from "src/constants";
 import { shortRecordToken } from "src/helpers";
 import {
@@ -46,7 +47,9 @@ const getRfpSubmissions = (proposals) =>
   )(proposals);
 
 const getUnfetchedTokens = (proposals, tokens) =>
-  difference(tokens.map((token) => shortRecordToken(token)))(keys(proposals));
+  difference(tokens.map((token) => shortRecordToken(token)))(
+    keys(proposals).map((token) => shortRecordToken(token))
+  );
 
 const getCurrentPage = (tokens) => {
   return tokens ? Math.floor(+tokens.length / INVENTORY_PAGE_SIZE) : 0;
@@ -138,7 +141,10 @@ export default function useProposalsBatch({
                   return send(FETCH);
                 }
               }
-              const unfetchedTokens = getUnfetchedTokens(proposals, fetch);
+              const unfetchedTokens = getUnfetchedTokens(
+                assign(proposals, fetchedProposals),
+                fetch
+              );
               setRemainingTokens([...unfetchedTokens, ...next]);
               return send(RESOLVE);
             })


### PR DESCRIPTION
Closed #2403 

### Solution description

The cause of the bug is the value of `unfetchedTokens` is wrong after the first time calculating when `proposals` is not updated yet since it is stored in redux. So I add the `fetchedProposals` at that moment to be calculated 

### Screen shot

![Screenshot from 2021-06-09 11-44-33](https://user-images.githubusercontent.com/84569563/121295510-602f2580-c919-11eb-9d9b-a8c86e6185f7.png)
