### PR TITLE
fix: Go Back link navigation

### DIFF
--- a/src/components/Router/GoBackLink.jsx
+++ b/src/components/Router/GoBackLink.jsx
@@ -12,7 +12,7 @@ function isExactMatch(match) {
   return match?.isExact;
 }
 
-const GoBackLink = ({ label, hierarchy, rootLink, breakpoint }) => {
+const GoBackLink = ({ label, hierarchy, breakpoint }) => {
   const { themeName } = useTheme();
   const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
   const { history, navigationHistory } = useRouter();
@@ -43,9 +43,7 @@ const GoBackLink = ({ label, hierarchy, rootLink, breakpoint }) => {
     [navigationHistory, breakpoint]
   );
 
-  return !previousHierarchyLink &&
-    !rootLink &&
-    previousDefaultLinkIndex < 0 ? null : (
+  return !previousHierarchyLink && previousDefaultLinkIndex < 0 ? null : (
     <div className={styles.returnLinkContainer}>
       <Link
         className={classNames(
@@ -55,8 +53,6 @@ const GoBackLink = ({ label, hierarchy, rootLink, breakpoint }) => {
         onClick={() =>
           previousHierarchyLink
             ? history.push(previousHierarchyLink)
-            : rootLink
-            ? history.push(rootLink)
             : history.go(-(previousDefaultLinkIndex + 1))
         }>
         {backArrow} {label}
@@ -68,7 +64,6 @@ const GoBackLink = ({ label, hierarchy, rootLink, breakpoint }) => {
 GoBackLink.propTypes = {
   label: PropTypes.string,
   hierarchy: PropTypes.arrayOf(PropTypes.string),
-  rootLink: PropTypes.string,
   breakpoint: PropTypes.string
 };
 

--- a/src/components/Router/GoBackLink.jsx
+++ b/src/components/Router/GoBackLink.jsx
@@ -4,6 +4,7 @@ import { matchPath } from "react-router-dom";
 import { Link, classNames, useTheme, DEFAULT_DARK_THEME_NAME } from "pi-ui";
 import { useRouter } from "src/components/Router";
 import styles from "./GoBackLink.module.css";
+import findIndex from "lodash/fp/findIndex";
 
 const backArrow = <>&#8592;</>;
 
@@ -11,13 +12,13 @@ function isExactMatch(match) {
   return match?.isExact;
 }
 
-const GoBackLink = ({ label, hierarchy }) => {
+const GoBackLink = ({ label, hierarchy, rootLink, breakpoint }) => {
   const { themeName } = useTheme();
   const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
-  const { history } = useRouter();
+  const { history, navigationHistory } = useRouter();
   const hierarchyRef = useRef(hierarchy);
-
-  const previousLink = useMemo(() => {
+  const previousHierarchyLink = useMemo(() => {
+    if (!hierarchyRef.current) return;
     const hierarchyMatches = hierarchyRef.current.map((path) =>
       matchPath(history.location.pathname, {
         path,
@@ -30,7 +31,21 @@ const GoBackLink = ({ label, hierarchy }) => {
     return previousMatch.url;
   }, [history]);
 
-  return (
+  const previousDefaultLinkIndex = useMemo(
+    () =>
+      findIndex(
+        (prev) =>
+          !matchPath(prev.pathname, {
+            path: breakpoint,
+            strict: true
+          })
+      )(navigationHistory),
+    [navigationHistory, breakpoint]
+  );
+
+  return !previousHierarchyLink &&
+    !rootLink &&
+    previousDefaultLinkIndex < 0 ? null : (
     <div className={styles.returnLinkContainer}>
       <Link
         className={classNames(
@@ -38,7 +53,11 @@ const GoBackLink = ({ label, hierarchy }) => {
           isDarkTheme && styles.darkReturnLink
         )}
         onClick={() =>
-          previousLink ? history.push(previousLink) : history.goBack()
+          previousHierarchyLink
+            ? history.push(previousHierarchyLink)
+            : rootLink
+            ? history.push(rootLink)
+            : history.go(-(previousDefaultLinkIndex + 1))
         }>
         {backArrow} {label}
       </Link>
@@ -48,12 +67,13 @@ const GoBackLink = ({ label, hierarchy }) => {
 
 GoBackLink.propTypes = {
   label: PropTypes.string,
-  hierarchy: PropTypes.arrayOf(PropTypes.string)
+  hierarchy: PropTypes.arrayOf(PropTypes.string),
+  rootLink: PropTypes.string,
+  breakpoint: PropTypes.string
 };
 
 GoBackLink.defaultProps = {
-  label: "Go Back",
-  hierarchy: ["/"]
+  label: "Go Back"
 };
 
 export default GoBackLink;

--- a/src/components/Router/RouterProvider.jsx
+++ b/src/components/Router/RouterProvider.jsx
@@ -1,4 +1,10 @@
-import React, { createContext, useContext, useMemo } from "react";
+import React, {
+  createContext,
+  useContext,
+  useMemo,
+  useRef,
+  useEffect
+} from "react";
 import { withRouter } from "react-router-dom";
 
 const routerCtx = createContext();
@@ -6,9 +12,17 @@ const routerCtx = createContext();
 export const useRouter = () => useContext(routerCtx);
 
 const RouterProvider = ({ location, children, ...rest }) => {
+  const navigationHistory = useRef([]);
   const ctxValue = useMemo(() => ({ ...rest, location }), [rest, location]);
-
-  return <routerCtx.Provider value={ctxValue}>{children}</routerCtx.Provider>;
+  useEffect(() => {
+    navigationHistory.current = [location, ...navigationHistory.current];
+  }, [location]);
+  return (
+    <routerCtx.Provider
+      value={{ ...ctxValue, navigationHistory: navigationHistory.current }}>
+      {children}
+    </routerCtx.Provider>
+  );
 };
 
 export default withRouter(RouterProvider);

--- a/src/containers/Proposal/Detail/Detail.jsx
+++ b/src/containers/Proposal/Detail/Detail.jsx
@@ -270,13 +270,7 @@ const ProposalDetail = ({ Main, match, history }) => {
   return (
     <>
       <Main className={styles.customMain} fillScreen>
-        <GoBackLink
-          hierarchy={[
-            "/",
-            "/record/:token",
-            "/record/:token/comments/:commentid"
-          ]}
-        />
+        {proposal && <GoBackLink breakpoint="/record/:token" />}
         {proposal && <SetPageTitle title={proposal.name} />}
         <UnvettedActionsProvider>
           <PublicActionsProvider>

--- a/src/containers/Proposal/Detail/hooks.js
+++ b/src/containers/Proposal/Detail/hooks.js
@@ -270,7 +270,13 @@ export function useProposal(token, proposalPageSize, threadParentID) {
     error: commentsError,
     loading: commentsLoading,
     finishedCommentsFetch
-  } = useComments(proposalToken, proposalState, null, threadParentID);
+  } = useComments(
+    proposalToken,
+    proposalState,
+    null,
+    threadParentID,
+    isCurrentUserProposalAuthor
+  );
 
   return {
     proposal: proposalWithLinks && {

--- a/src/hooks/api/useComments.js
+++ b/src/hooks/api/useComments.js
@@ -13,7 +13,8 @@ export default function useComments(
   recordToken,
   proposalState,
   sectionId,
-  threadParentID
+  threadParentID,
+  isCurrentUserProposalAuthor
 ) {
   const isSingleThread = !!threadParentID;
   const { enableCommentVote, recordType, constants } = useConfig();
@@ -89,8 +90,10 @@ export default function useComments(
   const hasCommentsLeft = !allCommentsBySection;
   const isRecordMissingComments = hasRecordToken && hasCommentsLeft;
   const isVettedProposal = proposalState === PROPOSAL_STATE_VETTED;
+  const canUserViewComments =
+    isVettedProposal || isCurrentUserAdmin || isCurrentUserProposalAuthor;
   const needsToFetchComments = isProposal
-    ? isRecordMissingComments && (isVettedProposal || isCurrentUserAdmin)
+    ? isRecordMissingComments && canUserViewComments
     : isRecordMissingComments && userLoggedIn;
 
   const needsToFetchCommentsLikes =

--- a/src/lib/queryString.js
+++ b/src/lib/queryString.js
@@ -7,7 +7,7 @@ export const setQueryStringWithoutPageReload = (qsValue) => {
     window.location.host +
     window.location.pathname +
     qsValue;
-  window.history.pushState({ path: newurl, search: qsValue }, "", newurl);
+  window.history.replaceState({ path: newurl, search: qsValue }, "", newurl);
 };
 
 export const getQueryStringValue = (
@@ -40,5 +40,5 @@ export const removeQueryStringsFromUrl = (url, parameter, parameter2) => {
     .replace(new RegExp("([?&])" + parameter + "=[^&]*&"), "$1")
     .replace(new RegExp("[?&]" + parameter2 + "=[^&#]*(#.*)?$"), "$1")
     .replace(new RegExp("([?&])" + parameter2 + "=[^&]*&"), "$1");
-  window.history.pushState({ path: newurl }, "", newurl);
+  window.history.replaceState({ path: newurl }, "", newurl);
 };


### PR DESCRIPTION
Closes #2655.

This diff fixes the Go Back link navigation by adding the `breakpoint` prop,
where users can inform the route match path that should be considered a
navigation rollback point.

Fortunately, due to privacy matters, the browsers don't allow the previous
history states access. Therefore, the method used consists in storing the
previous navigated pages on our platform in a stack, and then getting the
index of the first route that does not match the current breakpoint. This way
we can restore the window navigation state, instead of pushing a new one.