### PR TITLE
fix: Display error message on 2FA modal.

### DIFF
--- a/src/components/ModalTotpVerify.jsx
+++ b/src/components/ModalTotpVerify.jsx
@@ -11,7 +11,7 @@ const ModalTotpVerify = ({ show, onClose, onVerify }) => {
       onVerify(v)
         .then(() => {
           onClose();
-          setError();
+          // setError();
         })
         .catch((e) => {
           setError(e);

--- a/src/components/ModalTotpVerify.jsx
+++ b/src/components/ModalTotpVerify.jsx
@@ -11,7 +11,6 @@ const ModalTotpVerify = ({ show, onClose, onVerify }) => {
       onVerify(v)
         .then(() => {
           onClose();
-          // setError();
         })
         .catch((e) => {
           setError(e);

--- a/src/components/ModalTotpVerify.jsx
+++ b/src/components/ModalTotpVerify.jsx
@@ -1,23 +1,34 @@
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
-import { Modal } from "pi-ui";
+import { Modal, Message } from "pi-ui";
 import VerifyTotp from "src/containers/User/Totp/Verify";
 import { TOTP_CODE_LENGTH } from "src/constants";
 
 const ModalTotpVerify = ({ show, onClose, onVerify }) => {
+  const [error, setError] = useState();
   const handleChange = (v) => {
     if (v.length === TOTP_CODE_LENGTH) {
-      onVerify(v).then(() => onClose());
+      onVerify(v)
+        .then(() => {
+          onClose();
+          setError();
+        })
+        .catch((e) => {
+          setError(e);
+        });
     }
   };
   return (
     <Modal show={show} onClose={onClose} title="Verify 2FA Code">
-      <VerifyTotp
-        onType={handleChange}
-        extended={false}
-        tabIndex={1}
-        title="Authenticator Code"
-      />
+      <>
+        {error && <Message kind="error">{error.toString()}</Message>}
+        <VerifyTotp
+          onType={handleChange}
+          extended={false}
+          tabIndex={1}
+          title="Authenticator Code"
+        />
+      </>
     </Modal>
   );
 };

--- a/src/components/ModalTotpVerify.jsx
+++ b/src/components/ModalTotpVerify.jsx
@@ -21,7 +21,11 @@ const ModalTotpVerify = ({ show, onClose, onVerify }) => {
   return (
     <Modal show={show} onClose={onClose} title="Verify 2FA Code">
       <>
-        {error && <Message kind="error">{error.toString()}</Message>}
+        {error && (
+          <Message kind="error" className="margin-bottom-m">
+            {error.toString()}
+          </Message>
+        )}
         <VerifyTotp
           onType={handleChange}
           extended={false}

--- a/src/containers/User/Login/Form.jsx
+++ b/src/containers/User/Login/Form.jsx
@@ -28,8 +28,9 @@ const LoginForm = ({
     values,
     { resetForm, setSubmitting, setFieldError }
   ) => {
+    const credentials = { ...values, email: values.email.trim() };
     try {
-      await onLogin({ ...values, email: values.email.trim() });
+      await onLogin(credentials);
       setSubmitting(false);
       resetForm();
       onLoggedIn && onLoggedIn();
@@ -37,11 +38,7 @@ const LoginForm = ({
       setSubmitting(false);
       if (e.errorcode === TOTP_MISSING_LOGIN_ERROR) {
         handleOpenModal(ModalTotpVerify, {
-          onVerify: (code) =>
-            onSubmit(
-              { ...values, code },
-              { resetForm, setSubmitting, setFieldError }
-            ),
+          onVerify: (code) => onLogin({ ...credentials, code }),
           onClose: handleCloseModal
         });
         return;


### PR DESCRIPTION
Close #2543

This PR adds error messages on Two-Factor Authentication modal verification.

### UI Changes Screenshot

Before:
![2543-2fa-verify-before](https://user-images.githubusercontent.com/22639213/130861916-58845ff3-3401-4a54-86ea-81f161f8ba0b.gif)


After:
![2543-2fa-verify-after](https://user-images.githubusercontent.com/22639213/130861934-964fce09-b4eb-4904-8dbc-5ae846e61199.gif)