### PR TITLE
fix(Proposals List): do not reorder the list

### DIFF
--- a/src/reducers/models/proposals.js
+++ b/src/reducers/models/proposals.js
@@ -137,7 +137,10 @@ const updateProposalRfpLinks = (proposal) => (state) => {
   )(state);
 };
 
-const updateInventory = (payload) => (allProps) => ({
+const updateInventory = (payload) => (allProps) => {
+  console.log("payload", payload);
+  console.log("allProps", allProps);
+  return ({
   ...allProps,
   ...Object.keys(payload).reduce((res, status) => {
     const propsStatus = allProps[status] ? allProps[status] : [];
@@ -146,13 +149,14 @@ const updateInventory = (payload) => (allProps) => ({
       ...res,
       [status]: [
         ...new Set([
-          ...payloadStatus.map((token) => shortRecordToken(token)),
-          ...propsStatus
+          ...propsStatus,
+          ...payloadStatus.map((token) => shortRecordToken(token))
         ])
       ]
     };
   }, {})
 });
+};
 
 const onReceiveLogout = (state) =>
   compose(

--- a/src/reducers/models/proposals.js
+++ b/src/reducers/models/proposals.js
@@ -137,10 +137,7 @@ const updateProposalRfpLinks = (proposal) => (state) => {
   )(state);
 };
 
-const updateInventory = (payload) => (allProps) => {
-  console.log("payload", payload);
-  console.log("allProps", allProps);
-  return ({
+const updateInventory = (payload) => (allProps) => ({
   ...allProps,
   ...Object.keys(payload).reduce((res, status) => {
     const propsStatus = allProps[status] ? allProps[status] : [];
@@ -156,7 +153,6 @@ const updateInventory = (payload) => (allProps) => {
     };
   }, {})
 });
-};
 
 const onReceiveLogout = (state) =>
   compose(


### PR DESCRIPTION
The list was being reordered on RECEIVE_VOTES_INVENTORY because the
updateInventory function was inserting tokens into the front of the
allByVoteStatus[STATUS] array. With this commit now it inserts into
the back.

Closes #2654 

### Debugging

This was a very hard bug to reproduce. Thanks to redux devtools I could narrow the issue. Here's how I did it:

1. At first I couldn't repro the bug locally and thought it was related to proposals submissions. I was wrong.

2. As I couldn't repro the bug locally I went to https://test-proposals.decred.org/?tab=approved with the devtools network tab open and started to see what might be causing the bug. Then I saw something intriguing:


<img width="610" alt="Screen Shot 2021-11-19 at 08 44 04" src="https://user-images.githubusercontent.com/13955303/142619763-0366d0d5-a33f-46fb-af5e-70593707f1fb.png">
<img width="1280" alt="Screen Shot 2021-11-19 at 08 44 40" src="https://user-images.githubusercontent.com/13955303/142619862-dd52e648-f6d1-4b79-a1d8-ee7888bf3055.png">

The first records were the ones from the second inventory call. I had a pretty good guess: **it's related to the `ticketvote/inventory` somehow.**

3. Now back to my local environment I just created a lot of approved proposals and noticed I could repro not only doing the steps described on #2654 but also when scrolling to the end of the list.

4. Then, if you can repro a bug locally it's pretty easy to spot the culprit with `redux-devtools`:

Here is the approved records token list before the `RECEIVE_VOTES_INVENTORY` action:

<img width="608" alt="Screen Shot 2021-11-19 at 08 47 24" src="https://user-images.githubusercontent.com/13955303/142620704-181d3b8b-b374-4e5d-92c1-4b45b0cbf519.png">

After the action:

<img width="611" alt="Screen Shot 2021-11-19 at 08 41 03" src="https://user-images.githubusercontent.com/13955303/142620810-01aadb99-38b3-46a1-b79a-bd390eac2853.png">

So the tokens from the second inventory page was being inserted into the front of the `allByStatys["approved"]` list and the Proposals List in the UI is just a representation of this list.

5. Now the easy part. I went to that action and changed the state update function to insert new inventory tokens into the back. See a before and after the `RECEIVE_VOTES_INVENTORY` action now:


<img width="608" alt="Screen Shot 2021-11-19 at 08 47 24" src="https://user-images.githubusercontent.com/13955303/142621439-b3b27f18-1ee4-433e-b3e0-d0defcab2d5b.png">
<img width="608" alt="Screen Shot 2021-11-19 at 08 47 43" src="https://user-images.githubusercontent.com/13955303/142621492-5c62752c-77a2-4372-bad4-c594fc4de103.png">

It's fixed! 🎉 
