### PR TITLE
fix: Display 2FA on Login Modal

### DIFF
--- a/src/components/ModalProvider.jsx
+++ b/src/components/ModalProvider.jsx
@@ -15,7 +15,7 @@ const ModalProvider = ({ children }) => {
   const modalToDisplay = useRef(initialState);
   // Modals are refs, and refs doesn't trigger component re-render. This
   // will force the state update, hence a modal update.
-  const [, setIsDisplaying] = useState(false);
+  const [, toggleDisplay] = useState(Date.now());
 
   const handleOpenModal = useCallback(function (
     modal,
@@ -26,10 +26,10 @@ const ModalProvider = ({ children }) => {
     if (!modalStack.current || overlay) {
       modalStack.current && modalStack.current.push(newModal);
       modalToDisplay.current = newModal;
-      setIsDisplaying(true);
+      toggleDisplay(Date.now());
     } else if (modalToDisplay.current && !modalToDisplay.current.props.show) {
       modalToDisplay.current = newModal;
-      setIsDisplaying(true);
+      toggleDisplay(Date.now());
     }
   },
   []);
@@ -38,7 +38,7 @@ const ModalProvider = ({ children }) => {
     modalStack.current && modalStack.current.pop();
     const previousModal = modalStack.current && modalStack.current.pop();
     modalToDisplay.current = previousModal || initialState;
-    setIsDisplaying(false);
+    toggleDisplay(Date.now());
   }, []);
 
   const props = {

--- a/src/components/ModalProvider.jsx
+++ b/src/components/ModalProvider.jsx
@@ -1,4 +1,4 @@
-import React, { useState, createContext, useCallback, useRef } from "react";
+import React, { createContext, useCallback, useRef, useReducer } from "react";
 import IdentityErrorBoundary from "src/components/IdentityErrorBoundary";
 
 export const modalContext = createContext({ component: () => null, props: {} });
@@ -10,12 +10,16 @@ const initialState = {
   }
 };
 
+function toggleReducer(state) {
+  return { toggle: !state.toggle };
+}
+
 const ModalProvider = ({ children }) => {
   const modalStack = useRef([]);
   const modalToDisplay = useRef(initialState);
   // Modals are refs, and refs doesn't trigger component re-render. This
   // will force the state update, hence a modal update.
-  const [, toggleDisplay] = useState(Date.now());
+  const [, toggleDisplay] = useReducer(toggleReducer, { toggle: false });
 
   const handleOpenModal = useCallback(function (
     modal,
@@ -26,10 +30,10 @@ const ModalProvider = ({ children }) => {
     if (!modalStack.current || overlay) {
       modalStack.current && modalStack.current.push(newModal);
       modalToDisplay.current = newModal;
-      toggleDisplay(Date.now());
+      toggleDisplay();
     } else if (modalToDisplay.current && !modalToDisplay.current.props.show) {
       modalToDisplay.current = newModal;
-      toggleDisplay(Date.now());
+      toggleDisplay();
     }
   },
   []);
@@ -38,7 +42,7 @@ const ModalProvider = ({ children }) => {
     modalStack.current && modalStack.current.pop();
     const previousModal = modalStack.current && modalStack.current.pop();
     modalToDisplay.current = previousModal || initialState;
-    toggleDisplay(Date.now());
+    toggleDisplay();
   }, []);
 
   const props = {

--- a/src/components/ModalTotpVerify.jsx
+++ b/src/components/ModalTotpVerify.jsx
@@ -19,7 +19,7 @@ const ModalTotpVerifyContent = ({ onClose, onVerify }) => {
     }
   };
   return (
-    <div>
+    <div data-testid="modal-totp-verify">
       {error && (
         <Message
           kind="error"

--- a/teste2e/cypress/e2e/user/login.js
+++ b/teste2e/cypress/e2e/user/login.js
@@ -63,4 +63,15 @@ describe("2FA Login", () => {
     cy.findByTestId("digits-input").type("123456");
     cy.findByTestId("modal-totp-verify-error").should("be.visible");
   });
+  it("should display 2FA modal on login modal", () => {
+    cy.middleware("users.login", { error: { statusCode: 401, errorCode: 79 } });
+    cy.intercept("/api/ticketvote/v1/inventory").as("inventory");
+    cy.visit("/");
+    cy.findAllByTestId("record-title").first().click();
+    cy.findByTestId("wayt-login-button").click();
+    cy.findByLabelText(/email/i).type(unpaidUser.email);
+    cy.findByLabelText(/password/i).type(unpaidUser.password);
+    cy.findByTestId("login-form-button").click();
+    cy.findByTestId("modal-totp-verify").should("be.visible");
+  });
 });


### PR DESCRIPTION
This diff fixes a bug introduced by #2638, where modal overlays weren't
triggering visual updates, hence, modals were not being replaced, and the
2FA digits input couldn't be seen:

The error can be reproduced when logging in with a 2FA active account
using the "What are your thoughts" login button.

![2fa-login-modal](https://user-images.githubusercontent.com/22639213/142291229-72bac4f5-676f-4659-a7c3-6e1ea26029ea.gif)


- Also, adds e2e tests to cover this case.

Looks like this now:
![2fa-login-modal-after](https://user-images.githubusercontent.com/22639213/142291217-90cb2402-cf33-4337-930a-5fa6374f7dc8.gif)