### PR TITLE
fix: token inventory pagination adjustments 

### DIFF
--- a/src/containers/Proposal/Admin/Admin.jsx
+++ b/src/containers/Proposal/Admin/Admin.jsx
@@ -35,6 +35,7 @@ const AdminProposals = ({ TopBanner, PageDetails, Main }) => {
   } = useProposalsBatch({
     fetchRfpLinks: true,
     fetchVoteSummaries: false,
+    unvetted: true,
     proposalStatus: statusByTab[tabLabels[tabIndex]]
   });
 

--- a/src/containers/Proposal/Vetted/Vetted.jsx
+++ b/src/containers/Proposal/Vetted/Vetted.jsx
@@ -32,7 +32,8 @@ const VettedProposals = ({ TopBanner, PageDetails, Sidebar, Main }) => {
     verifying,
     onRestartMachine,
     hasMoreProposals,
-    onFetchMoreProposals
+    onFetchMoreProposals,
+    isFetchDone
   } = useProposalsBatch({
     fetchRfpLinks: true,
     fetchVoteSummaries: true,
@@ -42,7 +43,7 @@ const VettedProposals = ({ TopBanner, PageDetails, Sidebar, Main }) => {
 
   // TODO: remove legacy
   const { legacyProposals, legacyProposalsTokens } = useLegacyVettedProposals(
-    !hasMoreProposals,
+    isFetchDone,
     statusByTab[tabLabels[index]]
   );
 

--- a/src/containers/Proposal/Vetted/Vetted.jsx
+++ b/src/containers/Proposal/Vetted/Vetted.jsx
@@ -32,8 +32,7 @@ const VettedProposals = ({ TopBanner, PageDetails, Sidebar, Main }) => {
     verifying,
     onRestartMachine,
     hasMoreProposals,
-    onFetchMoreProposals,
-    isFetchDone
+    onFetchMoreProposals
   } = useProposalsBatch({
     fetchRfpLinks: true,
     fetchVoteSummaries: true,
@@ -43,7 +42,7 @@ const VettedProposals = ({ TopBanner, PageDetails, Sidebar, Main }) => {
 
   // TODO: remove legacy
   const { legacyProposals, legacyProposalsTokens } = useLegacyVettedProposals(
-    isFetchDone,
+    !hasMoreProposals,
     statusByTab[tabLabels[index]]
   );
 

--- a/src/hooks/api/useProposalsBatch.js
+++ b/src/hooks/api/useProposalsBatch.js
@@ -22,7 +22,13 @@ import isUndefined from "lodash/fp/isUndefined";
 import keys from "lodash/fp/keys";
 import difference from "lodash/fp/difference";
 import assign from "lodash/fp/assign";
-import { INVENTORY_PAGE_SIZE, PROPOSAL_PAGE_SIZE } from "src/constants";
+import {
+  INVENTORY_PAGE_SIZE,
+  PROPOSAL_PAGE_SIZE,
+  PROPOSAL_STATE_UNVETTED,
+  PROPOSAL_STATE_VETTED,
+  PROPOSAL_STATUS_UNREVIEWED
+} from "src/constants";
 import { shortRecordToken } from "src/helpers";
 import {
   getRfpLinkedProposals,
@@ -58,30 +64,31 @@ const getCurrentPage = (tokens) => {
 export default function useProposalsBatch({
   fetchRfpLinks,
   fetchVoteSummaries = false,
+  unvetted = false,
   proposalStatus,
   status,
   proposalPageSize = PROPOSAL_PAGE_SIZE
 }) {
   const [remainingTokens, setRemainingTokens] = useState([]);
   const [voteStatus, setStatus] = useState(status);
+  const [previousPage, setPreviousPage] = useState(0);
   const isByRecordStatus = isUndefined(voteStatus);
   const proposals = useSelector(sel.proposalsByToken);
+  const recordState = unvetted
+    ? PROPOSAL_STATE_UNVETTED
+    : PROPOSAL_STATE_VETTED;
+  const currentStatus = isByRecordStatus ? proposalStatus || 1 : voteStatus;
   const voteSummaries = useSelector(sel.summaryByToken);
   const allByStatus = useSelector(
     isByRecordStatus ? sel.allByRecordStatus : sel.allByVoteStatus
   );
+  const tokens = useMemo(
+    () => allByStatus[getProposalStatusLabel(currentStatus, isByRecordStatus)],
+    [allByStatus, isByRecordStatus, currentStatus]
+  );
   const page = useMemo(() => {
-    const tokens =
-      allByStatus[
-        getProposalStatusLabel(
-          isByRecordStatus ? proposalStatus || 1 : voteStatus,
-          isByRecordStatus
-        )
-      ];
-
     return getCurrentPage(tokens);
-  }, [allByStatus, isByRecordStatus, proposalStatus, voteStatus]);
-  const [previousPage, setPreviousPage] = useState(0);
+  }, [tokens]);
   const errorSelector = useMemo(
     () => or(sel.apiProposalsBatchError, sel.apiPropsVoteSummaryError),
     []
@@ -97,15 +104,20 @@ export default function useProposalsBatch({
       start: () => {
         if (hasRemainingTokens) return send(VERIFY);
         if (page && page === previousPage) return send(RESOLVE);
-        onFetchTokenInventory(page + 1)
+        onFetchTokenInventory(
+          recordState,
+          page && currentStatus, // first page fetches all status
+          page + 1,
+          !isByRecordStatus
+        )
           .catch((e) => send(REJECT, e))
           .then(({ votes, records }) => {
+            setPreviousPage(page);
             // prepare token batch to fetch proposal for given status
             const proposalStatusLabel = getProposalStatusLabel(
-              isByRecordStatus ? proposalStatus || 1 : voteStatus,
+              currentStatus,
               isByRecordStatus
             );
-            setPreviousPage(page);
             const tokens = (isByRecordStatus ? records : votes)[
               proposalStatusLabel
             ];
@@ -116,42 +128,40 @@ export default function useProposalsBatch({
         return send(FETCH);
       },
       verify: () => {
-        if (hasRemainingTokens) {
-          const [fetch, next] = getTokensForProposalsPagination(
-            remainingTokens,
-            proposalPageSize
-          );
-          onFetchProposalsBatch(fetch, fetchVoteSummaries)
-            .then(([fetchedProposals]) => {
-              if (isEmpty(fetchedProposals)) {
-                setRemainingTokens(next);
-                return send(RESOLVE);
-              }
-              if (fetchRfpLinks) {
-                const rfpLinks = getRfpLinks(fetchedProposals);
-                const rfpSubmissions = getRfpSubmissions(fetchedProposals);
-                const unfetchedRfpLinks = getUnfetchedTokens(proposals, [
-                  ...rfpLinks,
-                  ...rfpSubmissions
-                ]);
-                if (!isEmpty(unfetchedRfpLinks)) {
-                  onFetchProposalsBatch(unfetchedRfpLinks, fetchVoteSummaries)
-                    .then(() => send(RESOLVE))
-                    .catch((e) => send(REJECT, e));
-                  return send(FETCH);
-                }
-              }
-              const unfetchedTokens = getUnfetchedTokens(
-                assign(proposals, fetchedProposals),
-                fetch
-              );
-              setRemainingTokens([...unfetchedTokens, ...next]);
+        if (!hasRemainingTokens) return send(RESOLVE, { proposals });
+        const [tokensToFetch, next] = getTokensForProposalsPagination(
+          remainingTokens,
+          proposalPageSize
+        );
+        onFetchProposalsBatch(tokensToFetch, fetchVoteSummaries)
+          .then(([fetchedProposals]) => {
+            if (isEmpty(fetchedProposals)) {
+              setRemainingTokens(next);
               return send(RESOLVE);
-            })
-            .catch((e) => send(REJECT, e));
-          return send(FETCH);
-        }
-        return send(RESOLVE, { proposals });
+            }
+            if (fetchRfpLinks) {
+              const rfpLinks = getRfpLinks(fetchedProposals);
+              const rfpSubmissions = getRfpSubmissions(fetchedProposals);
+              const unfetchedRfpLinks = getUnfetchedTokens(proposals, [
+                ...rfpLinks,
+                ...rfpSubmissions
+              ]);
+              if (!isEmpty(unfetchedRfpLinks)) {
+                onFetchProposalsBatch(unfetchedRfpLinks, fetchVoteSummaries)
+                  .then(() => send(RESOLVE))
+                  .catch((e) => send(REJECT, e));
+                return send(FETCH);
+              }
+            }
+            const unfetchedTokens = getUnfetchedTokens(
+              assign(proposals, fetchedProposals),
+              tokensToFetch
+            );
+            setRemainingTokens([...unfetchedTokens, ...next]);
+            return send(RESOLVE);
+          })
+          .catch((e) => send(REJECT, e));
+        return send(FETCH);
       },
       done: () => {}
     },
@@ -168,18 +178,18 @@ export default function useProposalsBatch({
     const newStatusLabel = getProposalStatusLabel(
       !newStatus
         ? isByRecordStatus
-          ? proposalStatus || 1
+          ? proposalStatus || PROPOSAL_STATUS_UNREVIEWED
           : voteStatus
         : newStatus,
       isByRecordStatus
     );
-
     const unfetchedTokens = getUnfetchedTokens(
       proposals,
       uniq(allByStatus[newStatusLabel] || [])
     );
+
+    // machine stop condition: inventory loaded, but no tokens to fetch
     if (isEmpty(remainingTokens) && isEmpty(unfetchedTokens) && !page) {
-      // stop condition
       return send(RESOLVE);
     }
     setRemainingTokens(unfetchedTokens);
@@ -191,16 +201,21 @@ export default function useProposalsBatch({
     return send(START);
   };
 
-  const onFetchMoreProposals = useCallback(() => send(VERIFY), [send]);
+  const onFetchMoreProposals = useCallback(() => {
+    if (isEmpty(remainingTokens)) return send(START);
+    return send(VERIFY);
+  }, [send, remainingTokens]);
 
   const anyError = error || state.error;
   useThrowError(anyError);
+
   return {
     proposals: getRfpLinkedProposals(proposals, voteSummaries),
     onFetchProposalsBatch,
     proposalsTokens: allByStatus,
     loading: state.loading,
     verifying: state.verifying,
+    isFetchDone: state.status === "success" && !hasRemainingTokens,
     onRestartMachine,
     onFetchMoreProposals,
     hasMoreProposals: !!remainingTokens.length,

--- a/src/hooks/api/useProposalsBatch.js
+++ b/src/hooks/api/useProposalsBatch.js
@@ -215,7 +215,6 @@ export default function useProposalsBatch({
     proposalsTokens: allByStatus,
     loading: state.loading,
     verifying: state.verifying,
-    isFetchDone: state.status === "success" && !hasRemainingTokens,
     onRestartMachine,
     onFetchMoreProposals,
     hasMoreProposals: !!remainingTokens.length,

--- a/src/hooks/utils/useQueryStringWithIndexValue.js
+++ b/src/hooks/utils/useQueryStringWithIndexValue.js
@@ -1,13 +1,20 @@
 import { useEffect, useMemo, useState, useCallback } from "react";
 import useQueryString from "./useQueryString";
 
+const findIndexValue = (value, values, initialIndex = 0) => {
+  const index = values.findIndex((v) => v === value);
+  return index >= 0 ? index : initialIndex;
+};
+
 function useQueryStringWithIndexValue(key, initialIndex, values) {
   const computedValues = useMemo(
     () => values.map((v) => v.toLowerCase()),
     [values]
   );
   const [value, onSetValue] = useQueryString(key, values[initialIndex]);
-  const [index, setIndex] = useState(initialIndex);
+  const [index, setIndex] = useState(
+    findIndexValue(value, computedValues, initialIndex)
+  );
 
   const onSetIndex = useCallback(
     (index) => {
@@ -19,8 +26,7 @@ function useQueryStringWithIndexValue(key, initialIndex, values) {
 
   useEffect(
     function onValueChange() {
-      const newIndex = computedValues.findIndex((v) => v === value);
-      setIndex(newIndex >= 0 ? newIndex : initialIndex);
+      setIndex(findIndexValue(value, computedValues, initialIndex));
     },
     [value, computedValues, initialIndex]
   );

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -701,11 +701,11 @@ export const userProposalCredits = () =>
 export const rescanUserPayments = (csrf, userid) =>
   PUT("/user/payments/rescan", csrf, { userid }).then(getResponse);
 
-export const proposalsInventory = (page) =>
-  POST("/inventory", "", { page }, apiRecords).then(getResponse);
+export const proposalsInventory = (state, status, page) =>
+  POST("/inventory", "", { state, status, page }, apiRecords).then(getResponse);
 
-export const votesInventory = (page) =>
-  POST("/inventory", "", { page }, apiTicketVote).then(getResponse);
+export const votesInventory = (status, page) =>
+  POST("/inventory", "", { status, page }, apiTicketVote).then(getResponse);
 
 export const recordsTimestamp = (csrf, token, version) =>
   POST("/timestamps", csrf, { token, version }, apiRecords).then(getResponse);


### PR DESCRIPTION
This Diff fixes some pagination issues regarding votes/records token inventory. After submitting > 20 proposals, the inventory was not being fetched for page 2, because the pagination only works when a status is given.

### Solution description

The solution was to use the correct status for each list when fetching the token inventory's next page. The first page will return all tokens from all statuses, but the following requests will fetch the inventory according to its status.

### UI Changes

No UI changes expected.
