### PR TITLE
fix: keep `comments` redux store on logout.

### DIFF
--- a/src/reducers/models/comments.js
+++ b/src/reducers/models/comments.js
@@ -226,7 +226,6 @@ const comments = (state = DEFAULT_STATE, action) =>
             }
             return state;
           },
-          [act.RECEIVE_LOGOUT]: () => DEFAULT_STATE,
           [act.RECEIVE_CMS_LOGOUT]: () => DEFAULT_STATE
         }[action.type] || (() => state)
       )();


### PR DESCRIPTION
This diff fixes a bug where comments were cleared from the redux store 
on logout which shouldn't be the case as the comments are public
information and should be displayed without an active user session.

This bug originates in [#1729](https://github.com/decred/politeiagui/pull/1728/files#diff-16d2c3eeefa7ad1e36fd6ba4dd4c8b6899d095ead297f68fdd110345bc186647R139)