### PR TITLE
fix: enable blob directive on CSP headers

### DIFF
--- a/conf/headers.conf
+++ b/conf/headers.conf
@@ -5,7 +5,7 @@ add_header X-Frame-Options "DENY" always;
 add_header X-XSS-Protection "1; mode=block" always;
 
 #CSP Header
-add_header Content-Security-Policy "default-src 'none'; base-uri 'self'; script-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self' faucet.decred.org explorer.dcrdata.org testnet.dcrdata.org dcrdata.decred.org testnet.decred.org; manifest-src 'self'; object-src 'none';" always;
+add_header Content-Security-Policy "default-src 'none'; base-uri 'self'; script-src 'self'; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self' faucet.decred.org explorer.dcrdata.org testnet.dcrdata.org dcrdata.decred.org testnet.decred.org; manifest-src 'self'; object-src 'none';" always;
 
 #Feature Policy
 add_header Feature-Policy "geolocation 'none'; midi 'none'; notifications 'none'; push 'none'; sync-xhr 'self'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; speaker 'none'; vibrate 'none'; fullscreen 'self'; payment 'none'" always;

--- a/nojavascript/Nginx/headers.conf
+++ b/nojavascript/Nginx/headers.conf
@@ -5,7 +5,7 @@ add_header X-Frame-Options "DENY" always;
 add_header X-XSS-Protection "1; mode=block" always;
 
 #CSP Header
-add_header Content-Security-Policy "default-src 'none'; base-uri 'self'; script-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self' faucet.decred.org explorer.dcrdata.org testnet.dcrdata.org dcrdata.decred.org testnet.decred.org; manifest-src 'self'; object-src 'none';" always;
+add_header Content-Security-Policy "default-src 'none'; base-uri 'self'; script-src 'self'; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self' faucet.decred.org explorer.dcrdata.org testnet.dcrdata.org dcrdata.decred.org testnet.decred.org; manifest-src 'self'; object-src 'none';" always;
 
 #Feature Policy
 add_header Feature-Policy "geolocation 'none'; midi 'none'; notifications 'none'; push 'none'; sync-xhr 'self'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; speaker 'none'; vibrate 'none'; fullscreen 'self'; payment 'none'" always;

--- a/politeiae2e/dockerfiles/headers.conf
+++ b/politeiae2e/dockerfiles/headers.conf
@@ -5,7 +5,7 @@ add_header X-Frame-Options "DENY" always;
 add_header X-XSS-Protection "1; mode=block" always;
 
 #CSP Header
-add_header Content-Security-Policy "default-src 'none'; base-uri 'self'; script-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self' faucet.decred.org explorer.dcrdata.org testnet.dcrdata.org dcrdata.decred.org testnet.decred.org; manifest-src 'self'; object-src 'none';" always;
+add_header Content-Security-Policy "default-src 'none'; base-uri 'self'; script-src 'self'; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self' faucet.decred.org explorer.dcrdata.org testnet.dcrdata.org dcrdata.decred.org testnet.decred.org; manifest-src 'self'; object-src 'none';" always;
 
 #Feature Policy
 add_header Feature-Policy "geolocation 'none'; midi 'none'; notifications 'none'; push 'none'; sync-xhr 'self'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; speaker 'none'; vibrate 'none'; fullscreen 'self'; payment 'none'" always;


### PR DESCRIPTION
This diff fixes #2478, an issue that was preventing blobs from being rendered on production due to the CSP restriction for `blob` images. We can avoid it by adding the `blob:` directive into the `image-src` policy.