### PR TITLE
fix: use correct linkto param when editing a proposal type to RFP

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -84,7 +84,7 @@ export const makeProposal = (
   markdown,
   linkby = 0,
   type,
-  linkto = 0,
+  linkto = "",
   attachments = []
 ) => ({
   files: [


### PR DESCRIPTION
Closes #2444

### Solution description

The default value used to be a number, but backend expects a string.
