### PR TITLE
Make proposal details title a link.

### DIFF
--- a/src/components/Proposal/Proposal.jsx
+++ b/src/components/Proposal/Proposal.jsx
@@ -295,7 +295,7 @@ const Proposal = React.memo(function Proposal({
                   truncate
                   isLegacy={isLegacy}
                   linesBeforeTruncate={2}
-                  url={extended ? "" : proposalURL}>
+                  url={proposalURL}>
                   {name || shortToken}
                 </Title>
               }


### PR DESCRIPTION
Closes #2649

This diff make the proposal details title be a link. Allow the ability
to click on the title to navigate the user back to the base proposal
details page from the comment link