### PR TITLE
feat: Improve censored proposals UX

### DIFF
--- a/src/components/Proposal/Proposal.jsx
+++ b/src/components/Proposal/Proposal.jsx
@@ -158,7 +158,11 @@ const Proposal = React.memo(function Proposal({
   const { apiInfo } = useLoader();
   const mobile = useMediaQuery("(max-width: 560px)");
   const showEditedDate =
-    version > 1 && timestamp !== publishedat && !abandonedat && !mobile;
+    version > 1 &&
+    timestamp !== publishedat &&
+    !abandonedat &&
+    !censoredat &&
+    !mobile;
   const showPublishedDate = publishedat && !mobile;
   const showExtendedVersionPicker = extended && version > 1;
   const showAbandonedDate = abandonedat && !mobile;

--- a/src/components/Proposal/Proposal.jsx
+++ b/src/components/Proposal/Proposal.jsx
@@ -19,6 +19,7 @@ import {
   getMarkdownContent,
   getVotesReceived,
   isAbandonedProposal,
+  isCensoredProposal,
   isPublicProposal,
   isActiveRfp,
   isEditableProposal,
@@ -114,6 +115,7 @@ const Proposal = React.memo(function Proposal({
     name,
     publishedat,
     abandonedat,
+    censoredat,
     timestamp,
     userid,
     username,
@@ -145,6 +147,7 @@ const Proposal = React.memo(function Proposal({
   const isPublic = isPublicProposal(proposal);
   const isVotingFinished = isVotingFinishedProposal(voteSummary);
   const isAbandoned = isAbandonedProposal(proposal);
+  const isCensored = isCensoredProposal(proposal);
   const isPublicAccessible = isPublic || isAbandoned;
   const isAuthor = currentUser && currentUser.username === username;
   const isVotingAuthorized = isVotingAuthorizedProposal(voteSummary);
@@ -153,10 +156,11 @@ const Proposal = React.memo(function Proposal({
   const { apiInfo } = useLoader();
   const mobile = useMediaQuery("(max-width: 560px)");
   const showEditedDate =
-    version > 1 && timestamp !== publishedat && !abandonedat && !mobile;
+    version > 1 && timestamp !== publishedat && !abandonedat && !censoredat && !mobile;
   const showPublishedDate = publishedat && !mobile;
   const showExtendedVersionPicker = extended && version > 1;
   const showAbandonedDate = abandonedat && !mobile;
+  const showCensoredDate = censoredat && !mobile;
   const showVersionAsText = version > 1 && !extended && !mobile;
   const showRfpSubmissions =
     extended &&
@@ -192,7 +196,7 @@ const Proposal = React.memo(function Proposal({
     <>
       <RecordWrapper
         className={classNames(
-          isAbandoned && styles.abandonedProposal,
+          (isAbandoned || isCensored) && styles.abandonedProposal,
           isNotExtendedRfpOrSubmission && styles.rfpProposal
         )}>
         {({
@@ -279,6 +283,9 @@ const Proposal = React.memo(function Proposal({
                   {showAbandonedDate && (
                     <Event event="abandoned" timestamp={abandonedat} />
                   )}
+                  {showCensoredDate && (
+                    <Event event="censored" timestamp={censoredat} />
+                  )}
                   {showVersionAsText && (
                     <Text
                       id={`proposal-${proposalToken}-version`}
@@ -299,7 +306,7 @@ const Proposal = React.memo(function Proposal({
                 </Subtitle>
               }
               status={
-                (isPublic || isAbandoned) && (
+                (isPublic || isAbandoned || isCensored) && (
                   <Status>
                     <StatusTag
                       className={styles.statusTag}
@@ -369,6 +376,16 @@ const Proposal = React.memo(function Proposal({
                   showRfpSubmissions && styles.rfpMarkdownContainer
                 )}
                 body={text}
+              />
+            )}
+            {extended && isCensored && !collapseBodyContent && (
+              <Markdown
+                className={classNames(
+                  styles.markdownContainer,
+                  isDarkTheme && "dark",
+                  showRfpSubmissions && styles.rfpMarkdownContainer
+                )}
+                body={proposal.statuschangemsg}
               />
             )}
             {collapseBodyContent && (

--- a/src/components/Proposal/Proposal.jsx
+++ b/src/components/Proposal/Proposal.jsx
@@ -158,11 +158,7 @@ const Proposal = React.memo(function Proposal({
   const { apiInfo } = useLoader();
   const mobile = useMediaQuery("(max-width: 560px)");
   const showEditedDate =
-    version > 1 &&
-    timestamp !== publishedat &&
-    !abandonedat &&
-    !censoredat &&
-    !mobile;
+    version > 1 && timestamp !== publishedat && !abandonedat && !mobile;
   const showPublishedDate = publishedat && !mobile;
   const showExtendedVersionPicker = extended && version > 1;
   const showAbandonedDate = abandonedat && !mobile;

--- a/src/components/Proposal/Proposal.jsx
+++ b/src/components/Proposal/Proposal.jsx
@@ -156,7 +156,11 @@ const Proposal = React.memo(function Proposal({
   const { apiInfo } = useLoader();
   const mobile = useMediaQuery("(max-width: 560px)");
   const showEditedDate =
-    version > 1 && timestamp !== publishedat && !abandonedat && !censoredat && !mobile;
+    version > 1 &&
+    timestamp !== publishedat &&
+    !abandonedat &&
+    !censoredat &&
+    !mobile;
   const showPublishedDate = publishedat && !mobile;
   const showExtendedVersionPicker = extended && version > 1;
   const showAbandonedDate = abandonedat && !mobile;

--- a/src/components/Proposal/Proposal.jsx
+++ b/src/components/Proposal/Proposal.jsx
@@ -126,7 +126,9 @@ const Proposal = React.memo(function Proposal({
     type,
     rfpSubmissions,
     state,
-    commentsCount
+    commentsCount,
+    statuschangemsg,
+    statuschangeusername
   } = proposal;
   const isRfp = !!linkby || type === PROPOSAL_TYPE_RFP;
   const isRfpSubmission = !!linkto || type === PROPOSAL_TYPE_RFP_SUBMISSION;
@@ -148,7 +150,7 @@ const Proposal = React.memo(function Proposal({
   const isVotingFinished = isVotingFinishedProposal(voteSummary);
   const isAbandoned = isAbandonedProposal(proposal);
   const isCensored = isCensoredProposal(proposal);
-  const isPublicAccessible = isPublic || isAbandoned;
+  const isPublicAccessible = isPublic || isAbandoned || isCensored;
   const isAuthor = currentUser && currentUser.username === username;
   const isVotingAuthorized = isVotingAuthorizedProposal(voteSummary);
   const isEditable =
@@ -288,7 +290,11 @@ const Proposal = React.memo(function Proposal({
                     <Event event="abandoned" timestamp={abandonedat} />
                   )}
                   {showCensoredDate && (
-                    <Event event="censored" timestamp={censoredat} />
+                    <Event
+                      event="censored"
+                      timestamp={censoredat}
+                      username={statuschangeusername}
+                    />
                   )}
                   {showVersionAsText && (
                     <Text
@@ -389,7 +395,7 @@ const Proposal = React.memo(function Proposal({
                   isDarkTheme && "dark",
                   showRfpSubmissions && styles.rfpMarkdownContainer
                 )}
-                body={proposal.statuschangemsg}
+                body={statuschangemsg}
               />
             )}
             {collapseBodyContent && (

--- a/src/components/Proposal/helpers.js
+++ b/src/components/Proposal/helpers.js
@@ -8,7 +8,8 @@ import {
 } from "src/constants";
 import {
   isPublicProposal,
-  isAbandonedProposal
+  isAbandonedProposal,
+  isCensoredProposal
 } from "src/containers/Proposal/helpers";
 
 /**
@@ -69,6 +70,13 @@ export const getProposalStatusTagProps = (
     return {
       type: isDarkTheme ? "blueNegative" : "grayNegative",
       text: "Abandoned"
+    };
+  }
+
+  if (isCensoredProposal(proposal)) {
+    return {
+      type: "orangeNegativeCircled",
+      text: "Censored"
     };
   }
 

--- a/src/components/RecordWrapper/RecordWrapper.jsx
+++ b/src/components/RecordWrapper/RecordWrapper.jsx
@@ -32,14 +32,18 @@ import useTimestamps from "src/hooks/api/useTimestamps";
 export const Author = ({ username, url, isLegacy }) =>
   isLegacy ? <span>{username}</span> : <Link to={url}>{username}</Link>;
 
-export const Event = ({ event, timestamp, className, size }) => (
+export const Event = ({ event, timestamp, username, className, size }) => (
   <DateTooltip timestamp={timestamp} placement="bottom">
     {({ timeAgo }) => (
       <Text
         id={`event-${event}-${timestamp}`}
         className={classNames(styles.eventTooltip, className)}
         truncate
-        size={size}>{`${event} ${timeAgo}`}</Text>
+        size={size}>
+        {username
+          ? `${event} ${timeAgo} by ${username}`
+          : `${event} ${timeAgo}`}
+      </Text>
     )}
   </DateTooltip>
 );

--- a/src/containers/Proposal/Admin/Admin.jsx
+++ b/src/containers/Proposal/Admin/Admin.jsx
@@ -41,8 +41,10 @@ const AdminProposals = ({ TopBanner, PageDetails, Main }) => {
     proposalStatus: statusByTab[tabLabels[tabIndex]]
   });
 
-  const { proposals, loading: mdLoading } =
-    useProposalsStatusChangeUser(batchProposals, PROPOSAL_STATUS_CENSORED);
+  const { proposals, loading: mdLoading } = useProposalsStatusChangeUser(
+    batchProposals,
+    PROPOSAL_STATUS_CENSORED
+  );
 
   const getEmptyMessage = useCallback((tab) => {
     const mapTabToMessage = {

--- a/src/containers/Proposal/Admin/Admin.jsx
+++ b/src/containers/Proposal/Admin/Admin.jsx
@@ -3,6 +3,8 @@ import useProposalsBatch from "src/hooks/api/useProposalsBatch";
 import Proposal from "src/components/Proposal";
 import ProposalLoader from "src/components/Proposal/ProposalLoader";
 import useQueryStringWithIndexValue from "src/hooks/utils/useQueryStringWithIndexValue";
+import useProposalsStatusChangeUser from "src/hooks/api/useProposalsStatusChangeUser";
+import { PROPOSAL_STATUS_CENSORED } from "src/constants";
 import { tabValues, mapProposalsTokensByTab, statusByTab } from "./helpers";
 // XXX change to AdminActionsProvider
 import {
@@ -25,7 +27,7 @@ const AdminProposals = ({ TopBanner, PageDetails, Main }) => {
     tabLabels
   );
   const {
-    proposals,
+    proposals: batchProposals,
     proposalsTokens,
     loading,
     verifying,
@@ -38,6 +40,9 @@ const AdminProposals = ({ TopBanner, PageDetails, Main }) => {
     unvetted: true,
     proposalStatus: statusByTab[tabLabels[tabIndex]]
   });
+
+  const { proposals, loading: mdLoading } =
+    useProposalsStatusChangeUser(batchProposals, PROPOSAL_STATUS_CENSORED);
 
   const getEmptyMessage = useCallback((tab) => {
     const mapTabToMessage = {
@@ -65,7 +70,7 @@ const AdminProposals = ({ TopBanner, PageDetails, Main }) => {
       onFetchMoreProposals={onFetchMoreProposals}
       dropdownTabsForMobile={true}
       hasMore={hasMoreProposals}
-      isLoading={loading || verifying}
+      isLoading={loading || verifying || mdLoading}
       getEmptyMessage={getEmptyMessage}>
       {({ tabs, content }) => (
         <>

--- a/src/containers/Proposal/Vetted/Vetted.jsx
+++ b/src/containers/Proposal/Vetted/Vetted.jsx
@@ -42,7 +42,7 @@ const VettedProposals = ({ TopBanner, PageDetails, Sidebar, Main }) => {
     status: statusByTab[tabLabels[index]]
   });
 
-  const { proposals, loading: fullLoading } =
+  const { proposals, loading: mdLoading } =
     useProposalsStatusChangeUser(batchProposals, PROPOSAL_STATUS_CENSORED);
 
   // TODO: remove legacy
@@ -128,7 +128,7 @@ const VettedProposals = ({ TopBanner, PageDetails, Sidebar, Main }) => {
       onFetchMoreProposals={onFetchMoreProposals}
       dropdownTabsForMobile={true}
       hasMore={hasMoreProposals}
-      isLoading={loading || verifying || fullLoading}>
+      isLoading={loading || verifying || mdLoading}>
       {content}
     </RecordsView>
   );

--- a/src/containers/Proposal/Vetted/Vetted.jsx
+++ b/src/containers/Proposal/Vetted/Vetted.jsx
@@ -42,8 +42,10 @@ const VettedProposals = ({ TopBanner, PageDetails, Sidebar, Main }) => {
     status: statusByTab[tabLabels[index]]
   });
 
-  const { proposals, loading: mdLoading } =
-    useProposalsStatusChangeUser(batchProposals, PROPOSAL_STATUS_CENSORED);
+  const { proposals, loading: mdLoading } = useProposalsStatusChangeUser(
+    batchProposals,
+    PROPOSAL_STATUS_CENSORED
+  );
 
   // TODO: remove legacy
   const { legacyProposals, legacyProposalsTokens } = useLegacyVettedProposals(

--- a/src/containers/Proposal/Vetted/Vetted.jsx
+++ b/src/containers/Proposal/Vetted/Vetted.jsx
@@ -10,6 +10,8 @@ import { PublicActionsProvider } from "src/containers/Proposal/Actions";
 import RecordsView from "src/components/RecordsView";
 import { LIST_HEADER_VETTED } from "src/constants";
 import useQueryStringWithIndexValue from "src/hooks/utils/useQueryStringWithIndexValue";
+import { PROPOSAL_STATUS_CENSORED } from "src/constants";
+import useProposalsStatusChangeUser from "src/hooks/api/useProposalsStatusChangeUser";
 
 const renderProposal = (record) => (
   <Proposal key={record.censorshiprecord.token} proposal={record} />
@@ -26,7 +28,7 @@ const tabLabels = [
 const VettedProposals = ({ TopBanner, PageDetails, Sidebar, Main }) => {
   const [index, onSetIndex] = useQueryStringWithIndexValue("tab", 0, tabLabels);
   const {
-    proposals,
+    proposals: batchProposals,
     proposalsTokens,
     loading,
     verifying,
@@ -39,6 +41,9 @@ const VettedProposals = ({ TopBanner, PageDetails, Sidebar, Main }) => {
     fetchVoteSummaries: true,
     status: statusByTab[tabLabels[index]]
   });
+
+  const { proposals, loading: fullLoading } =
+    useProposalsStatusChangeUser(batchProposals, PROPOSAL_STATUS_CENSORED);
 
   // TODO: remove legacy
   const { legacyProposals, legacyProposalsTokens } = useLegacyVettedProposals(
@@ -123,7 +128,7 @@ const VettedProposals = ({ TopBanner, PageDetails, Sidebar, Main }) => {
       onFetchMoreProposals={onFetchMoreProposals}
       dropdownTabsForMobile={true}
       hasMore={hasMoreProposals}
-      isLoading={loading || verifying}>
+      isLoading={loading || verifying || fullLoading}>
       {content}
     </RecordsView>
   );

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -189,7 +189,7 @@ export const parseRawProposal = (proposal) => {
     proposal,
     usermds.timestamp
   );
-  
+
   return {
     ...proposal,
     description: description || proposal.description,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -133,8 +133,10 @@ const parseUserPluginMetadata = (proposal = {}) =>
   compose(
     reduce(
       (acc, curr) =>
-        curr.status ? { ...acc, [curr.status]: curr } : { ...acc, ...curr },
-      {}
+        curr.status
+          ? { ...acc, byStatus: { ...acc.byStatus, [curr.status]: curr } }
+          : { ...acc, ...curr },
+      { byStatus: {} }
     ),
     map(({ payload }) => {
       try {
@@ -148,9 +150,15 @@ const parseUserPluginMetadata = (proposal = {}) =>
           reduce(
             (acc, curr) =>
               curr.status
-                ? { ...acc, [curr.status]: curr }
+                ? {
+                    ...acc,
+                    byStatus: {
+                      ...acc.byStatus,
+                      [curr.status]: curr
+                    }
+                  }
                 : { ...acc, ...curr },
-            {}
+            { byStatus: {} }
           ),
           filter((md) => Object.keys(md).length),
           map((parsed) => JSON.parse(`{${parsed}}`)),
@@ -181,8 +189,8 @@ export const parseRawProposal = (proposal) => {
   const { linkby, linkto } = parseVoteMetadata(proposal);
   const { description } = parseProposalIndexFile(proposal);
   const usermds = parseUserPluginMetadata(proposal);
-  const statuschangemsg = usermds[proposal.status]?.message;
-  const statuschangepk = usermds[proposal.status]?.publickey;
+  const statuschangemsg = usermds.byStatus[proposal.status]?.message;
+  const statuschangepk = usermds.byStatus[proposal.status]?.publickey;
 
   // get prop timestamps
   const { publishedat, censoredat, abandonedat } = getProposalTimestamps(

--- a/src/hooks/api/useProposalsStatusChangeUser.js
+++ b/src/hooks/api/useProposalsStatusChangeUser.js
@@ -31,10 +31,10 @@ export default function useProposalsStatusChangeUser(proposals = {}, status) {
   // The public keys for the users we need to search for
   const unfetchedPublicKeys = flow(
     Object.values,
-    flatMap((prop) => prop.status === status ? prop.statuschangepk : []),
+    flatMap((prop) => (prop.status === status ? prop.statuschangepk : [])),
     uniq,
     filter((pk) => pk && !resultsByPk[pk])
-  )(proposals)
+  )(proposals);
 
   const hasPublicKeys = !isEmpty(publicKeys);
   const hasUnfetchedPublicKeys = !isEmpty(unfetchedPublicKeys);

--- a/src/hooks/api/useProposalsStatusChangeUser.js
+++ b/src/hooks/api/useProposalsStatusChangeUser.js
@@ -1,0 +1,97 @@
+import { useState } from "react";
+import * as act from "src/actions";
+import * as sel from "src/selectors";
+import { useAction, useSelector } from "src/redux";
+import head from "lodash/head";
+import isEmpty from "lodash/fp/isEmpty";
+import uniq from "lodash/uniq";
+import useFetchMachine, {
+  VERIFY,
+  FETCH,
+  REJECT,
+  RESOLVE,
+  START
+} from "src/hooks/utils/useFetchMachine";
+import { shortRecordToken } from "src/helpers";
+
+// useProposalStatusChangeUser receives a list of proposals and a status.
+// For all proposals that are in the passed in status, the hook adds a
+// 'statuschangeusername' field to the proposal object, which corresponds
+// to the username of the user that submitted the status change action
+// to the server.
+export default function useProposalsStatusChangeUser(proposals = {}, status) {
+  const [publicKeys, setPublicKeys] = useState([]);
+  const onSearchUser = useAction(act.onSearchUser);
+  const resultsByPk = useSelector(sel.queryResultsByPublicKey);
+  const resultsByID = useSelector(sel.searchResultsByID);
+
+  // The public keys for the users we need to search for
+  const unfetchedPublicKeys = uniq(
+    Object.values(proposals).flatMap((prop) =>
+      prop.status === status ? prop.statuschangepk : []
+    )
+  ).filter((pk) => pk && resultsByPk[pk] === undefined);
+
+  const hasPublicKeys = !isEmpty(publicKeys);
+  const hasUnfetchedPublicKeys = !isEmpty(unfetchedPublicKeys);
+
+  // Fetch users by public key
+  const [state, send] = useFetchMachine({
+    actions: {
+      initial: () => send(START),
+      start: () => {
+        if (hasPublicKeys) return send(VERIFY);
+        if (!hasUnfetchedPublicKeys) return send(RESOLVE);
+        setPublicKeys(unfetchedPublicKeys);
+        return send(VERIFY);
+      },
+      verify: () => {
+        if (!hasPublicKeys) return send(RESOLVE);
+        const pk = head(publicKeys);
+        onSearchUser({ publickey: pk })
+          .then(() => {
+            setPublicKeys(publicKeys.filter((v) => v !== pk));
+            return send(VERIFY);
+          })
+          .catch((e) => send(REJECT, e));
+        return send(FETCH);
+      },
+      done: () => {}
+    },
+    initialValues: {
+      status: "idle",
+      loading: true,
+      verifying: true
+    }
+  });
+
+  // Restart machine if there are unfetched public keys left
+  if (!isEmpty(unfetchedPublicKeys) && state.status === "success") {
+    send(START);
+  }
+
+  // Add statuschangeusername data to proposals that needs it
+  const parsedProposals = Object.values(proposals)
+    .map((prop) => {
+      const userID = resultsByPk[prop.statuschangepk];
+      const user = resultsByID[userID];
+      return prop.status === status
+        ? {
+            ...prop,
+            statuschangeusername: user?.username
+          }
+        : prop;
+    })
+    .reduce(
+      (acc, prop) => ({
+        ...acc,
+        [shortRecordToken(prop.censorshiprecord.token)]: prop
+      }),
+      {}
+    );
+
+  return {
+    proposals: parsedProposals,
+    loading: state.loading || state.verifying
+  };
+}

--- a/src/hooks/api/useProposalsStatusChangeUser.js
+++ b/src/hooks/api/useProposalsStatusChangeUser.js
@@ -4,6 +4,9 @@ import * as sel from "src/selectors";
 import { useAction, useSelector } from "src/redux";
 import head from "lodash/head";
 import isEmpty from "lodash/fp/isEmpty";
+import flow from "lodash/fp/flow";
+import flatMap from "lodash/fp/flatMap";
+import filter from "lodash/fp/filter";
 import uniq from "lodash/uniq";
 import useFetchMachine, {
   VERIFY,
@@ -26,11 +29,12 @@ export default function useProposalsStatusChangeUser(proposals = {}, status) {
   const resultsByID = useSelector(sel.searchResultsByID);
 
   // The public keys for the users we need to search for
-  const unfetchedPublicKeys = uniq(
-    Object.values(proposals).flatMap((prop) =>
-      prop.status === status ? prop.statuschangepk : []
-    )
-  ).filter((pk) => pk && !resultsByPk[pk]);
+  const unfetchedPublicKeys = flow(
+    Object.values,
+    flatMap((prop) => prop.status === status ? prop.statuschangepk : []),
+    uniq,
+    filter((pk) => pk && !resultsByPk[pk])
+  )(proposals)
 
   const hasPublicKeys = !isEmpty(publicKeys);
   const hasUnfetchedPublicKeys = !isEmpty(unfetchedPublicKeys);

--- a/src/reducers/models/users.js
+++ b/src/reducers/models/users.js
@@ -7,7 +7,8 @@ const DEFAULT_SEARCH_STATE = {
   results: [],
   resultsByID: {},
   queryByEmail: {},
-  queryByUsername: {}
+  queryByUsername: {},
+  queryByPublicKey: {}
 };
 
 const DEFAULT_CMS_USERS_STATE = {
@@ -113,7 +114,7 @@ const users = (state = DEFAULT_STATE, action) =>
           [act.RECEIVE_USER_SEARCH]: () => {
             const {
               users,
-              query: { email, username }
+              query: { email, username, publickey }
             } = action.payload;
             const usersByID = users.reduce(
               (res, user) => ({ ...res, [user.id]: user }),
@@ -122,6 +123,7 @@ const users = (state = DEFAULT_STATE, action) =>
             const usersIds = users.map((user) => user.id);
             const searchedByEmail = !!email;
             const searchedByUsername = !!username;
+            const searchedByPublicKey = !!publickey;
             return compose(
               set(["search", "results"], users),
               update("search.resultsByID", (users) => ({
@@ -133,6 +135,9 @@ const users = (state = DEFAULT_STATE, action) =>
                 : skip(),
               searchedByUsername
                 ? set(["search", "queryByUsername", username], usersIds)
+                : skip(),
+              searchedByPublicKey
+                ? set(["search", "queryByPublicKey", publickey], usersIds)
                 : skip()
             )(state);
           },

--- a/src/selectors/models/users.js
+++ b/src/selectors/models/users.js
@@ -16,6 +16,11 @@ export const queryResultsByUsername = get([
   "search",
   "queryByUsername"
 ]);
+export const queryResultsByPublicKey = get([
+  "users",
+  "search",
+  "queryByPublicKey"
+]);
 export const cmsUsersByContractorType = get([
   "users",
   "cms",
@@ -108,6 +113,17 @@ export const makeGetSearchResultsByUsername = (username) =>
     queryResultsByUsername,
     (allResults, idsByUsn) => {
       const results = idsByUsn[username];
+      if (!results) return null;
+      return results.map((id) => allResults[id]);
+    }
+  );
+
+export const makeGetSearchResultsByPublicKey = (publickey) =>
+  createSelector(
+    searchResultsByID,
+    queryResultsByPublicKey,
+    (allResults, idsByPk) => {
+      const results = idsByPk[publickey];
       if (!results) return null;
       return results.map((id) => allResults[id]);
     }


### PR DESCRIPTION
Closes #2440

### Solution description

Include new censored proposal render conditions on `Proposal.jsx`. Add fetch machine to control fetching user data by public key, and include the data needed into the parsed raw proposals object, which we use to render proposals list and details.

### UI Changes Screenshot

Proposal List
![image](https://user-images.githubusercontent.com/2729122/123457992-e3f43d80-d5ba-11eb-80ed-397b4289368a.png)

Proposal Details
![image](https://user-images.githubusercontent.com/2729122/123465132-1d7d7680-d5c4-11eb-8696-02a3a933043c.png)

