### PR TITLE
fix: Autofocus adjustments on 2FA digits input.

### DIFF
--- a/src/components/DigitsInput/DigitsInput.jsx
+++ b/src/components/DigitsInput/DigitsInput.jsx
@@ -64,7 +64,7 @@ const DigitsInput = ({
         value={digits.join("")}
         ref={inputRef}
         onBlur={() => {
-          setFocused(false);
+          !autoFocus && setFocused(false);
         }}
       />
       <div

--- a/src/components/DigitsInput/DigitsInput.jsx
+++ b/src/components/DigitsInput/DigitsInput.jsx
@@ -12,9 +12,16 @@ const getDigitsArrayFromCode = (code = "", length) => {
   return newDigits;
 };
 
-const DigitsInput = ({ length, onChange, className, code, tabIndex }) => {
+const DigitsInput = ({
+  length,
+  onChange,
+  className,
+  code,
+  tabIndex,
+  autoFocus
+}) => {
   const [digits, setDigits] = useState(getDigitsArrayFromCode(code, length));
-  const [focused, setFocused] = useState(false);
+  const [focused, setFocused] = useState();
   const inputRef = useRef(null);
 
   const handleChangeDigit = (e) => {
@@ -36,12 +43,23 @@ const DigitsInput = ({ length, onChange, className, code, tabIndex }) => {
     inputRef.current.focus();
   };
 
+  // Both useEffects are used to trigger the input focus
+  // on render because useEffect does not recognize changes
+  // for references, therefore, inputRef cannot be used as
+  // a dependency
+  useEffect(() => {
+    focused && inputRef.current.focus();
+  }, [focused]);
+
+  useEffect(() => {
+    setFocused(autoFocus);
+  }, [autoFocus]);
+
   return (
     <>
       <input
         type="text"
         className={styles.mainInput}
-        autoFocus
         onChange={handleChangeDigit}
         value={digits.join("")}
         ref={inputRef}
@@ -81,14 +99,16 @@ DigitsInput.propTypes = {
   onChange: PropTypes.func,
   className: PropTypes.string,
   code: PropTypes.string,
-  tabIndex: PropTypes.number
+  tabIndex: PropTypes.number,
+  autoFocus: PropTypes.bool
 };
 
 DigitsInput.defaultProps = {
   tabIndex: 1,
   length: 6,
   onChange: () => {},
-  onFill: () => {}
+  onFill: () => {},
+  autoFocus: false
 };
 
 export default DigitsInput;

--- a/src/containers/User/Totp/Verify.jsx
+++ b/src/containers/User/Totp/Verify.jsx
@@ -46,6 +46,7 @@ const VerifyTotp = ({
           className={inputClassName}
           tabIndex={tabIndex}
           code={code}
+          autoFocus={true}
         />
         {extended && (
           <Button


### PR DESCRIPTION
Closes #2550 

This PR fixes an issue that requested improvements on Two-Factor Authentication digits input regarding its autofocus. Now, the input gets automatically focused after display if the `autoFocus` prop is `true`.

### UI Changes Screenshot
Haven't clicked anywhere after the 2FA modal shows up:
![2550-2fa-focus](https://user-images.githubusercontent.com/22639213/131043176-6794a8c1-43e5-4db8-ab20-118e8924d374.gif)

