### PR TITLE
proposal: Data persistence after unvetted logout.

### DIFF
--- a/src/components/ModalLogin.jsx
+++ b/src/components/ModalLogin.jsx
@@ -11,6 +11,7 @@ const ModalLogin = ({ title = "Login", onLoggedIn, onClose, ...props }) => {
       onClose={onClose}
       iconType="info"
       iconSize="lg"
+      data-testid="modal-login"
       {...props}
       contentStyle={{ width: "100%" }}
       titleStyle={{ paddingRight: "4rem" }}>

--- a/src/components/WhatAreYourThoughts/WhatAreYourThoughts.jsx
+++ b/src/components/WhatAreYourThoughts/WhatAreYourThoughts.jsx
@@ -18,7 +18,10 @@ const WhatAreYourThoughts = ({ onLoginClick, onSignupClick }) => {
       </Text>
       <div className={styles.buttonsWrapper}>
         {onLoginClick && (
-          <Button kind="secondary" onClick={onLoginClick}>
+          <Button
+            kind="secondary"
+            onClick={onLoginClick}
+            data-testid="wayt-login-button">
             Log in
           </Button>
         )}

--- a/src/containers/Proposal/Detail/hooks.js
+++ b/src/containers/Proposal/Detail/hooks.js
@@ -182,10 +182,11 @@ export function useProposal(token, threadParentID) {
     proposals
   );
 
-  const onReloadProposalDetails = useCallback(
-    () => send("RETRY", { status: "idle" }),
-    [send]
-  );
+  const onReloadProposalDetails = () => send("RETRY", { status: "idle" });
+  // const onReloadProposalDetails = useCallback(
+  //   () => send("RETRY", { status: "idle" }),
+  //   [send]
+  // );
   const proposalToken = getProposalToken(proposalWithLinks);
   const proposalState = proposalWithLinks?.state;
 

--- a/src/containers/Proposal/Detail/hooks.js
+++ b/src/containers/Proposal/Detail/hooks.js
@@ -182,11 +182,11 @@ export function useProposal(token, threadParentID) {
     proposals
   );
 
-  const onReloadProposalDetails = () => send("RETRY", { status: "idle" });
-  // const onReloadProposalDetails = useCallback(
-  //   () => send("RETRY", { status: "idle" }),
-  //   [send]
-  // );
+  const onReloadProposalDetails = useCallback(
+    () => send("RETRY", { status: "idle" }),
+    [send]
+  );
+
   const proposalToken = getProposalToken(proposalWithLinks);
   const proposalState = proposalWithLinks?.state;
 

--- a/src/containers/Proposal/Detail/hooks.js
+++ b/src/containers/Proposal/Detail/hooks.js
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, useCallback } from "react";
 import * as sel from "src/selectors";
 import * as act from "src/actions";
 import { useSelector, useAction } from "src/redux";
@@ -182,6 +182,10 @@ export function useProposal(token, threadParentID) {
     proposals
   );
 
+  const onReloadProposalDetails = useCallback(
+    () => send("RETRY", { status: "idle" }),
+    [send]
+  );
   const proposalToken = getProposalToken(proposalWithLinks);
   const proposalState = proposalWithLinks?.state;
 
@@ -206,6 +210,7 @@ export function useProposal(token, threadParentID) {
     onSubmitComment,
     commentsError,
     currentUser,
-    commentsLoading
+    commentsLoading,
+    onReloadProposalDetails
   };
 }

