### PR TITLE
refactor: Clear 2FA code on error.

### DIFF
--- a/src/components/ModalTotpVerify.jsx
+++ b/src/components/ModalTotpVerify.jsx
@@ -6,13 +6,14 @@ import { TOTP_CODE_LENGTH } from "src/constants";
 
 const ModalTotpVerifyContent = ({ onClose, onVerify }) => {
   const [error, setError] = useState();
-  const handleChange = (v) => {
+  const handleChange = (v, clearCode) => {
     if (v.length === TOTP_CODE_LENGTH) {
       onVerify(v)
         .then(() => {
           onClose();
         })
         .catch((e) => {
+          clearCode();
           setError(e);
         });
     }

--- a/src/containers/User/Totp/Verify.jsx
+++ b/src/containers/User/Totp/Verify.jsx
@@ -24,7 +24,9 @@ const VerifyTotp = ({
   const onFillCode = (newCode) => {
     setEnableVerify(newCode.length === TOTP_CODE_LENGTH);
     setCode(newCode);
-    onType(newCode);
+    onType(newCode, () => {
+      setCode("");
+    });
   };
   const handleVerify = (e) => {
     e && e.preventDefault();


### PR DESCRIPTION
Closes #2619.

----

This diff updates the 2FA workflow to clear out the 2FA code from the
modal if an error is returned by the server. The cursor is also reset
back to the first digit so that the user can easily input a new 2FA
code.

Previously, if the server returned a 2FA error the invalid code was
not cleared out and the user was forced to manually click the first
digit of the input box if they wanted to input a new code.

https://user-images.githubusercontent.com/9039877/135285128-87d9398e-b1a3-41c2-a995-f91ae629ea42.mp4