### PR TITLE
improve Embed image button UX

### DIFF
--- a/src/components/Files/Input.jsx
+++ b/src/components/Files/Input.jsx
@@ -5,7 +5,7 @@ import { getFormattedFiles } from "./helpers";
 const FilesInput = ({ onChange, children, acceptedFiles }) => {
   function handleFilesChange(e, files) {
     const formattedFiles = getFormattedFiles(files);
-    onChange(formattedFiles);
+    onChange(formattedFiles, files);
   }
 
   return (

--- a/src/components/MarkdownEditor/CustomImageCommand.jsx
+++ b/src/components/MarkdownEditor/CustomImageCommand.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { ReactComponent as ImageSVG } from "./assets/image.svg";
+import ModalAttachFiles from "src/components/ModalAttachFiles";
+import useModalContext from "src/hooks/utils/useModalContext";
+import { saveFileToMde } from "./helpers";
+
+export function useCustomImageCommand(saveImage) {
+  const [handleOpenModal, handleCloseModal] = useModalContext();
+
+  const imageCommand = {
+    name: "image",
+    icon: () => <ImageSVG />,
+    execute({ initialState, textApi, l18n }) {
+      const handleOnChange = async function (_, files) {
+        handleCloseModal();
+        for (const file of files) {
+          await saveFileToMde(file[1], saveImage, initialState, textApi, l18n);
+        }
+      };
+      handleOpenModal(ModalAttachFiles, {
+        title: "Upload an image",
+        onChange: handleOnChange,
+        onClose: handleCloseModal
+      });
+    }
+  };
+
+  return {
+    imageCommand
+  };
+}

--- a/src/components/MarkdownEditor/CustomImageCommand.jsx
+++ b/src/components/MarkdownEditor/CustomImageCommand.jsx
@@ -19,7 +19,8 @@ export function useCustomImageCommand(saveImage) {
       };
       handleOpenModal(ModalAttachFiles, {
         title: "Insert an image",
-        subTitle: "Select the image that you would like to insert into the proposal text.",
+        subTitle:
+          "Select the image that you would like to insert into the proposal text.",
         onChange: handleOnChange,
         onClose: handleCloseModal
       });

--- a/src/components/MarkdownEditor/CustomImageCommand.jsx
+++ b/src/components/MarkdownEditor/CustomImageCommand.jsx
@@ -18,7 +18,8 @@ export function useCustomImageCommand(saveImage) {
         }
       };
       handleOpenModal(ModalAttachFiles, {
-        title: "Upload an image",
+        title: "Insert an image",
+        subTitle: "Select the image that you would like to insert into the proposal text.",
         onChange: handleOnChange,
         onClose: handleCloseModal
       });

--- a/src/components/MarkdownEditor/commands.jsx
+++ b/src/components/MarkdownEditor/commands.jsx
@@ -16,7 +16,8 @@ const commandTypes = {
   link: "link",
   quote: "quote",
   code: "code",
-  image: "image"
+  image: "image",
+  saveImage: "save-image"
 };
 
 export const toolbarCommands = (allowImgs) =>
@@ -91,6 +92,11 @@ export const commands = [
     command: commandTypes.numberedList,
     tooltipText: "Add a numbered list",
     Icon: NumberedListSVG
+  },
+  {
+    command: commandTypes.saveImage,
+    tooltipText: "Add an image",
+    Icon: ImageSVG
   }
 ];
 

