### PR TITLE
fix: do not fetch summaries and count for rfp submissions details + improve initial fetch condition

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -474,7 +474,8 @@ export const onFetchProposalsBatch = (
       const summaries =
         fetchVoteSummary &&
         response.find((res) => res && res.summaries).summaries;
-      const commentsCount = fetchProposalsCount && response.find((res) => res && res.counts).counts;
+      const commentsCount =
+        fetchProposalsCount && response.find((res) => res && res.counts).counts;
       const proposalsWithCommentsCount = Object.keys(proposals).reduce(
         (acc, curr) => {
           return {

--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -453,7 +453,8 @@ export const onFetchProposalDetailsWithoutState =
 export const onFetchProposalsBatch = (
   tokens,
   fetchVoteSummary = true,
-  userid
+  userid,
+  fetchProposalsCount = true
 ) =>
   withCsrf(async (dispatch, _, csrf) => {
     dispatch(act.REQUEST_PROPOSALS_BATCH(tokens));
@@ -467,13 +468,13 @@ export const onFetchProposalsBatch = (
           requests
         }),
         fetchVoteSummary && dispatch(onFetchProposalsBatchVoteSummary(tokens)),
-        api.commentsCount(tokens)
+        fetchProposalsCount && api.commentsCount(tokens)
       ]);
       const proposals = response.find((res) => res && res.records).records;
       const summaries =
         fetchVoteSummary &&
         response.find((res) => res && res.summaries).summaries;
-      const commentsCount = response.find((res) => res && res.counts).counts;
+      const commentsCount = fetchProposalsCount && response.find((res) => res && res.counts).counts;
       const proposalsWithCommentsCount = Object.keys(proposals).reduce(
         (acc, curr) => {
           return {

--- a/src/containers/Proposal/Detail/hooks.js
+++ b/src/containers/Proposal/Detail/hooks.js
@@ -92,7 +92,7 @@ export function useProposal(token, threadParentID) {
   const isMissingVoteSummary = !(
     voteSummaries[tokenShort] && voteSummaries[tokenShort].details
   );
-  const needsInitialFetch = (token && isMissingDetails);
+  const needsInitialFetch = token && isMissingDetails;
 
   const [remainingTokens, setRemainingTokens] = useState(
     unfetchedProposalTokens

--- a/src/containers/Proposal/Detail/hooks.js
+++ b/src/containers/Proposal/Detail/hooks.js
@@ -19,9 +19,10 @@ import values from "lodash/fp/values";
 import pick from "lodash/pick";
 import concat from "lodash/fp/concat";
 
-const getUnfetchedVoteSummaries = (proposal, voteSummaries) => {
+const getUnfetchedVoteSummaries = (proposal, voteSummaries, isSubmission) => {
   if (!proposal) return [];
-  const rfpLinks = getProposalRfpLinksTokens(proposal);
+  // no need to fetch vote summary if its submission
+  const rfpLinks = isSubmission ? [] : getProposalRfpLinksTokens(proposal);
   const proposalToken = getProposalToken(proposal);
   const tokens = concat(rfpLinks || [])(proposalToken);
   // compare tokens by short form
@@ -59,6 +60,8 @@ export function useProposal(token, threadParentID) {
   const voteSummaries = useSelector(sel.summaryByToken);
   const loadingVoteSummary = useSelector(sel.isApiRequestingVoteSummary);
   const rfpLinks = getProposalRfpLinksTokens(proposal);
+  const isRfp = proposal && !!proposal.linkby;
+  const isSubmission = proposal && !!proposal.linkto;
 
   const unfetchedProposalTokens =
     rfpLinks &&
@@ -68,7 +71,8 @@ export function useProposal(token, threadParentID) {
     );
   const unfetchedSummariesTokens = getUnfetchedVoteSummaries(
     proposal,
-    voteSummaries
+    voteSummaries,
+    isSubmission
   );
   const rfpSubmissions = rfpLinks &&
     proposal.linkby && {
@@ -84,17 +88,20 @@ export function useProposal(token, threadParentID) {
       )
     };
 
-  const isRfp = proposal && !!proposal.linkby;
   const isMissingDetails = !(proposal && getDetailsFile(proposal.files));
   const isMissingVoteSummary = !(
     voteSummaries[tokenShort] && voteSummaries[tokenShort].details
   );
-  const needsInitialFetch = isRfp || (token && isMissingDetails);
+  const needsInitialFetch = (token && isMissingDetails);
 
   const [remainingTokens, setRemainingTokens] = useState(
     unfetchedProposalTokens
   );
   const hasRemainingTokens = !isEmpty(remainingTokens);
+
+  const initialValues = {
+    status: "idle"
+  };
 
   const [state, send, { FETCH, RESOLVE, VERIFY, REJECT }] = useFetchMachine({
     actions: {
@@ -129,10 +136,11 @@ export function useProposal(token, threadParentID) {
         if (hasRemainingTokens) {
           const [tokensBatch, next] =
             getTokensForProposalsPagination(remainingTokens);
-          onFetchProposalsBatch(tokensBatch, isRfp)
+          // only fetch summaries and count if the proposal is a RFP. If it is a submission, just grab the records info.
+          onFetchProposalsBatch(tokensBatch, isRfp, undefined, !isSubmission)
             .then(() => {
               setRemainingTokens(next);
-              return send(RESOLVE);
+              return send(VERIFY);
             })
             .catch((e) => send(REJECT, e));
           return send(FETCH);
@@ -158,11 +166,13 @@ export function useProposal(token, threadParentID) {
       },
       done: () => {
         // verify proposal on proposal changes
+        // TODO: improve this in the future so we don't need to verify once it should be done
         if (!isEqual(state.proposal, proposal)) {
           return send(VERIFY);
         }
       }
-    }
+    },
+    initialValues
   });
 
   const proposalWithLinks = getProposalRfpLinks(
@@ -174,7 +184,7 @@ export function useProposal(token, threadParentID) {
   return {
     proposal: proposalWithLinks,
     error: state.error,
-    loading: state.loading,
+    loading: state.status === "idle" || state.status === "loading",
     threadParentID
   };
 }


### PR DESCRIPTION
This PR does 3 simple things:

1. Remove the **need** of initial fetching if proposal is a RFP. Notice it will still fetch if it's missing details but it was forcing a fetch every time before.
2. Improve proposal details loading state using the state machine.
3. Do not fetch `summaries` and `count` for the RFP proposal of a RFP submission in the proposal details.

## UI Changes

https://user-images.githubusercontent.com/13955303/122621377-bb74bc80-d06b-11eb-8851-4e84f9f56f26.mp4
