### PR TITLE
fix: abandoned proposals pagination bug

### DIFF
--- a/src/containers/Proposal/Vetted/Vetted.jsx
+++ b/src/containers/Proposal/Vetted/Vetted.jsx
@@ -32,17 +32,17 @@ const VettedProposals = ({ TopBanner, PageDetails, Sidebar, Main }) => {
     verifying,
     onRestartMachine,
     hasMoreProposals,
-    onFetchMoreProposals
+    onFetchMoreProposals,
+    isProposalsBatchComplete
   } = useProposalsBatch({
     fetchRfpLinks: true,
     fetchVoteSummaries: true,
-    status: statusByTab[tabLabels[index]],
-    proposalPageSize: 4
+    status: statusByTab[tabLabels[index]]
   });
 
   // TODO: remove legacy
   const { legacyProposals, legacyProposalsTokens } = useLegacyVettedProposals(
-    !hasMoreProposals,
+    isProposalsBatchComplete,
     statusByTab[tabLabels[index]]
   );
 

--- a/src/containers/Proposal/Vetted/Vetted.jsx
+++ b/src/containers/Proposal/Vetted/Vetted.jsx
@@ -122,7 +122,6 @@ const VettedProposals = ({ TopBanner, PageDetails, Sidebar, Main }) => {
       onSetIndex={handleSetIndex}
       onFetchMoreProposals={onFetchMoreProposals}
       dropdownTabsForMobile={true}
-      filterCensored={true}
       hasMore={hasMoreProposals}
       isLoading={loading || verifying}>
       {content}

--- a/src/hooks/api/useProposalsBatch.js
+++ b/src/hooks/api/useProposalsBatch.js
@@ -152,10 +152,12 @@ export default function useProposalsBatch({
                 ...rfpSubmissions
               ]);
               if (!isEmpty(unfetchedRfpLinks)) {
-                onFetchProposalsBatch(unfetchedRfpLinks, fetchVoteSummaries)
-                  .then(() => send(RESOLVE))
-                  .catch((e) => send(REJECT, e));
-                return send(FETCH);
+                setRemainingTokens([
+                  ...unfetchedRfpLinks,
+                  ...unfetchedTokens,
+                  ...next
+                ]);
+                return send(VERIFY);
               }
             }
             return send(RESOLVE);

--- a/src/hooks/api/useProposalsBatch.js
+++ b/src/hooks/api/useProposalsBatch.js
@@ -139,6 +139,11 @@ export default function useProposalsBatch({
               setRemainingTokens(next);
               return send(RESOLVE);
             }
+            const unfetchedTokens = getUnfetchedTokens(
+              assign(proposals, fetchedProposals),
+              tokensToFetch
+            );
+            setRemainingTokens([...unfetchedTokens, ...next]);
             if (fetchRfpLinks) {
               const rfpLinks = getRfpLinks(fetchedProposals);
               const rfpSubmissions = getRfpSubmissions(fetchedProposals);
@@ -153,11 +158,6 @@ export default function useProposalsBatch({
                 return send(FETCH);
               }
             }
-            const unfetchedTokens = getUnfetchedTokens(
-              assign(proposals, fetchedProposals),
-              tokensToFetch
-            );
-            setRemainingTokens([...unfetchedTokens, ...next]);
             return send(RESOLVE);
           })
           .catch((e) => send(REJECT, e));
@@ -201,10 +201,19 @@ export default function useProposalsBatch({
     return send(START);
   };
 
+  const isFetchDone =
+    !remainingTokens.length &&
+    state.status === "success" &&
+    !getUnfetchedTokens(proposals, tokens).length;
+
+  const isAnotherInventoryCallRequired =
+    tokens && tokens.length && tokens.length % INVENTORY_PAGE_SIZE === 0;
+
   const onFetchMoreProposals = useCallback(() => {
-    if (isEmpty(remainingTokens)) return send(START);
+    if (isEmpty(remainingTokens) && isAnotherInventoryCallRequired)
+      return send(START);
     return send(VERIFY);
-  }, [send, remainingTokens]);
+  }, [send, remainingTokens, isAnotherInventoryCallRequired]);
 
   const anyError = error || state.error;
   useThrowError(anyError);
@@ -218,6 +227,7 @@ export default function useProposalsBatch({
     onRestartMachine,
     onFetchMoreProposals,
     hasMoreProposals: !!remainingTokens.length,
+    isProposalsBatchComplete: isFetchDone && !isAnotherInventoryCallRequired,
     machineCurrentState: state.status
   };
 }


### PR DESCRIPTION
This diff Closes #2436, which reported a bug that caused the proposals list page to duplicate its records requests.

1. The `remainingTokens` array wasn't updated properly after an RFP linked proposal gets fetched. The previously fetched tokens were not being removed after the request.

2. Also, after loading legacy proposals, the `LazyList` component was triggering `onFetchMoreProposals` with an empty `remainingTokens` array, so it caused the machine to load the inventory again.

### Solution description

1. Update the `remainingTokens` array properly.
2. Check if the inventory needs to be fetched, i.e., `inventory's length % 20 == 0`

