### PR TITLE
fix: Record submission error message position

### DIFF
--- a/src/components/ProposalForm/ProposalForm.jsx
+++ b/src/components/ProposalForm/ProposalForm.jsx
@@ -211,7 +211,7 @@ const ProposalForm = React.memo(function ProposalForm({
   const textAreaProps = useMemo(() => ({ tabIndex: 2 }), []);
 
   const hasError = errors && errors.global;
-  useScrollTo("errorMessage", hasError);
+  useScrollTo("record-submission-error-message", hasError);
 
   return (
     <form onSubmit={handleSubmit}>
@@ -401,7 +401,7 @@ const ProposalForm = React.memo(function ProposalForm({
       {hasError && (
         <Row>
           <Message
-            id="errorMessage"
+            id="record-submission-error-message"
             className={classNames(styles.errorRow, "margin-bottom-m")}
             kind="error">
             {errors.global.toString()}

--- a/src/components/ProposalForm/ProposalForm.jsx
+++ b/src/components/ProposalForm/ProposalForm.jsx
@@ -400,7 +400,7 @@ const ProposalForm = React.memo(function ProposalForm({
       )}
       {hasError && (
         <Row>
-          <Message 
+          <Message
             id="errorMessage"
             className={classNames(styles.errorRow, "margin-bottom-m")}
             kind="error">

--- a/src/components/ProposalForm/ProposalForm.jsx
+++ b/src/components/ProposalForm/ProposalForm.jsx
@@ -46,6 +46,7 @@ import {
 import { convertObjectToUnixTimestamp } from "src/helpers";
 import { isActiveApprovedRfp } from "src/containers/Proposal/helpers";
 import useModalContext from "src/hooks/utils/useModalContext";
+import useScrollTo from "src/hooks/utils/useScrollTo";
 import FormatHelpButton from "./FormatHelpButton";
 import SubmitButton from "./SubmitButton";
 
@@ -209,6 +210,9 @@ const ProposalForm = React.memo(function ProposalForm({
 
   const textAreaProps = useMemo(() => ({ tabIndex: 2 }), []);
 
+  const hasError = errors && errors.global;
+  useScrollTo("errorMessage", hasError);
+
   return (
     <form onSubmit={handleSubmit}>
       <Message kind="warning" className="margin-bottom-m">
@@ -216,11 +220,6 @@ const ProposalForm = React.memo(function ProposalForm({
         something goes wrong. We recommend drafting the content offline then
         using the editor to submit the final version.
       </Message>
-      {errors && errors.global && (
-        <Message className="margin-bottom-m" kind="error">
-          {errors.global.toString()}
-        </Message>
-      )}
       <Row
         noMargin
         wrap={smallTablet}
@@ -398,6 +397,16 @@ const ProposalForm = React.memo(function ProposalForm({
             />
           </Row>
         </>
+      )}
+      {hasError && (
+        <Row>
+          <Message 
+            id="errorMessage"
+            className={classNames(styles.errorRow, "margin-bottom-m")}
+            kind="error">
+            {errors.global.toString()}
+          </Message>
+        </Row>
       )}
     </form>
   );

--- a/src/components/ProposalForm/ProposalForm.module.css
+++ b/src/components/ProposalForm/ProposalForm.module.css
@@ -12,6 +12,10 @@
   padding-bottom: 0.5em;
 }
 
+.errorRow {
+  width: 100%;
+}
+
 .errorMsg {
   color: var(--color-orange);
   font-size: var(--font-size-small);


### PR DESCRIPTION
This diff moves the error message position to below the Submit button on the record submission page.

closes #2531 

UI changes:

Desktop:
![image](https://user-images.githubusercontent.com/2729122/134019118-321e1a7d-c060-4945-b1f0-0deea6d107cc.png)

Mobile (iPhone X):
![image](https://user-images.githubusercontent.com/2729122/134019402-1b0a54ad-6de0-4663-bc11-63b7458fd9ce.png)
