### PR TITLE
fix: Comments timestamp download infinite loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ yalc.lock
 
 cypress/videos
 cypress/screenshots
+teste2e/cypress/downloads

--- a/src/containers/Comments/Download/hooks.js
+++ b/src/containers/Comments/Download/hooks.js
@@ -44,7 +44,10 @@ export function useDownloadCommentsTimestamps(recordToken) {
     [recordToken]
   );
   const allCommentsBySection = useSelector(commentsSelector);
-  const comments = Object.values(allCommentsBySection).flat();
+  const comments = useMemo(
+    () => Object.values(allCommentsBySection).flat(),
+    [allCommentsBySection]
+  );
   const commentsLength = comments?.length || 0;
   const multiPage = commentsLength > TIMESTAMPS_PAGE_SIZE;
   const onFetchCommentsTimestamps = useAction(act.onFetchCommentsTimestamps);

--- a/teste2e/cypress/utils.js
+++ b/teste2e/cypress/utils.js
@@ -1,7 +1,13 @@
 import CryptoJS from "crypto-js";
-import get from "lodash/fp/get";
 import * as pki from "./pki";
 import MerkleTree from "./merkle";
+import compose from "lodash/fp/compose";
+import filter from "lodash/fp/filter";
+import keys from "lodash/fp/keys";
+import first from "lodash/fp/first";
+import get from "lodash/fp/get";
+import find from "lodash/fp/find";
+import path from "path";
 
 const PROPOSAL_TYPE_REGULAR = 1;
 const PROPOSAL_TYPE_RFP = 2;
@@ -31,6 +37,23 @@ const PROPOSAL_STATUS_UNREVIEWED = 1;
 const PROPOSAL_STATUS_PUBLIC = 2;
 const PROPOSAL_STATUS_CENSORED = 3;
 const PROPOSAL_STATUS_ARCHIVED = 4;
+
+const findRecordFileByName = (record, name) =>
+  compose(
+    find((file) => file.name === name),
+    get("files")
+  )(record);
+
+export const getFirstShortProposalToken = (records = {}) =>
+  compose(
+    first,
+    filter(
+      (token) =>
+        !findRecordFileByName(records[token], VOTE_METADATA_FILENAME) &&
+        findRecordFileByName(records[token], PROPOSAL_METADATA_FILENAME)
+    ),
+    keys
+  )(records);
 
 export const requestWithCsrfToken = (url, body, failOnStatusCode = true) =>
   cy.request("/api").then((res) =>


### PR DESCRIPTION
This diff fixes the infinite loop when attempting to download comments
timestamps results.

The bug originates in the following `useMemo` usage discussion:
https://github.com/decred/politeiagui/pull/2549#discussion_r711424772

---

Closes #2606.
