### PR TITLE
fix: display placeholders while loading initial records batch

### DIFF
--- a/src/components/RecordsView/RecordsView.jsx
+++ b/src/components/RecordsView/RecordsView.jsx
@@ -6,7 +6,11 @@ import { getRecordsByTabOption } from "./helpers";
 import HelpMessage from "src/components/HelpMessage";
 import { useConfig } from "src/containers/Config";
 import { shortRecordToken } from "src/helpers";
-import { NOJS_ROUTE_PREFIX, PROPOSAL_STATUS_CENSORED } from "src/constants";
+import {
+  NOJS_ROUTE_PREFIX,
+  PROPOSAL_STATUS_CENSORED,
+  PROPOSAL_PAGE_SIZE
+} from "src/constants";
 
 const LoadingPlaceholders = ({ numberOfItems, placeholder }) => {
   const Item = placeholder;
@@ -49,9 +53,10 @@ const RecordsView = ({
   index,
   onSetIndex,
   hasMore,
-  filterCensored
+  filterCensored,
+  pageSize = PROPOSAL_PAGE_SIZE
 }) => {
-  const [loadingItems, setLoadingItems] = useState(0);
+  const [loadingItems, setLoadingItems] = useState(pageSize);
   const { javascriptEnabled } = useConfig();
 
   useEffect(
@@ -75,7 +80,7 @@ const RecordsView = ({
   const handleFetchMoreRecords = () => {
     if (!filteredTokens || isLoading) return;
     onFetchMoreProposals && onFetchMoreProposals();
-    setLoadingItems(4);
+    setLoadingItems(pageSize);
   };
 
   const tabs = useMemo(


### PR DESCRIPTION
This diff fixes #2471 by adding the initial value for placeholders according to given `pageSize` argument. Default is set to `PROPOSAL_PAGE_SIZE`, which is 5.

### UI Changes Screenshot
**before:**
<img width="1768" alt="Screen Shot 2021-07-20 at 7 27 59 PM" src="https://user-images.githubusercontent.com/22639213/126403756-c43ef7b1-884f-4eb4-b967-405e74995742.png">

**after:**
<img width="1780" alt="Screen Shot 2021-07-20 at 7 25 51 PM" src="https://user-images.githubusercontent.com/22639213/126403748-9a229787-bd42-4bb0-ba1b-e8315c693fcf.png">
