### PR TITLE
fix: Use record short token on action redirects

### DIFF
--- a/src/containers/Proposal/Actions/PublicActionsProvider.jsx
+++ b/src/containers/Proposal/Actions/PublicActionsProvider.jsx
@@ -12,6 +12,7 @@ import ModalConfirmWithReason from "src/components/ModalConfirmWithReason";
 import ModalStartVote from "src/components/ModalStartVote";
 import useModalContext from "src/hooks/utils/useModalContext";
 import values from "lodash/fp/values";
+import { shortRecordToken } from "src/helpers";
 import {
   VOTE_TYPE_STANDARD,
   VOTE_TYPE_RUNOFF,
@@ -34,7 +35,7 @@ const PublicActionsProvider = ({ children, history }) => {
     (proposal) => {
       const handleCloseSuccess = () => {
         handleCloseModal();
-        history.push(`/record/${proposal.censorshiprecord.token}`);
+        history.push(`/record/${shortRecordToken(proposal.censorshiprecord.token)}`);
       };
       handleOpenModal(ModalConfirmWithReason, {
         title: `Abandon - ${proposal.name}`,

--- a/src/containers/Proposal/Actions/PublicActionsProvider.jsx
+++ b/src/containers/Proposal/Actions/PublicActionsProvider.jsx
@@ -35,7 +35,9 @@ const PublicActionsProvider = ({ children, history }) => {
     (proposal) => {
       const handleCloseSuccess = () => {
         handleCloseModal();
-        history.push(`/record/${shortRecordToken(proposal.censorshiprecord.token)}`);
+        history.push(
+          `/record/${shortRecordToken(proposal.censorshiprecord.token)}`
+        );
       };
       handleOpenModal(ModalConfirmWithReason, {
         title: `Abandon - ${proposal.name}`,

--- a/src/containers/Proposal/Actions/UnvettedActionsProvider.jsx
+++ b/src/containers/Proposal/Actions/UnvettedActionsProvider.jsx
@@ -16,7 +16,9 @@ const UnvettedActionsProvider = ({ children, history }) => {
   const handleOpenCensorModal = (proposal) => {
     const handleCloseSuccess = () => {
       handleCloseModal();
-      history.push(`/record/${shortRecordToken(proposal.censorshiprecord.token)}`);
+      history.push(
+        `/record/${shortRecordToken(proposal.censorshiprecord.token)}`
+      );
     };
     handleOpenModal(ModalConfirmWithReason, {
       title: `Censor proposal - ${proposal.name}`,
@@ -39,7 +41,9 @@ const UnvettedActionsProvider = ({ children, history }) => {
   const handleOpenApproveModal = (proposal) => {
     const handleCloseSuccess = () => {
       handleCloseModal();
-      history.push(`/record/${shortRecordToken(proposal.censorshiprecord.token)}`);
+      history.push(
+        `/record/${shortRecordToken(proposal.censorshiprecord.token)}`
+      );
     };
     handleOpenModal(ModalConfirm, {
       title: `Approve proposal - ${proposal.name}`,

--- a/src/containers/Proposal/Actions/UnvettedActionsProvider.jsx
+++ b/src/containers/Proposal/Actions/UnvettedActionsProvider.jsx
@@ -6,6 +6,7 @@ import Link from "src/components/Link";
 import ModalConfirmWithReason from "src/components/ModalConfirmWithReason";
 import ModalConfirm from "src/components/ModalConfirm";
 import useModalContext from "src/hooks/utils/useModalContext";
+import { shortRecordToken } from "src/helpers";
 
 const UnvettedActionsProvider = ({ children, history }) => {
   const { onCensorProposal, onApproveProposal } = useUnvettedActions();
@@ -15,7 +16,7 @@ const UnvettedActionsProvider = ({ children, history }) => {
   const handleOpenCensorModal = (proposal) => {
     const handleCloseSuccess = () => {
       handleCloseModal();
-      history.push(`/record/${proposal.censorshiprecord.token}`);
+      history.push(`/record/${shortRecordToken(proposal.censorshiprecord.token)}`);
     };
     handleOpenModal(ModalConfirmWithReason, {
       title: `Censor proposal - ${proposal.name}`,
@@ -38,7 +39,7 @@ const UnvettedActionsProvider = ({ children, history }) => {
   const handleOpenApproveModal = (proposal) => {
     const handleCloseSuccess = () => {
       handleCloseModal();
-      history.push(`/record/${proposal.censorshiprecord.token}`);
+      history.push(`/record/${shortRecordToken(proposal.censorshiprecord.token)}`);
     };
     handleOpenModal(ModalConfirm, {
       title: `Approve proposal - ${proposal.name}`,


### PR DESCRIPTION
This diff fixes the redirect of the approve, censor and abandon actions. It used to redirect to the proposal details page using the full record token, when it should be using the short token.

closes #2487 