### PR TITLE
ux: Add min loading time to list views.

### DIFF
--- a/src/components/LazyList.jsx
+++ b/src/components/LazyList.jsx
@@ -20,23 +20,23 @@ const LazyList = ({
   emptyListComponent,
   renderItem,
   pageStart,
-  minimumInitialLoading
+  minInitialLoading
 }) => {
   const isEmpty = !items.length;
   const [initialLoading, setInitialLoading] = useState(true);
   useEffect(() => {
     let timer;
-    if (minimumInitialLoading > 0 && initialLoading) {
+    if (minInitialLoading > 0 && initialLoading) {
       timer = setTimeout(() => {
         setInitialLoading(false);
-      }, minimumInitialLoading);
+      }, minInitialLoading);
     }
     return () => {
       // clearTimeout when the component is unmounted.
       clearTimeout(timer);
     };
-  }, [minimumInitialLoading, initialLoading]);
-  const placeholdersLoading = isLoading || initialLoading;
+  }, [minInitialLoading, initialLoading]);
+  const arePlaceholdersLoading = isLoading || initialLoading;
   return (
     <div data-testid="lazy-list">
       <InfiniteScroll
@@ -46,7 +46,7 @@ const LazyList = ({
         hasMore={hasMore}>
         {items.map(renderItem)}
       </InfiniteScroll>
-      {placeholdersLoading ? (
+      {arePlaceholdersLoading ? (
         <div data-testid="loading-placeholders">{loadingPlaceholder}</div>
       ) : isEmpty ? (
         emptyListComponent
@@ -64,7 +64,7 @@ LazyList.propTypes = {
   loadingPlaceholder: PropTypes.node,
   hasMore: PropTypes.bool,
   pageStart: PropTypes.number,
-  minimumInitialLoading: PropTypes.number
+  minInitialLoading: PropTypes.number
 };
 
 LazyList.defaultProps = {
@@ -72,7 +72,7 @@ LazyList.defaultProps = {
   emptyListComponent: <DefaultEmptyList />,
   loadingPlaceholder: <DefaultLoader />,
   pageStart: 0,
-  minimumInitialLoading: 1250
+  minInitialLoading: 1250
   // 1250 allows the animation to complete one full cycle.
 };
 


### PR DESCRIPTION
Closes #2586.

This diff adds a minimum timeout of 1.25s when loading the proposal
lists, if the list does not contain any proposals. This creates a
smoother UX since the loading animation is not abruptly cut off.

**Old UX**

https://user-images.githubusercontent.com/9039877/133443369-e6144e7c-3083-4683-8f8e-a69220237804.mp4

**New UX**


https://user-images.githubusercontent.com/9039877/138359346-8a2f66ca-675f-4114-a7d0-6d8840b41651.mp4



