### PR TITLE
fix: Use correct delay for comment votes e2e tests.

### DIFF
--- a/teste2e/cypress/e2e/comments/commentsVotes.js
+++ b/teste2e/cypress/e2e/comments/commentsVotes.js
@@ -86,7 +86,7 @@ describe("Comments Votes", () => {
     let token;
     beforeEach(() => {
       cy.middleware("comments.comments", 50);
-      cy.middleware("comments.vote", { isError: true, throttleKbps: 50 });
+      cy.middleware("comments.vote", { isError: true, delay: 3000 });
       cy.intercept("/api/ticketvote/v1/inventory").as("inventory");
       cy.visit("/");
       cy.wait("@inventory").then(
@@ -107,6 +107,13 @@ describe("Comments Votes", () => {
         .then((score) => (upvotes = score[0].innerText));
       cy.wait(1000);
       cy.findAllByTestId("like-btn").first().click();
+      cy.wait(1000);
+      cy.findAllByTestId("score-like")
+        .first()
+        .then((score) => {
+          const newup = score[0].innerText;
+          expect(Number(newup)).to.equal(Number(upvotes) + 1);
+        });
       cy.wait("@comments.vote");
       // assert votes count after delayed vote response
       cy.findAllByTestId("score-like")

--- a/teste2e/cypress/e2e/comments/commentsVotes.js
+++ b/teste2e/cypress/e2e/comments/commentsVotes.js
@@ -99,7 +99,7 @@ describe("Comments Votes", () => {
       cy.findAllByTestId("dislike-btn").first().click();
       cy.findByText(/Error/).should("exist");
     });
-    it("shouldn't change votes count on error", () => {
+    it("should reset votes count on error", () => {
       let upvotes;
       cy.visit(`/record/${shortRecordToken(token)}`);
       cy.findAllByTestId("score-like")

--- a/teste2e/cypress/support/mock/comments.js
+++ b/teste2e/cypress/support/mock/comments.js
@@ -30,12 +30,12 @@ export const middlewares = {
       )(0);
       req.reply({ body: { comments } });
     }),
-  vote: ({ isError, throttleKbps = 1000000 } = {}) =>
+  vote: ({ isError, delay = 0 } = {}) =>
     cy.intercept("/api/comments/v1/vote", (req) => {
       req.reply({
         body: isError ? { errorcode: 10, pluginid: "comments" } : {},
         statusCode: isError ? 400 : 200,
-        throttleKbps
+        delay: delay
       });
     })
 };


### PR DESCRIPTION
This fixes the optimistic votes E2E tests for failed votes count.