### PR TITLE
fix: Loading animation bug on proposals list.

### DIFF
--- a/src/components/LazyList.jsx
+++ b/src/components/LazyList.jsx
@@ -36,8 +36,12 @@ const LazyList = ({
       clearTimeout(timer);
     };
   }, [minInitialLoading, initialLoading]);
-  const arePlaceholdersLoading = isLoading || initialLoading;
-  return (
+
+  return initialLoading ? (
+    <div data-testid="lazy-list">
+      <div data-testid="loading-placeholders">{loadingPlaceholder}</div>
+    </div>
+  ) : (
     <div data-testid="lazy-list">
       <InfiniteScroll
         pageStart={pageStart}
@@ -46,7 +50,7 @@ const LazyList = ({
         hasMore={hasMore}>
         {items.map(renderItem)}
       </InfiniteScroll>
-      {arePlaceholdersLoading ? (
+      {isLoading ? (
         <div data-testid="loading-placeholders">{loadingPlaceholder}</div>
       ) : isEmpty ? (
         emptyListComponent

--- a/teste2e/cypress/e2e/proposal/list.js
+++ b/teste2e/cypress/e2e/proposal/list.js
@@ -209,12 +209,18 @@ describe("General pagination", () => {
 
 describe("Given an empty proposals list", () => {
   it("should render loading placeholders properly", () => {
-    cy.ticketvoteMiddleware("inventory", {}, { delay: 2000 });
+    cy.ticketvoteMiddleware("inventory", {});
     cy.visit("/");
-    cy.get("[data-testid='loading-placeholders'] > div").should(
-      "have.length",
-      5
-    );
+    cy.get("[data-testid='loading-placeholders'] > div", {
+      timeout: 100
+    }).should("have.length", 5);
+    cy.findByTestId("help-message", { timeout: 1250 })
+      .should("be.visible")
+      .then(() => {
+        cy.get("[data-testid='loading-placeholders'] > div", {
+          timeout: 1
+        }).should("not.exist");
+      });
   });
   it("should switch tabs and show empty message", () => {
     // Test
@@ -231,6 +237,23 @@ describe("Given an empty proposals list", () => {
     // wait to see if no requests are done, since inventory is fully fetched
     cy.wait(1000);
     cy.findByTestId("help-message").should("be.visible");
+  });
+});
+
+describe("Given 1 under-review proposal", () => {
+  it("should render loading placeholders only once", () => {
+    cy.ticketvoteMiddleware("inventory", { amountByStatus: { started: 1 } });
+    cy.recordsMiddleware("records", { status: 2, state: 2 });
+    cy.visit("/?tab=under-review");
+    cy.get("[data-testid='loading-placeholders'] > div", {
+      timeout: 1200
+    }).should("have.length", 5);
+    cy.wait("@records.records");
+    cy.get("[data-testid='record-title']").then(() => {
+      cy.get("[data-testid='loading-placeholders'] > div", {
+        timeout: 1
+      }).should("not.exist");
+    });
   });
 });
 


### PR DESCRIPTION
Closes #2667.

- Adds e2e tests for the initial load case.

### UI Changes

**Before:**
![2667-proposal-list-loading-animation-before](https://user-images.githubusercontent.com/22639213/142895142-cee16a08-648c-419d-b1f8-6faa1b347568.gif)

**After:**
![2667-proposal-list-loading-animation](https://user-images.githubusercontent.com/22639213/142895161-9e1f699a-e33e-48db-a1f4-d5a858c1f14a.gif)
