### PR TITLE
Proposal card: Fix legacy abandoned indication.

### DIFF
--- a/src/components/Proposal/Proposal.jsx
+++ b/src/components/Proposal/Proposal.jsx
@@ -28,6 +28,7 @@ import {
   getMarkdownContent,
   getVotesReceived,
   isAbandonedProposal,
+  isLegacyAbandonedProposal,
   isCensoredProposal,
   isPublicProposal,
   isClosedProposal,
@@ -182,7 +183,9 @@ const Proposal = React.memo(function Proposal({
   const isPublic = isPublicProposal(proposal);
   const isVotingFinished = isVotingFinishedProposal(voteSummary);
   const isVoteActive = isVoteActiveProposal(voteSummary);
-  const isAbandoned = isAbandonedProposal(proposalSummary);
+  const isAbandoned =
+    isAbandonedProposal(proposalSummary) ||
+    (isLegacy && isLegacyAbandonedProposal(proposal));
   const isCensored = isCensoredProposal(proposal);
   const isClosed = isClosedProposal(proposalSummary);
   const proposalStatusReason =

--- a/src/components/Proposal/helpers.js
+++ b/src/components/Proposal/helpers.js
@@ -21,7 +21,7 @@ import {
 } from "src/constants";
 import {
   isPublicProposal,
-  isAbandonedProposal,
+  isLegacyAbandonedProposal,
   isCensoredProposal
 } from "src/containers/Proposal/helpers";
 
@@ -80,7 +80,7 @@ export const getLegacyProposalStatusTagProps = (
     }
   }
 
-  if (isAbandonedProposal(proposal)) {
+  if (isLegacyAbandonedProposal(proposal)) {
     return {
       type: isDarkTheme ? "blueNegative" : "grayNegative",
       text: "Abandoned"

--- a/src/containers/Proposal/helpers.js
+++ b/src/containers/Proposal/helpers.js
@@ -199,6 +199,10 @@ export const isUnderDiscussionProposal = (proposal, voteSummary) =>
   !isVoteActiveProposal(voteSummary) &&
   !isVotingFinishedProposal(voteSummary);
 
+// TODO: remove legacy
+export const isLegacyAbandonedProposal = (proposal) =>
+  !!proposal && proposal.status === PROPOSAL_STATUS_ARCHIVED;
+
 /**
  * Returns true if the given proposal is abandoned
  * @param {Object} proposalSummary


### PR DESCRIPTION
This diff fixes a bug where legacy abandoned proposals' cards displayed
a missing tag and wrong background. It re-adds the old logic to
determine whether a proposal is abandoned without using the new proposal
summary metadata which is not available for legacy proposals.

---

Closes #2671.