### PR TITLE
fix: show proposal published and edited dates

### DIFF
--- a/src/components/Proposal/Proposal.jsx
+++ b/src/components/Proposal/Proposal.jsx
@@ -207,8 +207,7 @@ const Proposal = React.memo(function Proposal({
     isAuthor && isEditableProposal(proposal, voteSummary) && !isLegacy;
   const { apiInfo } = useLoader();
   const mobile = useMediaQuery("(max-width: 560px)");
-  const showEditedDate = version > 1 && timestamp !== publishedat && !mobile;
-  const showPublishedDate = publishedat && !mobile && !showEditedDate;
+  const showEditedDate = version > 1 && timestamp !== publishedat;
   const showExtendedVersionPicker =
     extended && version > 1 && !isCensored && (isVetted || isAuthor || isAdmin);
   const showVersionAsText = !extended && !mobile;
@@ -343,11 +342,13 @@ const Proposal = React.memo(function Proposal({
                       timestamp={linkby}
                     />
                   )}
-                  {showPublishedDate && (
+                  <span data-testid="proposal-published-timestamp">
                     <Event event="published" timestamp={publishedat} />
-                  )}
+                  </span>
                   {showEditedDate && (
-                    <Event event="edited" timestamp={timestamp} />
+                    <span data-testid="proposal-edited-timestamp">
+                      <Event event="edited" timestamp={timestamp} />
+                    </span>
                   )}
                   {showVersionAsText && (
                     <Text

--- a/src/components/RecordWrapper/RecordWrapper.jsx
+++ b/src/components/RecordWrapper/RecordWrapper.jsx
@@ -103,9 +103,7 @@ export const Subtitle = ({ children, separatorSymbol = "•" }) => (
   <Join
     className={classNames("margin-top-s", styles.subtitleWrapper)}
     SeparatorComponent={() => (
-      <span className="text-secondary-color margin-left-s margin-right-s">
-        {separatorSymbol}
-      </span>
+      <span className={styles.subtitleSeparator}>{separatorSymbol}</span>
     )}>
     {children}
   </Join>
@@ -115,9 +113,7 @@ export const JoinTitle = ({ children, className, separatorSymbol = "•" }) => (
   <Join
     className={classNames(className, styles.flexWrap)}
     SeparatorComponent={() => (
-      <span className="text-secondary-color margin-left-s margin-right-s">
-        {separatorSymbol}
-      </span>
+      <span className={styles.subtitleSeparator}>{separatorSymbol}</span>
     )}>
     {children}
   </Join>

--- a/src/components/RecordWrapper/RecordWrapper.module.css
+++ b/src/components/RecordWrapper/RecordWrapper.module.css
@@ -19,6 +19,12 @@
   flex-wrap: wrap;
 }
 
+.subtitleSeparator {
+  margin-right: var(--spacing-small);
+  margin-left: var(--spacing-small);
+  color: var(--text-secondary-color);
+}
+
 .flexWrap {
   flex-wrap: wrap;
 }
@@ -149,5 +155,18 @@ div.darkActionsTooltip {
 
   .title {
     max-width: 100%;
+  }
+
+  .subtitleWrapper {
+    flex-flow: column;
+    max-width: 100%;
+  }
+
+  .subtitleWrapper > .subtitleSeparator {
+    display: none;
+  }
+
+  .subtitleWrapper > *:not(:first-child) {
+    padding-top: 1rem;
   }
 }

--- a/teste2e/cypress/e2e/proposal/edit.js
+++ b/teste2e/cypress/e2e/proposal/edit.js
@@ -41,6 +41,8 @@ describe("Proposal Edit", () => {
           .its("status")
           .should("eq", 200);
         cy.findByText(/version 2/).should("exist");
+        cy.findByTestId("proposal-published-timestamp").should("be.visible");
+        cy.findByTestId("proposal-edited-timestamp").should("be.visible");
       }
     );
   });
@@ -67,6 +69,8 @@ describe("Proposal Edit", () => {
         cy.identity();
         cy.visit(`record/${shortRecordToken(censorshiprecord.token)}`);
         cy.findByTestId(/record-edit-button/i).should("not.exist");
+        cy.findByTestId("proposal-published-timestamp").should("be.visible");
+        cy.findByTestId("proposal-edited-timestamp").should("not.exist");
       }
     );
   });


### PR DESCRIPTION
Closes #2675 

This commit displays the missing "published" timestamp event for
proposals that have been edited. Also, display timestamps for mobile
views and adds e2e tests to prevent this from happening further.

### UI Changes Screenshot

**Regular view**:

List:
<img width="830" alt="Screen Shot 2021-11-29 at 9 03 10 PM" src="https://user-images.githubusercontent.com/22639213/143961810-5b4b7758-b06e-4ce4-9c84-67cce6bcc06a.png">

Details:
<img width="1231" alt="Screen Shot 2021-11-29 at 9 04 36 PM" src="https://user-images.githubusercontent.com/22639213/143961909-8a707b9a-f970-4377-a20c-cdf65d145c74.png">


**Mobile View**

List:
<img width="453" alt="Screen Shot 2021-11-29 at 9 02 55 PM" src="https://user-images.githubusercontent.com/22639213/143961799-32f41098-e7ba-443e-abf6-693aed18d895.png">

Details:
<img width="448" alt="Screen Shot 2021-11-29 at 9 03 21 PM" src="https://user-images.githubusercontent.com/22639213/143961806-e2580bd0-d8b6-4847-b23f-b59a6f29d8e5.png">