### PR TITLE
fix: use correct data for new proposals on user proposals list

### DIFF
--- a/src/reducers/models/proposals.js
+++ b/src/reducers/models/proposals.js
@@ -200,10 +200,7 @@ const proposals = (state = DEFAULT_STATE, action) =>
               ),
               update(
                 ["allProposalsByUserId", action.payload.userid],
-                (userProposals = []) => [
-                  shortRecordToken(proposalToken(action.payload)),
-                  ...userProposals
-                ]
+                (userProposals = []) => [action.payload, ...userProposals]
               ),
               update(
                 ["numOfProposalsByUserId", action.payload.userid],


### PR DESCRIPTION
This diff fixes #2462 by using the correct reducer payload when calling the `RECEIVE_NEW_PROPOSAL` action.
