### PR TITLE
fix: Persist public data on the proposals state tree on logout

### DIFF
--- a/src/reducers/models/proposals.js
+++ b/src/reducers/models/proposals.js
@@ -17,7 +17,8 @@ import {
   CENSORED,
   ARCHIVED,
   INELIGIBLE,
-  PROPOSAL_STATE_UNVETTED
+  PROPOSAL_STATE_UNVETTED,
+  PROPOSAL_STATE_VETTED
 } from "../../constants";
 import {
   shortRecordToken,
@@ -141,6 +142,28 @@ const updateInventory = (payload) => (allProps) => {
     }, {})
   };
 };
+
+const onReceiveLogout = (state) =>
+  compose(
+    update("byToken", (data) => {
+      const vetteds = {};
+      Object.keys(data).flatMap((id) => 
+        data[id].state === PROPOSAL_STATE_VETTED ? (
+        vetteds[id] = {
+          ...data[id]
+        }
+      ) : []);
+      return vetteds;
+    }),
+    update("allByRecordStatus", (data) => ({
+      [ARCHIVED]: data[ARCHIVED],
+      [CENSORED]: data[CENSORED],
+      [UNREVIEWED]: {}
+    })),
+    set("allProposalsByUserId", DEFAULT_STATE.allProposalsByUserId),
+    set("allTokensByUserId", DEFAULT_STATE.allTokensByUserId),
+    set("numOfProposalsByUserId", DEFAULT_STATE.numOfProposalsByUserId)
+  )(state);
 
 const proposals = (state = DEFAULT_STATE, action) =>
   action.error
@@ -284,7 +307,7 @@ const proposals = (state = DEFAULT_STATE, action) =>
               (commentsCount) => ++commentsCount
             )(state);
           },
-          [act.RECEIVE_LOGOUT]: () => DEFAULT_STATE
+          [act.RECEIVE_LOGOUT]: () => onReceiveLogout(state)
         }[action.type] || (() => state)
       )();
 

--- a/src/reducers/models/proposals.js
+++ b/src/reducers/models/proposals.js
@@ -147,19 +147,15 @@ const onReceiveLogout = (state) =>
   compose(
     update("byToken", (data) => {
       const vetteds = {};
-      Object.keys(data).flatMap((id) => 
-        data[id].state === PROPOSAL_STATE_VETTED ? (
-        vetteds[id] = {
-          ...data[id]
-        }
-      ) : []);
+      Object.keys(data).flatMap((id) =>
+        data[id].state === PROPOSAL_STATE_VETTED
+          ? (vetteds[id] = {
+              ...data[id]
+            })
+          : []
+      );
       return vetteds;
     }),
-    update("allByRecordStatus", (data) => ({
-      [ARCHIVED]: data[ARCHIVED],
-      [CENSORED]: data[CENSORED],
-      [UNREVIEWED]: {}
-    })),
     set("allProposalsByUserId", DEFAULT_STATE.allProposalsByUserId),
     set("allTokensByUserId", DEFAULT_STATE.allTokensByUserId),
     set("numOfProposalsByUserId", DEFAULT_STATE.numOfProposalsByUserId)


### PR DESCRIPTION
This diff persists public data from the proposals state tree on user logout event.

closes #2474 