### PR TITLE
fix: Comments view all navigation bug

### DIFF
--- a/src/containers/Comments/Comments.jsx
+++ b/src/containers/Comments/Comments.jsx
@@ -227,7 +227,10 @@ const CommentsListAndActions = ({
         {isSingleThread && (
           <div className="justify-left margin-top-s">
             <Text className="margin-right-xs">Single comment thread. </Text>
-            <Link to={`/record/${recordToken}?scrollToComments=true`}> View all.</Link>
+            <Link to={`/record/${recordToken}?scrollToComments=true`}>
+              {" "}
+              View all.
+            </Link>
           </div>
         )}
       </div>

--- a/src/containers/Comments/Comments.jsx
+++ b/src/containers/Comments/Comments.jsx
@@ -228,7 +228,6 @@ const CommentsListAndActions = ({
           <div className="justify-left margin-top-s">
             <Text className="margin-right-xs">Single comment thread. </Text>
             <Link to={`/record/${recordToken}?scrollToComments=true`}>
-              {" "}
               View all.
             </Link>
           </div>

--- a/src/containers/Comments/Comments.jsx
+++ b/src/containers/Comments/Comments.jsx
@@ -227,7 +227,7 @@ const CommentsListAndActions = ({
         {isSingleThread && (
           <div className="justify-left margin-top-s">
             <Text className="margin-right-xs">Single comment thread. </Text>
-            <Link to={`/record/${recordToken}`}> View all.</Link>
+            <Link to={`/record/${recordToken}?scrollToComments=true`}> View all.</Link>
           </div>
         )}
       </div>


### PR DESCRIPTION
close #2551

![image](https://user-images.githubusercontent.com/9039877/130989044-a06bcdff-aaf8-4aa7-bbf5-d55726a2aa29.png)

The View all comments button go to 

https://proposals.decred.org/record/58d9f46?scrollToComments=true

instead of 

https://proposals.decred.org/record/58d9f46

