### PR TITLE
fix: use correct comments width on firefox

### DIFF
--- a/src/containers/Comments/Comments.module.css
+++ b/src/containers/Comments/Comments.module.css
@@ -5,6 +5,7 @@ div.commentAreaContainer {
 
 div.commentsWrapper {
   padding: 0 2.6rem 2rem 2.6rem;
+  max-width: calc(100vw - 12rem);
 }
 
 div.commentsHeader {
@@ -66,9 +67,16 @@ span.flatModeActive {
   margin-top: 0.1rem;
 }
 
+@media screen and (max-width: 768px) {
+  div.commentsWrapper {
+    max-width: calc(100vw - 6rem);
+  }
+}
+
 @media screen and (max-width: 560px) {
   div.commentsWrapper {
     padding: 0 0 2rem 0;
+    max-width: 100vw;
   }
 
   .commentsHeaderWrapper,


### PR DESCRIPTION
This diff fixes some weird behavior regarding long comments. The comments div was overflowing the screen width.

### UI Changes Screenshot
 **before**
<img width="1920" alt="Screen Shot 2021-07-20 at 4 24 01 PM" src="https://user-images.githubusercontent.com/22639213/126392526-87013232-081d-4bb4-af5c-fec0eb70ecfe.png">

**after**
<img width="1803" alt="Screen Shot 2021-07-20 at 5 41 53 PM" src="https://user-images.githubusercontent.com/22639213/126392713-7341c527-4b76-4865-a643-998242860327.png">

Closes #2480 
