### PR TITLE
fix: 2FA modal screen flickering.

### DIFF
--- a/src/components/DigitsInput/DigitsInput.module.css
+++ b/src/components/DigitsInput/DigitsInput.module.css
@@ -35,3 +35,9 @@
   height: 0;
   width: 0;
 }
+
+@media screen and (max-width: 560px) {
+  .digitsWrapper > div {
+    margin-right: 1rem;
+  }
+}

--- a/src/components/ModalTotpVerify.jsx
+++ b/src/components/ModalTotpVerify.jsx
@@ -4,7 +4,7 @@ import { Modal, Message } from "pi-ui";
 import VerifyTotp from "src/containers/User/Totp/Verify";
 import { TOTP_CODE_LENGTH } from "src/constants";
 
-const ModalTotpVerify = ({ show, onClose, onVerify }) => {
+const Verify = ({ onClose, onVerify }) => {
   const [error, setError] = useState();
   const handleChange = (v) => {
     if (v.length === TOTP_CODE_LENGTH) {
@@ -18,28 +18,32 @@ const ModalTotpVerify = ({ show, onClose, onVerify }) => {
     }
   };
   return (
-    <Modal show={show} onClose={onClose} title="Verify 2FA Code">
-      <>
-        {error && (
-          <Message kind="error" className="margin-bottom-m">
-            {error.toString()}
-          </Message>
-        )}
-        <VerifyTotp
-          onType={handleChange}
-          extended={false}
-          tabIndex={1}
-          title="Authenticator Code"
-        />
-      </>
-    </Modal>
+    <div>
+      {error && (
+        <Message kind="error" className="margin-bottom-m">
+          {error.toString()}
+        </Message>
+      )}
+      <VerifyTotp
+        onType={handleChange}
+        extended={false}
+        tabIndex={1}
+        title="Authenticator Code"
+      />
+    </div>
   );
 };
 
-ModalTotpVerify.propTypes = {
+const ModalWrapper = ({ show, onClose, onVerify }) => (
+  <Modal show={show} onClose={onClose} title="Verify 2FA Code">
+    <Verify onVerify={onVerify} onClose={onClose} />
+  </Modal>
+);
+
+ModalWrapper.propTypes = {
   show: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   onVerify: PropTypes.func.isRequired
 };
 
-export default ModalTotpVerify;
+export default ModalWrapper;

--- a/src/components/ModalTotpVerify.jsx
+++ b/src/components/ModalTotpVerify.jsx
@@ -4,7 +4,7 @@ import { Modal, Message } from "pi-ui";
 import VerifyTotp from "src/containers/User/Totp/Verify";
 import { TOTP_CODE_LENGTH } from "src/constants";
 
-const Verify = ({ onClose, onVerify }) => {
+const ModalTotpVerifyContent = ({ onClose, onVerify }) => {
   const [error, setError] = useState();
   const handleChange = (v) => {
     if (v.length === TOTP_CODE_LENGTH) {
@@ -34,16 +34,16 @@ const Verify = ({ onClose, onVerify }) => {
   );
 };
 
-const ModalWrapper = ({ show, onClose, onVerify }) => (
+const ModalTotpVerify = ({ show, onClose, onVerify }) => (
   <Modal show={show} onClose={onClose} title="Verify 2FA Code">
-    <Verify onVerify={onVerify} onClose={onClose} />
+    <ModalTotpVerifyContent onVerify={onVerify} onClose={onClose} />
   </Modal>
 );
 
-ModalWrapper.propTypes = {
+ModalTotpVerify.propTypes = {
   show: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   onVerify: PropTypes.func.isRequired
 };
 
-export default ModalWrapper;
+export default ModalTotpVerify;


### PR DESCRIPTION
Closes #2556 

This diff fixes the screen flickering for failing 2FA modal actions
on Firefox by using a modal wrapper for the 2FA modal to prevent it
from re-renders.

### UI Changes

**Before:**
![2556-2fa-modal-flicker-before](https://user-images.githubusercontent.com/22639213/134429551-bf6a76f6-fb78-42f6-bcd3-f26c0b0ad5dc.gif)

**After:**
![2556-2fa-modal-flicker](https://user-images.githubusercontent.com/22639213/134429560-691ba2ea-db43-4ef6-a527-cb8d62097546.gif)

