### PR TITLE
fix: Consistent error message for invalid identity

### DIFF
--- a/src/lib/pki.js
+++ b/src/lib/pki.js
@@ -5,8 +5,10 @@ import util from "tweetnacl-util";
 import get from "lodash/fp/get";
 
 export const STORAGE_PREFIX = "ed255191~";
-export const IDENTITY_ERROR =
-  "User identity not found. You need to restore it from a backup or generate a new one. If this is a verification from an emailed link, please ensure to open it in the same browser where you requested it.";
+export const IDENTITY_ERROR = `
+  Your identity is invalid. You cannot currently submit proposals or comments, 
+  please visit your account page to correct this problem.
+`;
 
 export const toHex = (x) => Buffer.from(toUint8Array(x)).toString("hex");
 


### PR DESCRIPTION
closes #2516 

I decided to keep this simple and just match the error message for errors thrown in the `lib/pki` and for errors rendered with `components/IdentityErrorIndicator` components.

- `lib/pki` throws the identity error caused on runtime by methods that call the lib's functions.
- `components/IdentityErrorIndicator` is rendered when the components check beforehand if the identity is valid or not.