### PR TITLE
fix: Type error on comment bundle download

### DIFF
--- a/src/containers/Comments/Download/hooks.js
+++ b/src/containers/Comments/Download/hooks.js
@@ -28,7 +28,8 @@ export function useDownloadComments(token) {
     [token]
   );
   const allCommentsBySection = useSelector(commentsSelector);
-  const comments = Object.values(allCommentsBySection).flat();
+  const comments = allCommentsBySection && 
+    Object.values(allCommentsBySection).flat();
   const { onFetchCommentsTimestamps } = useTimestamps();
 
   return { comments, onFetchCommentsTimestamps };

--- a/src/containers/Comments/Download/hooks.js
+++ b/src/containers/Comments/Download/hooks.js
@@ -28,8 +28,8 @@ export function useDownloadComments(token) {
     [token]
   );
   const allCommentsBySection = useSelector(commentsSelector);
-  const comments = allCommentsBySection && 
-    Object.values(allCommentsBySection).flat();
+  const comments =
+    allCommentsBySection && Object.values(allCommentsBySection).flat();
   const { onFetchCommentsTimestamps } = useTimestamps();
 
   return { comments, onFetchCommentsTimestamps };


### PR DESCRIPTION
This diff adds a check to see if comments are properly loaded on the
redux store before manipulating it as an object, which would result 
in the type error.

closes #2607 
