### PR TITLE
fix: Billing and summary on RFP proposals.

### DIFF
--- a/src/components/Proposal/ProposalActions.jsx
+++ b/src/components/Proposal/ProposalActions.jsx
@@ -78,6 +78,7 @@ const PublicActions = ({
   const isProposalOwner =
     currentUser && proposal && currentUser.username === proposal.username;
   const isRfpSubmission = !!proposal.linkto;
+  const isRfp = !!proposal.linkby;
   const isVotingStartAuthorized = !isVotingNotAuthorizedProposal(voteSummary);
   const isReadyToRunoff = isRfpReadyToRunoff(
     proposal,
@@ -89,6 +90,7 @@ const PublicActions = ({
   const { numbillingstatuschanges } = billingStatusChangeMetadata || {};
   const isSetBillingStatusAllowed =
     !isLegacy &&
+    !isRfp &&
     isApproved &&
     numbillingstatuschanges < billingstatuschangesmax;
 

--- a/src/components/Proposal/helpers.js
+++ b/src/components/Proposal/helpers.js
@@ -16,6 +16,7 @@ import {
   PROPOSAL_SUMMARY_STATUS_REJECTED,
   PROPOSAL_SUMMARY_STATUS_ACTIVE,
   PROPOSAL_SUMMARY_STATUS_CLOSED,
+  PROPOSAL_SUMMARY_STATUS_APPROVED,
   PROPOSAL_SUMMARY_STATUS_COMPLETED
 } from "src/constants";
 import {
@@ -154,6 +155,9 @@ export const getProposalStatusTagProps = (
 
       case PROPOSAL_SUMMARY_STATUS_COMPLETED:
         return { type: "greenCheck", text: "Completed" };
+
+      case PROPOSAL_SUMMARY_STATUS_APPROVED:
+        return { type: "greenCheck", text: "Approved" };
 
       default:
         break;

--- a/src/constants.js
+++ b/src/constants.js
@@ -49,6 +49,7 @@ export const PROPOSAL_SUMMARY_STATUS_VOTE_STARTED = "vote-started";
 export const PROPOSAL_SUMMARY_STATUS_REJECTED = "rejected";
 export const PROPOSAL_SUMMARY_STATUS_ACTIVE = "active";
 export const PROPOSAL_SUMMARY_STATUS_COMPLETED = "completed";
+export const PROPOSAL_SUMMARY_STATUS_APPROVED = "approved";
 export const PROPOSAL_SUMMARY_STATUS_CLOSED = "closed";
 
 export const PROPOSAL_STATE_UNVETTED = 1;

--- a/src/containers/Proposal/Detail/hooks.js
+++ b/src/containers/Proposal/Detail/hooks.js
@@ -130,7 +130,7 @@ export function useProposal(token, proposalPageSize, threadParentID) {
   const isAdmin = currentUser?.isadmin;
   const isApproved = isApprovedProposal(proposal, voteSummary);
   const isMissingBillingStatusChangeMetadata =
-    isAdmin && isApproved && isEmpty(billingStatusChangeMetadata);
+    isAdmin && isApproved && isEmpty(billingStatusChangeMetadata) && !isRfp;
   const needsInitialFetch = token && isMissingDetails;
   const isCensored = isCensoredProposal(proposal);
   const isAbandoned = isAbandonedProposal(proposalSummary);


### PR DESCRIPTION
Closes #2657.

Depends on https://github.com/decred/politeia/pull/1578

This commit fixes the incorrect pi summary status tag and removes both
"Set Billing Status" button and `onFetchBillingStatusChanges` call for
RFP proposals.

<img width="739" alt="Screen Shot 2021-11-17 at 5 50 03 PM" src="https://user-images.githubusercontent.com/22639213/142280257-f2d5ce47-abd0-4ec2-9454-aa484fe7fe7f.png">


