### PR TITLE
fix: properly show the comments count on user proposals

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -484,7 +484,7 @@ export const onFetchProposalsBatch = (tokens, fetchVoteSummary = true) =>
       dispatch(
         act.RECEIVE_PROPOSALS_BATCH({ proposals: proposalsWithCommentsCount })
       );
-      return [parseRawProposalsBatch(proposals), summaries];
+      return [parseRawProposalsBatch(proposalsWithCommentsCount), summaries];
     } catch (e) {
       dispatch(act.RECEIVE_PROPOSALS_BATCH(null, e));
       throw e;


### PR DESCRIPTION
Closes https://github.com/decred/politeiagui/issues/2425

### Solution description

This one liner was hard to track down. The `proposalsBatch` function wasn't returning the proposals with `commentsCount` and it was getting overwritten by the `RECEIVE_USER_PROPOSALS` action handler in the proposals reducer.

### UI Changes Screenshot

<img width="612" alt="Screen Shot 2021-06-10 at 21 13 05" src="https://user-images.githubusercontent.com/13955303/121612382-adea8180-ca30-11eb-88b6-699721951136.png">


