### PR TITLE
fix: Avoid registration error after unpaid user logout.

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -90,6 +90,10 @@ export const setPollingPointer = (paymentpolling) => {
 const POLL_INTERVAL = 10 * 1000;
 export const onPollUserPayment = () => (dispatch, getState) => {
   const userid = sel.currentUserID(getState());
+  if (!userid) {
+    clearPollingPointer();
+    return;
+  }
   return api
     .verifyUserPayment()
     .then((response) => response.haspaid)

--- a/src/components/HeaderNav/HeaderNav.jsx
+++ b/src/components/HeaderNav/HeaderNav.jsx
@@ -82,6 +82,7 @@ const HeaderNav = ({ history }) => {
 
   return user && username ? (
     <div
+      data-testid="header-nav"
       className={classNames(
         styles.loggedInContainer,
         !enableCredits && styles.noCreditsContainer

--- a/src/components/PaymentComponent/PaymentComponent.jsx
+++ b/src/components/PaymentComponent/PaymentComponent.jsx
@@ -19,6 +19,7 @@ const PaymentComponent = ({ address, amount, extraSmall, status }) => {
   return (
     <>
       <div
+        data-testid="payment-component"
         className={classNames(
           styles.paywallInfo,
           isDarkTheme && styles.dark,
@@ -41,7 +42,11 @@ const PaymentComponent = ({ address, amount, extraSmall, status }) => {
             tooltipPlacement={"bottom"}>
             {address}
           </CopyableText>
-          {!extraSmall && <PaymentStatusTag status={status} />}
+          {!extraSmall && (
+            <span data-testid="payment-status-tag">
+              <PaymentStatusTag status={status} />
+            </span>
+          )}
         </div>
       </div>
       <PaymentFaucet address={address} amount={amount} />

--- a/src/components/PaymentStatusTag/PaymentStatusTag.jsx
+++ b/src/components/PaymentStatusTag/PaymentStatusTag.jsx
@@ -27,6 +27,7 @@ const mapPaymentToStatusTag = {
     <StatusTag
       className={styles.statusTag}
       type="greenCheck"
+      data-testid="paywall-status-paid"
       text="Confirmed"
     />
   )

--- a/src/components/PaywallMessage.jsx
+++ b/src/components/PaywallMessage.jsx
@@ -24,7 +24,10 @@ const PaywallMessage = ({ wrapper, ...props }) => {
       <>
         <WrapperComponent {...props}>
           <StaticMarkdown contentName={paywallContent} />
-          <Button onClick={openPaywallModal} className="margin-top-m">
+          <Button
+            onClick={openPaywallModal}
+            className="margin-top-m"
+            data-testid="registration-fee-btn">
             Pay the registration fee
           </Button>
         </WrapperComponent>

--- a/teste2e/cypress/e2e/login.js
+++ b/teste2e/cypress/e2e/login.js
@@ -1,10 +1,39 @@
+const unpaidUser = {
+  email: "user3@example.com",
+  username: "user3",
+  password: "password"
+};
+
+const adminUser = {
+  email: "adminuser@example.com",
+  username: "adminuser",
+  password: "password"
+};
+
 describe("Login", () => {
   it("Can login", () => {
-    const user = {
-      email: "adminuser@example.com",
-      username: "adminuser",
-      password: "password"
-    };
-    cy.typeLogin(user);
+    cy.typeLogin(adminUser);
+  });
+  it("Can login with an unpaid user", () => {
+    cy.typeLogin(unpaidUser);
+    cy.findByTestId("registration-fee-btn").should("be.visible");
+  });
+  it("Can logout with a paid user", () => {
+    cy.typeLogin(adminUser);
+    cy.userLogout(adminUser.username);
+  });
+  it("Can logout with an unpaid user", () => {
+    cy.typeLogin(unpaidUser);
+    cy.userLogout(unpaidUser.username);
+    // wait to see if any payment requests are triggered
+    cy.wait(10000);
+    cy.findByTestId("header-nav").should("not.exist");
+  });
+  it("Can logout with an unpaid user on payment screen", () => {
+    cy.typeLogin(unpaidUser);
+    cy.findByTestId("registration-fee-btn").click();
+    cy.findByTestId("close").click();
+    cy.userLogout(unpaidUser.username);
+    cy.wait(10000);
   });
 });

--- a/teste2e/cypress/e2e/register.js
+++ b/teste2e/cypress/e2e/register.js
@@ -19,4 +19,21 @@ describe("Registration", () => {
       /Please check your inbox to verify your registration/i
     ).should("exist");
   });
+  it("can pay the registration fee", () => {
+    const unpaidUser = {
+      email: "user3@example.com",
+      password: "password"
+    };
+    cy.login(unpaidUser);
+    cy.visit("/");
+    cy.findByTestId("registration-fee-btn").click();
+    cy.findByTestId("payment-component").should("be.visible");
+    cy.middleware("users.payments.registration");
+    cy.middleware("users.payments.paywall");
+    cy.wait("@users.payments.registration", { timeout: 10000 });
+    cy.findByTestId("payment-status-tag")
+      .should("be.visible")
+      .children()
+      .should("have.text", "Confirmed");
+  });
 });

--- a/teste2e/cypress/support/commands.js
+++ b/teste2e/cypress/support/commands.js
@@ -34,6 +34,7 @@ import { shortRecordToken } from "../utils";
 import { middlewares as recordMiddlewares } from "./mock/records";
 import { middlewares as ticketVoteMiddlewares } from "./mock/ticketvote";
 import { middlewares as commentsMiddlewares } from "./mock/comments";
+import { middlewares as usersMiddlewares } from "./mock/users";
 
 Cypress.Commands.add("assertHome", () => {
   cy.url().should("eq", `${Cypress.config().baseUrl}/`);
@@ -82,6 +83,13 @@ Cypress.Commands.add("register", (user) => {
 
 Cypress.Commands.add("logout", () => {
   requestWithCsrfToken("api/v1/logout");
+});
+
+Cypress.Commands.add("userLogout", (username) => {
+  cy.get("[data-testid='header-nav']").findByText(username).click();
+  cy.get("[data-testid='header-nav']")
+    .findByText(/logout/i)
+    .click();
 });
 
 // Should use after login
@@ -158,7 +166,8 @@ Cypress.Commands.add("middleware", (path, ...args) => {
   const mw = get(path)({
     ticketvote: ticketVoteMiddlewares,
     records: recordMiddlewares,
-    comments: commentsMiddlewares
+    comments: commentsMiddlewares,
+    users: usersMiddlewares
   });
   return mw(...args).as(path);
 });

--- a/teste2e/cypress/support/generate.js
+++ b/teste2e/cypress/support/generate.js
@@ -60,6 +60,23 @@ export const buildRecordComment = ({
     upvotes
   })();
 
+export const buildPaymentRegistration = build("PaymentRegistration").fields({
+  paywalladdress: fake(
+    (f) => `Ts${f.datatype.hexaDecimal(33, false, /[0-9a-z]/)}`
+  ),
+  haspaid: true,
+  paywallamount: 1,
+  paywalltxnotbefore: Date.now() / 1000 - 3600
+});
+
+export const buildPaymentPaywall = build("PaymentPaywall").fields({
+  paywalltxnotbefore: Date.now() / 1000 - 3600,
+  paywalladdress: fake(
+    (f) => `Ts${f.datatype.hexaDecimal(33, false, /[0-9a-z]/)}`
+  ),
+  creditprice: 10000000
+});
+
 const fakeToken = () => buildRecord().token;
 
 /**

--- a/teste2e/cypress/support/mock/users.js
+++ b/teste2e/cypress/support/mock/users.js
@@ -1,0 +1,18 @@
+import { buildPaymentRegistration, buildPaymentPaywall } from "../generate";
+
+const API_URL = "/api/v1/user";
+
+export const middlewares = {
+  payments: {
+    registration: () =>
+      cy.intercept(`${API_URL}/payments/registration`, (req) => {
+        const registration = buildPaymentRegistration();
+        req.reply({ body: registration });
+      }),
+    paywall: () =>
+      cy.intercept(`${API_URL}/payments/paywall`, (req) => {
+        const paywall = buildPaymentPaywall();
+        req.reply({ body: paywall, statusCode: 200 });
+      })
+  }
+};


### PR DESCRIPTION
Closes #2562.

This fixes an error triggered after an unpaid user logout. It happened
due to the payment polling call not being canceled on logout action.

It also adds E2E tests for user registration, login and logout.

### UI Changes Screenshot

**Before**
![before](https://user-images.githubusercontent.com/22639213/132261125-16802995-3bd1-4603-b3e6-d747332f0f0c.gif)

**After**
![unregistered-users-logout-error-fix](https://user-images.githubusercontent.com/22639213/132591891-6f9b913b-a12b-43d3-9a63-bc8df17c00e2.gif)