--- a/src/components/MarkdownEditor/customSaveImageCommand.js
+++ b/src/components/MarkdownEditor/customSaveImageCommand.js
@@ -1,50 +1,4 @@
-function getBreaksNeededForEmptyLineBefore(text = "", startPosition = 0) {
-  if (startPosition === 0) return 0;
-
-  // - If we're in the first line, no breaks are needed
-  // - Otherwise there must be 2 breaks before the previous character.
-
-  // Depending on how many breaks exist already, we may need to insert 0, 1 or 2 breaks
-  let neededBreaks = 2;
-  let isInFirstLine = true;
-  for (let i = startPosition - 1; i >= 0 && neededBreaks >= 0; i--) {
-    switch (text.charCodeAt(i)) {
-      case 32: // blank space
-        continue;
-      case 10: // line break
-        neededBreaks--;
-        isInFirstLine = false;
-        break;
-      default:
-        return neededBreaks;
-    }
-  }
-  return isInFirstLine ? 0 : neededBreaks;
-}
-
-export function readFileAsync(file, as = "arrayBuffer") {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-
-    reader.onload = () => {
-      if (typeof reader.result === "string" && as !== "binary") {
-        throw new Error("reader.result is expected to be an ArrayBuffer");
-      }
-      if (typeof reader.result !== "string" && as === "binary") {
-        throw new Error("reader.result is expected to be an BinaryString");
-      }
-      resolve([reader.result, file]);
-    };
-
-    reader.onerror = reject;
-
-    if (as === "binary") {
-      reader.readAsBinaryString(file);
-    } else {
-      reader.readAsArrayBuffer(file);
-    }
-  });
-}
+import { saveFileToMde, saveFileToMde } from "./helpers";
 
 function dataTransferToArray(items) {
   const result = [];
@@ -83,48 +37,8 @@ const customSaveImageCommand = {
       ? dataTransferToArray(event.dataTransfer.items)
       : fileListToArray(event.target.files);
 
-    for (const index in items) {
-      const breaksBeforeCount = getBreaksNeededForEmptyLineBefore(
-        initialState.text,
-        initialState.selection.start
-      );
-      const breaksBefore = Array(breaksBeforeCount + 1).join("\n");
-
-      const placeHolder = `${breaksBefore}![${l18n.uploadingImage}]()`;
-
-      textApi.replaceSelection(placeHolder);
-
-      const blob = items[index];
-      // this is the format we have to send to the server
-      const serverImage = await readFileAsync(blob, "binary");
-      // this is the format we have can show a blob
-      const displayImage = await readFileAsync(blob);
-      const image = await saveImage({ serverImage, displayImage });
-      const newState = textApi.getState();
-
-      const uploadingText = newState.text.substr(
-        initialState.selection.start,
-        placeHolder.length
-      );
-
-      if (uploadingText === placeHolder) {
-        // In this case, the user did not touch the placeholder. Good user
-        // we will replace it with the real one that came from the server
-        textApi.setSelectionRange({
-          start: initialState.selection.start,
-          end: initialState.selection.start + placeHolder.length
-        });
-
-        const realImageMarkdown = `${breaksBefore}![${image.name}](${image.url})`;
-
-        const selectionDelta = realImageMarkdown.length - placeHolder.length;
-
-        textApi.replaceSelection(realImageMarkdown);
-        textApi.setSelectionRange({
-          start: newState.selection.start + selectionDelta,
-          end: newState.selection.end + selectionDelta
-        });
-      }
+    for (const blob of items) {
+      await saveFileToMde(blob, saveImage, initialState, textApi, l18n);
     }
   }
 };

--- a/src/components/MarkdownEditor/customSaveImageCommand.js
+++ b/src/components/MarkdownEditor/customSaveImageCommand.js
@@ -1,4 +1,4 @@
-import { saveFileToMde, saveFileToMde } from "./helpers";
+import { saveFileToMde } from "./helpers";
 
 function dataTransferToArray(items) {
   const result = [];

--- a/src/components/MarkdownEditor/helpers.js
+++ b/src/components/MarkdownEditor/helpers.js
@@ -1,0 +1,121 @@
+import { digestPayload } from "src/helpers";
+
+function readFileAsync(file, as = "arrayBuffer") {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.onload = () => {
+      if (typeof reader.result === "string" && as !== "binary") {
+        throw new Error("reader.result is expected to be an ArrayBuffer");
+      }
+      if (typeof reader.result !== "string" && as === "binary") {
+        throw new Error("reader.result is expected to be an BinaryString");
+      }
+      resolve([reader.result, file]);
+    };
+
+    reader.onerror = reject;
+
+    if (as === "binary") {
+      reader.readAsBinaryString(file);
+    } else {
+      reader.readAsArrayBuffer(file);
+    }
+  });
+}
+
+/** displayBlobSolution receives a pair of [ArrayBuffer, File] and returns a blob URL to display the image on preview. */
+export function displayBlobSolution(f) {
+  const [result] = f;
+  const bytes = new Uint8Array(result);
+  const blob = new Blob([bytes], { type: "image/png" });
+  const urlCreator = window.URL || window.webkitURL;
+  const imageUrl = urlCreator.createObjectURL(blob);
+  return imageUrl;
+}
+
+/** getFormattedFile receives a pair of [ArrayBuffer, File] and returns an object in the exact format we need to submit to the backend */
+export function getFormattedFile(f) {
+  const [result, file] = f;
+  const payload = btoa(result);
+  return {
+    name: file.name,
+    mime: file.type,
+    size: file.size,
+    payload,
+    digest: digestPayload(payload)
+  };
+}
+
+function getBreaksNeededForEmptyLineBefore(text = "", startPosition = 0) {
+  if (startPosition === 0) return 0;
+
+  // - If we're in the first line, no breaks are needed
+  // - Otherwise there must be 2 breaks before the previous character.
+
+  // Depending on how many breaks exist already, we may need to insert 0, 1 or 2 breaks
+  let neededBreaks = 2;
+  let isInFirstLine = true;
+  for (let i = startPosition - 1; i >= 0 && neededBreaks >= 0; i--) {
+    switch (text.charCodeAt(i)) {
+      case 32: // blank space
+        continue;
+      case 10: // line break
+        neededBreaks--;
+        isInFirstLine = false;
+        break;
+      default:
+        return neededBreaks;
+    }
+  }
+  return isInFirstLine ? 0 : neededBreaks;
+}
+
+export async function saveFileToMde(
+  blob,
+  saveImage,
+  initialState,
+  textApi,
+  l18n
+) {
+  const breaksBeforeCount = getBreaksNeededForEmptyLineBefore(
+    initialState.text,
+    initialState.selection.start
+  );
+  const breaksBefore = Array(breaksBeforeCount + 1).join("\n");
+
+  const placeHolder = `${breaksBefore}![${l18n.uploadingImage}]()`;
+
+  textApi.replaceSelection(placeHolder);
+
+  // this is the format we have to send to the server
+  const serverImage = await readFileAsync(blob, "binary");
+  // this is the format we have can show a blob
+  const displayImage = await readFileAsync(blob);
+  const image = await saveImage({ serverImage, displayImage });
+  const newState = textApi.getState();
+
+  const uploadingText = newState.text.substr(
+    initialState.selection.start,
+    placeHolder.length
+  );
+
+  if (uploadingText === placeHolder) {
+    // In this case, the user did not touch the placeholder. Good user
+    // we will replace it with the real one that came from the server
+    textApi.setSelectionRange({
+      start: initialState.selection.start,
+      end: initialState.selection.start + placeHolder.length
+    });
+
+    const realImageMarkdown = `${breaksBefore}![${image.name}](${image.url})`;
+
+    const selectionDelta = realImageMarkdown.length - placeHolder.length;
+
+    textApi.replaceSelection(realImageMarkdown);
+    textApi.setSelectionRange({
+      start: newState.selection.start + selectionDelta,
+      end: newState.selection.end + selectionDelta
+    });
+  }
+}

