### PR TITLE
fix: only apply flat mode if comments are not on single thread mode

### DIFF
--- a/src/containers/Comments/CommentsList/CommentsListWrapper.jsx
+++ b/src/containers/Comments/CommentsList/CommentsListWrapper.jsx
@@ -57,10 +57,12 @@ const CommentsListWrapper = ({
   recordsBaseLink
 }) => {
   const [nestedComments, setNestedComments] = useState([]);
+  // single thread mode: find the childrens of the thread parent comment
+  const isSingleThread = threadParentID && !!comments.length;
   useEffect(
     function generateNestedComments() {
       // flat mode: keep comments array flat
-      if (isFlatMode) {
+      if (isFlatMode && !isSingleThread) {
         setNestedComments(
           comments.map((c) =>
             createComputedComment(c, comments, lastTimeAccessed, currentUserID)
@@ -68,9 +70,7 @@ const CommentsListWrapper = ({
         );
         return;
       }
-      // single thread mode: find the childrens of the thread parent comment
-      const isSingleThred = threadParentID && !!comments.length;
-      if (isSingleThred) {
+      if (isSingleThread) {
         const singleThreadParent = comments.find(
           (c) => +c.commentid === +threadParentID
         );
@@ -87,12 +87,19 @@ const CommentsListWrapper = ({
       const result = getChildren(comments, 0, lastTimeAccessed, currentUserID);
       setNestedComments(result);
     },
-    [comments, threadParentID, currentUserID, isFlatMode, lastTimeAccessed]
+    [
+      comments,
+      threadParentID,
+      currentUserID,
+      isFlatMode,
+      lastTimeAccessed,
+      isSingleThread
+    ]
   );
   return (
     <CommentsList
       comments={nestedComments}
-      isFlatMode={isFlatMode}
+      isFlatMode={isSingleThread ? false : isFlatMode}
       proposalState={proposalState}
       recordBaseLink={recordsBaseLink}
     />


### PR DESCRIPTION
Closes https://github.com/decred/politeiagui/issues/2451

### Solution description

Easy fix. We shouldn't apply flat mode when on single thread.

### UI Changes Screenshot

**Before**

<img width="705" alt="Screen Shot 2021-06-23 at 11 08 39" src="https://user-images.githubusercontent.com/13955303/123112840-71495d80-d414-11eb-8c39-c8647aaddd02.png">

**After**
<img width="706" alt="Screen Shot 2021-06-23 at 11 09 02" src="https://user-images.githubusercontent.com/13955303/123112882-7ad2c580-d414-11eb-8dda-53189f97338e.png">
