### PR TITLE
fix: adjust diff modal width and display loading indicator

### DIFF
--- a/src/components/Diff/Diff.module.css
+++ b/src/components/Diff/Diff.module.css
@@ -39,7 +39,7 @@
   width: 1em;
 }
 .lineContent {
-  width: 500px;
+  width: 100%;
   word-wrap: break-word;
   overflow-wrap: break-word;
 }

--- a/src/components/ModalDiff/ModalDiff.module.css
+++ b/src/components/ModalDiff/ModalDiff.module.css
@@ -3,6 +3,12 @@
   margin: 2rem 0;
 }
 
+.modalContent {
+  width: 100%;
+  min-height: 40rem;
+  min-width: 90rem;
+}
+
 .diffTabs > li {
   flex: 50%;
   justify-content: center;
@@ -11,7 +17,11 @@
 .diffTabContent {
   min-height: 20rem;
   overflow-y: auto;
-  max-height: calc(70vh - 20rem);
+  width: calc(100% - 8rem);
+}
+
+.diffWrapper {
+  overflow-wrap: break-word;
 }
 
 .version {
@@ -28,8 +38,24 @@
   overflow: scroll;
 }
 
+@media screen and (max-width: 1000px) {
+  .modalContent {
+    min-width: 60rem;
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .modalContent {
+    min-width: 40rem;
+  }
+}
+
 @media screen and (max-width: 560px) {
   .diffTabContent {
     max-height: calc(70vh);
+    width: calc(100% - 5rem);
+  }
+  .modalContent {
+    min-width: 100%;
   }
 }

--- a/src/components/ModalDiff/ModalDiffProposal.jsx
+++ b/src/components/ModalDiff/ModalDiffProposal.jsx
@@ -28,10 +28,7 @@ const ModalDiffProposal = ({
     setActiveTabIndex(0);
   }, [props.show]);
   return (
-    <Modal
-      onClose={onClose}
-      {...props}
-      contentStyle={{ width: "100%", minHeight: "40rem" }}>
+    <Modal onClose={onClose} contentClassName={styles.modalContent} {...props}>
       <Header
         title={
           <Title id={"proposal-title-gfsag"} truncate linesBeforeTruncate={2}>
@@ -75,7 +72,9 @@ const ModalDiffProposal = ({
         className={styles.diffTabs}
         contentClassName={styles.diffTabContent}>
         <Tab label="Text Changes">
-          <DiffHTML oldTextBody={oldText} newTextBody={newText} />
+          <div className={styles.diffWrapper}>
+            <DiffHTML oldTextBody={oldText} newTextBody={newText} />
+          </div>
         </Tab>
         <Tab label="Attachments Changes">
           <FilesDiff oldFiles={oldFiles} newFiles={newFiles} />

--- a/src/components/VersionPicker/VersionPicker.jsx
+++ b/src/components/VersionPicker/VersionPicker.jsx
@@ -1,10 +1,10 @@
 import React, { useMemo } from "react";
 import PropTypes from "prop-types";
-import { Dropdown, DropdownItem } from "pi-ui";
+import { Dropdown, DropdownItem, Spinner } from "pi-ui";
 import { useVersionPicker } from "./hooks";
 
 const VersionPicker = ({ version, token, className, proposalState }) => {
-  const { disablePicker, onChangeVersion } = useVersionPicker(
+  const { disablePicker, onChangeVersion, isLoading } = useVersionPicker(
     version,
     token,
     proposalState
@@ -19,7 +19,8 @@ const VersionPicker = ({ version, token, className, proposalState }) => {
   }, [version]);
 
   return (
-    !disablePicker && (
+    !disablePicker &&
+    (!isLoading ? (
       <Dropdown
         title={`version ${version}`}
         className={className}
@@ -34,7 +35,11 @@ const VersionPicker = ({ version, token, className, proposalState }) => {
           </DropdownItem>
         ))}
       </Dropdown>
-    )
+    ) : (
+      <div style={{ padding: "2px" }}>
+        <Spinner invert />
+      </div>
+    ))
   );
 };
 

--- a/src/components/VersionPicker/hooks.js
+++ b/src/components/VersionPicker/hooks.js
@@ -8,6 +8,7 @@ import { useAction } from "src/redux";
 import * as act from "src/actions";
 
 export function useVersionPicker(version, token) {
+  const [isLoading, setIsLoading] = useState(false);
   const [selectedVersion, setSelectedVersion] = useState(version);
   const [handleOpenModal, handleCloseModal] = useModalContext();
   const { recordType, constants } = useConfig();
@@ -79,6 +80,7 @@ export function useVersionPicker(version, token) {
   const onChangeVersion = useCallback(
     async (v) => {
       setSelectedVersion(v);
+      setIsLoading(true);
       try {
         if (recordType === constants.RECORD_TYPE_PROPOSAL) {
           const proposalDiff = await fetchProposalVersions(
@@ -86,6 +88,7 @@ export function useVersionPicker(version, token) {
             token,
             v
           );
+          setIsLoading(false);
           handleOpenModal(ModalDiffProposal, {
             proposalDetails: proposalDiff.details,
             onClose: handleCloseModal,
@@ -99,6 +102,7 @@ export function useVersionPicker(version, token) {
         }
         if (recordType === constants.RECORD_TYPE_INVOICE) {
           const { invoice, prevInvoice } = await fetchInvoiceVersions(token, v);
+          setIsLoading(false);
           handleOpenModal(ModalDiffInvoice, {
             onClose: handleCloseModal,
             invoice,
@@ -106,6 +110,7 @@ export function useVersionPicker(version, token) {
           });
         }
       } catch (err) {
+        setIsLoading(false);
         setError(err);
       }
     },
@@ -127,6 +132,7 @@ export function useVersionPicker(version, token) {
     disablePicker,
     selectedVersion,
     onChangeVersion,
-    error
+    error,
+    isLoading
   };
 }


### PR DESCRIPTION
This diff closes #2465, an issue that reported minor visual issues regarding modal width and loading indicator.

### UI Changes Screenshot
<img width="1473" alt="Screen Shot 2021-07-30 at 1 29 12 PM" src="https://user-images.githubusercontent.com/22639213/127683605-40a28d35-caef-4bd9-8fa7-807569615b81.png">
<img width="668" alt="Screen Shot 2021-07-30 at 1 30 03 PM" src="https://user-images.githubusercontent.com/22639213/127683633-4f0e1460-e1d5-4160-9326-3d4388f9b45f.png">