--- a/src/components/ModalAttachFiles/ModalAttachFiles.jsx
+++ b/src/components/ModalAttachFiles/ModalAttachFiles.jsx
@@ -5,7 +5,8 @@ import FilesInput from "src/components/Files/Input";
 import usePolicy from "src/hooks/api/usePolicy";
 
 const ModalAttachFiles = ({
-  title = "Upload new file",
+  title = "Attach a file",
+  subTitle = "Select the file that you would like to attach to your proposal.",
   show,
   onChange,
   onClose
@@ -14,7 +15,7 @@ const ModalAttachFiles = ({
   return (
     <Modal title={title} show={show} onClose={onClose}>
       <div className={styles.wrapper}>
-        <P>Please upload an image you want to attach to your proposal.</P>
+        <P>{subTitle}</P>
         {policy && (
           <P>
             Valid MIME types - image/png <br />


### PR DESCRIPTION
close #2477 

This pull request improve Embed image button in Mardown Editor.
* **The old behavior:** When clicking on the image button. An empty markdown image will be inserted in the editor. The user will need to copy the image url and define the name of the image
* **The new behavior:** When clicking on the image button. An upload image modal will be appeared. After selecting an image, the image url will be inserted to the markdown text at the current location of the cursor.


https://user-images.githubusercontent.com/84569563/132450260-2339fbc9-8da1-4800-acc4-f3fb36f672eb.mp4