--- a/src/containers/User/Login/Form.jsx
+++ b/src/containers/User/Login/Form.jsx
@@ -116,7 +116,11 @@ const LoginForm = ({
             />
             <Actions>
               <Link to="/user/request-reset-password">Reset Password</Link>
-              <Button loading={isSubmitting} kind="primary" type="submit">
+              <Button
+                loading={isSubmitting}
+                kind="primary"
+                type="submit"
+                data-testid="login-form-button">
                 Login
               </Button>
             </Actions>

--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -98,7 +98,7 @@ RecordsUserError.prototype = new Error();
 function CommentsUserError(code) {
   const errorMap = {
     1: "Invalid inputs for request",
-    2: "Unvetted records can only be voted by an admin or the author",
+    2: "You must be an author or admin to perform this action",
     3: "The user public key is not active",
     4: "The provided signature was invalid for this comment",
     5: "The record has an invalid state",

--- a/src/reducers/models/comments.js
+++ b/src/reducers/models/comments.js
@@ -11,7 +11,8 @@ import {
   PROPOSAL_STATUS_PUBLIC,
   PROPOSAL_STATUS_UNREVIEWED,
   PROPOSAL_MAIN_THREAD_KEY,
-  PROPOSAL_UPDATE_HINT
+  PROPOSAL_UPDATE_HINT,
+  PROPOSAL_STATE_UNVETTED
 } from "src/constants";
 
 const DEFAULT_STATE = {
@@ -284,6 +285,21 @@ const comments = (state = DEFAULT_STATE, action) =>
               ];
             }
             return state;
+          },
+          [act.RECEIVE_LOGOUT]: function removeUnvettedComments() {
+            return update(["comments", "byToken"], (commentsByToken) =>
+              Object.keys(commentsByToken).reduce((acc, token) => {
+                const { sectionIds, comments } = commentsByToken[token];
+                const isUnvetted = sectionIds.some((sec) =>
+                  comments[sec].some(
+                    ({ state }) => state === PROPOSAL_STATE_UNVETTED
+                  )
+                );
+                return isUnvetted
+                  ? { ...acc }
+                  : { ...acc, [token]: commentsByToken[token] };
+              }, {})
+            )(state);
           },
           [act.RECEIVE_CMS_LOGOUT]: () => DEFAULT_STATE
         }[action.type] || (() => state)

--- a/src/reducers/models/proposals.js
+++ b/src/reducers/models/proposals.js
@@ -149,15 +149,29 @@ const updateInventory = (payload) => (allProps) => {
 const onReceiveLogout = (state) =>
   compose(
     update("byToken", (data) => {
-      const vetteds = {};
+      const vetted = {};
+      const unvetted = {};
       Object.keys(data).flatMap((id) =>
         data[id].state === PROPOSAL_STATE_VETTED
-          ? (vetteds[id] = {
+          ? (vetted[id] = {
               ...data[id]
+            })
+          : data[id].state === PROPOSAL_STATE_UNVETTED
+          ? (unvetted[id] = {
+              name: id,
+              censorshiprecord: data[id].censorshiprecord,
+              userid: data[id].userid,
+              username: data[id].username,
+              state: data[id].state,
+              status: data[id].status,
+              files: [],
+              timestamp: data[id].timestamp,
+              version: data[id].version,
+              metadata: data[id].metadata
             })
           : []
       );
-      return vetteds;
+      return { ...vetted, ...unvetted };
     }),
     set("allProposalsByUserId", DEFAULT_STATE.allProposalsByUserId),
     set("allTokensByUserId", DEFAULT_STATE.allTokensByUserId),

--- a/teste2e/cypress/e2e/proposal/detail.js
+++ b/teste2e/cypress/e2e/proposal/detail.js
@@ -118,8 +118,10 @@ describe("Record Details", () => {
         cy.userLogout(admin.username);
         cy.visit(`/record/${shortToken}`);
         cy.wait("@details");
+        cy.wait(1000);
         cy.findByTestId("wayt-login-button").click();
         cy.typeLoginModal(admin);
+        cy.wait("@details");
         cy.findByTestId("markdown-wrapper").should("exist");
         cy.get("#commentArea").should("exist");
       });

--- a/teste2e/cypress/e2e/proposal/detail.js
+++ b/teste2e/cypress/e2e/proposal/detail.js
@@ -88,5 +88,33 @@ describe("Record Details", () => {
         cy.wait("@details").its("response.statusCode").should("eq", 400);
       });
     });
+    describe("user proposals actions", () => {
+      const admin = {
+        email: "adminuser@example.com",
+        username: "adminuser",
+        password: "password"
+      };
+      beforeEach(() => {
+        cy.login(admin);
+        cy.visit("/admin/records");
+        cy.wait("@records").then(({ response: { body } }) => {
+          const { records } = body;
+          shortToken = getShortProposalToken(records);
+          expect(shortToken, "You should have at least one unvetted record.").to
+            .exist;
+        });
+      });
+      it("can logout from unvetted proposals details page", () => {
+        cy.visit(`/record/${shortToken}`);
+        cy.wait("@details");
+        cy.findByTestId("record-header").should("be.visible");
+        cy.findByTestId("markdown-wrapper").should("exist");
+        cy.userLogout(admin.username);
+        cy.wait(2000);
+        // assert that proposal files were removed from store
+        cy.findByTestId("record-header").should("be.visible");
+        cy.findByTestId("markdown-wrapper").should("not.exist");
+      });
+    });
   });
 });

