### PR TITLE
fix: do not show error msg when paywall is off

### DIFF
--- a/src/components/IdentityErrorIndicators.jsx
+++ b/src/components/IdentityErrorIndicators.jsx
@@ -5,16 +5,14 @@ import { useLoaderContext } from "src/containers/Loader";
 
 export const IdentityMessageError = () => {
   const { currentUser } = useLoaderContext();
-  return (
-    currentUser && (
-      <Message className="margin-bottom-m" kind="error">
-        <P>
-          Your identity is invalid. You cannot currently submit proposals or
-          comments, please visit your{" "}
-          <Link to={`/user/${currentUser.userid}`}>account</Link> page to
-          correct this problem.
-        </P>
-      </Message>
-    )
-  );
+  return currentUser ? (
+    <Message className="margin-bottom-m" kind="error">
+      <P>
+        Your identity is invalid. You cannot currently submit proposals or
+        comments, please visit your{" "}
+        <Link to={`/user/${currentUser.userid}`}>account</Link> page to correct
+        this problem.
+      </P>
+    </Message>
+  ) : null;
 };

--- a/src/containers/Proposal/Edit/Edit.jsx
+++ b/src/containers/Proposal/Edit/Edit.jsx
@@ -26,7 +26,7 @@ const EditProposal = ({ match }) => {
   const isPublic = isPublicProposal(proposal);
   const { onEditProposal, currentUser } = useEditProposal();
   const { userid } = currentUser || {};
-  const { isPaid } = usePaywall();
+  const { isPaid, paywallEnabled } = usePaywall();
   const [, identityError] = useIdentity();
   const hasDetails =
     proposal?.files.filter((f) => f.name === "index.md").length > 0;
@@ -52,7 +52,7 @@ const EditProposal = ({ match }) => {
   return (
     <Card className="container">
       <Or>
-        {!isPaid && (
+        {!isPaid && paywallEnabled && (
           <Message kind="error">
             <P>
               You won't be able to submit comments or proposals before paying

--- a/src/containers/Proposal/New/New.jsx
+++ b/src/containers/Proposal/New/New.jsx
@@ -11,13 +11,13 @@ import { useNewProposal } from "./hooks";
 const NewProposal = () => {
   const { onSubmitProposal, currentUser } = useNewProposal();
   const { userid } = currentUser || {};
-  const { isPaid } = usePaywall();
+  const { isPaid, paywallEnabled } = usePaywall();
   const [, identityError] = useIdentity();
 
   return (
     <Card className="container">
       <Or>
-        {!isPaid && (
+        {!isPaid && paywallEnabled && (
           <Message kind="error">
             <P>
               You won't be able to submit comments or proposals before paying
@@ -30,7 +30,7 @@ const NewProposal = () => {
         {!!identityError && <IdentityMessageError />}
       </Or>
       <ProposalForm
-        disableSubmit={!isPaid || !!identityError}
+        disableSubmit={(paywallEnabled && !isPaid) || !!identityError}
         onSubmit={onSubmitProposal}
       />
     </Card>

--- a/src/containers/User/Detail/Detail.jsx
+++ b/src/containers/User/Detail/Detail.jsx
@@ -64,6 +64,7 @@ const UserDetail = ({
 
   const {
     recordType,
+    enablePaywall,
     constants: { RECORD_TYPE_INVOICE, RECORD_TYPE_PROPOSAL }
   } = useConfig();
 
@@ -72,10 +73,16 @@ const UserDetail = ({
   const proposalsOwned = user && user.proposalsowned;
   const ownsProposals = proposalsOwned && proposalsOwned.length > 0;
 
+  console.log(enablePaywall);
+
   const tabLabels = useMemo(() => {
     const isTabDisabled = (tabLabel) => {
       if (tabLabel === tabValues.PREFERENCES && !isUserPageOwner) return true;
-      if (tabLabel === tabValues.CREDITS && !isAdminOrTheUser) return true;
+      if (
+        tabLabel === tabValues.CREDITS &&
+        (!isAdminOrTheUser || !enablePaywall)
+      )
+        return true;
       if (tabLabel === tabValues.MANAGE_DCC && !isAdminOrTheUser) return true;
       if (tabLabel === tabValues.INVOICES && !isAdmin) return true;
       if (tabLabel === tabValues.DRAFTS && !isUserPageOwner) return true;
@@ -120,6 +127,7 @@ const UserDetail = ({
   }, [
     isUserPageOwner,
     isAdminOrTheUser,
+    enablePaywall,
     isAdmin,
     ownsProposals,
     recordType,

--- a/src/containers/User/Detail/Detail.jsx
+++ b/src/containers/User/Detail/Detail.jsx
@@ -73,8 +73,6 @@ const UserDetail = ({
   const proposalsOwned = user && user.proposalsowned;
   const ownsProposals = proposalsOwned && proposalsOwned.length > 0;
 
-  console.log(enablePaywall);
-
   const tabLabels = useMemo(() => {
     const isTabDisabled = (tabLabel) => {
       if (tabLabel === tabValues.PREFERENCES && !isUserPageOwner) return true;


### PR DESCRIPTION
Closes https://github.com/decred/politeiagui/issues/2445

This PR also removes the `user/<userid>?tab=credits` when the paywall is off.