--- a/teste2e/cypress/e2e/proposal/detail.js
+++ b/teste2e/cypress/e2e/proposal/detail.js
@@ -69,11 +69,6 @@ describe("Record Details", () => {
           .and("have.length", 2);
         // assert description existence
         cy.get("[data-testid='markdown-wrapper']").should("exist");
-        // assert downloads existence
-        cy.get("[data-testid='record-links']").click();
-        cy.get("[data-testid='record-links']")
-          .and("include.text", "Proposal Timestamps")
-          .and("include.text", "Proposal Bundle");
         // assert metadata existence
         cy.get("[data-testid='record-metadata']")
           .should("include.text", "Domain")
@@ -104,7 +99,8 @@ describe("Record Details", () => {
             .exist;
         });
       });
-      it("can logout from unvetted proposals details page", () => {
+      it("should be able to logout from unvetted proposal details page", () => {
+        cy.middleware("comments.comments", 10, 1);
         cy.visit(`/record/${shortToken}`);
         cy.wait("@details");
         cy.findByTestId("record-header").should("be.visible");
@@ -114,6 +110,18 @@ describe("Record Details", () => {
         // assert that proposal files were removed from store
         cy.findByTestId("record-header").should("be.visible");
         cy.findByTestId("markdown-wrapper").should("not.exist");
+        cy.get("#commentArea").should("not.exist");
+      });
+      it("should render unvetted proposal details after admin/author login", () => {
+        cy.visit("/");
+        cy.wait("@records");
+        cy.userLogout(admin.username);
+        cy.visit(`/record/${shortToken}`);
+        cy.wait("@details");
+        cy.findByTestId("wayt-login-button").click();
+        cy.typeLoginModal(admin);
+        cy.findByTestId("markdown-wrapper").should("exist");
+        cy.get("#commentArea").should("exist");
       });
     });
   });

--- a/teste2e/cypress/errors.js
+++ b/teste2e/cypress/errors.js
@@ -98,7 +98,7 @@ RecordsUserError.prototype = new Error();
 function CommentsUserError(code) {
   const errorMap = {
     1: "Invalid inputs for request",
-    2: "Unvetted records can only be voted by an admin or the author",
+    2: "You must be an author or admin to perform this action",
     3: "The user public key is not active",
     4: "The provided signature was invalid for this comment",
     5: "The record has an invalid state",

--- a/teste2e/cypress/support/commands.js
+++ b/teste2e/cypress/support/commands.js
@@ -60,9 +60,16 @@ Cypress.Commands.add("typeLogin", (user) => {
   cy.visit("/user/login");
   cy.findByLabelText(/email/i).type(user.email);
   cy.findByLabelText(/password/i).type(user.password);
-  cy.findByRole("button", { text: /login/i }).click();
+  cy.findByTestId("login-form-button").click();
   cy.assertHome();
   cy.assertLoggedInAs();
+});
+
+Cypress.Commands.add("typeLoginModal", (user) => {
+  cy.findByTestId("modal-login").should("be.visible");
+  cy.findByLabelText(/email/i).type(user.email);
+  cy.findByLabelText(/password/i).type(user.password);
+  cy.findByTestId("login-form-button").click();
 });
 
 Cypress.Commands.add("login", (user) => {


### PR DESCRIPTION
Closes #2584

This diff fixes the infinite loading issue on unvetted proposal page
after author or admin logout, by persisting the public data for 
unvetted records on the redux store after the logout.

Adds e2e tests for unvetted proposal details logout action.

### UI Changes Screenshot

Before:
![before-2584](https://user-images.githubusercontent.com/22639213/133301825-ffe48c75-6d4a-498e-8539-d6717d83e853.gif)

After:
![unvetted-logout-bug-fix](https://user-images.githubusercontent.com/22639213/133318810-d81d021e-76d2-44a9-86d7-df2e4f0306d3.gif)

