### PR TITLE
fix: Votes timestamps download bug.

### DIFF
--- a/src/components/Proposal/Proposal.jsx
+++ b/src/components/Proposal/Proposal.jsx
@@ -530,7 +530,7 @@ const Proposal = React.memo(function Proposal({
                   )}
                   {votesCount > 0 && (
                     <DownloadVotesTimestamps
-                      label="Votes Timestamp"
+                      label="Votes Timestamps"
                       votesCount={votesCount}
                       recordToken={shortToken}
                     />

--- a/src/containers/Proposal/Download/DownloadVotesTimestamps.jsx
+++ b/src/containers/Proposal/Download/DownloadVotesTimestamps.jsx
@@ -28,9 +28,7 @@ const DownloadVotesTimestampsWrapper = ({ label, recordToken, votesCount }) => {
 
 const DownloadVotesTimestamps = ({ recordToken, votesCount }) => {
   const {
-    policy: {
-      policyTicketVote: { timestampspagesize: timestampsPageSize }
-    }
+    policyTicketVote: { timestampspagesize: timestampsPageSize }
   } = usePolicy();
   const { timestamps, progress, loading, error, multiPage } =
     useDownloadVoteTimestamps(recordToken, votesCount, timestampsPageSize);

--- a/teste2e/cypress/e2e/proposal/votes.js
+++ b/teste2e/cypress/e2e/proposal/votes.js
@@ -11,8 +11,45 @@ beforeEach(function mockApiCalls() {
 });
 
 describe("Given an approved proposal", () => {
+  const yes = 250,
+    no = 50;
+  const total = yes + no;
   beforeEach(() => {
-    cy.ticketvoteMiddleware();
+    cy.ticketvoteMiddleware("summaries", {
+      amountByStatus: { approved: 1 },
+      resultsByStatus: { approved: { yes, no } }
+    });
+    cy.ticketvoteMiddleware("timestamps", {
+      votesAmount: 100,
+      authsAmount: 100
+    });
+    cy.recordsMiddleware("details", { status: 2, state: 2 });
+    cy.piMiddleware("summaries", { amountByStatus: { active: 1 } });
   });
-  it("should be able to download votes timestamps", () => {});
+  it("should be able to download votes timestamps from a single page", () => {
+    cy.ticketvoteMiddleware("timestamps", {
+      votesAmount: total,
+      authsAmount: total
+    });
+    cy.visit("/record/abcdefg");
+    cy.wait("@records.details");
+    cy.wait("@pi.summaries");
+    cy.findByTestId("record-links").click();
+    cy.findByText(/votes timestamps/i).click();
+    cy.wait(1000);
+    cy.get("@ticketvote.timestamps.all").should("have.length.of.at.most", 2);
+  });
+  it("should be able to download paginated votes timestamps", () => {
+    cy.ticketvoteMiddleware("timestamps", {
+      votesAmount: total / 2,
+      authsAmount: total / 2
+    });
+    cy.visit("/record/abcdefg");
+    cy.wait("@records.details");
+    cy.wait("@pi.summaries");
+    cy.findByTestId("record-links").click();
+    cy.findByText(/votes timestamps/i).click();
+    cy.findByText(/50%/i).should("be.visible");
+    cy.get("@ticketvote.timestamps.all").should("have.length.of.at.most", 3);
+  });
 });

--- a/teste2e/cypress/e2e/proposal/votes.js
+++ b/teste2e/cypress/e2e/proposal/votes.js
@@ -1,0 +1,18 @@
+beforeEach(function mockApiCalls() {
+  // currently mocking pi and ticketvote summaries calls with any status, since
+  // they aren't used for assertions. the `Missing` status will show up, but it
+  // doesn't affect the list behavior.
+  cy.useTicketvoteApi();
+  cy.useRecordsApi();
+  cy.usePiApi();
+  cy.useWwwApi();
+  cy.useCommentsApi();
+  cy.userEnvironment("noLogin");
+});
+
+describe("Given an approved proposal", () => {
+  beforeEach(() => {
+    cy.ticketvoteMiddleware();
+  });
+  it("should be able to download votes timestamps", () => {});
+});

--- a/teste2e/cypress/support/ticketvote/api.js
+++ b/teste2e/cypress/support/ticketvote/api.js
@@ -1,7 +1,8 @@
 import { inventoryReply as recordsInventoryReply } from "../core/api";
-import { Summary } from "./generate";
+import { Summary, Timestamp } from "./generate";
 import { statusToString, stringToStatus, typeFromStatus } from "./utils";
 import { chunkByStatusAmount } from "../core/utils";
+import times from "lodash/fp/times";
 
 export const API_BASE_URL = "/api/ticketvote/v1";
 
@@ -85,8 +86,18 @@ export function policyReply() {
   };
 }
 
+export function timestampsReply({
+  testParams: { votesAmount = 0, authsAmount = 0 }
+}) {
+  const timestamp = new Timestamp();
+  const votes = times(() => timestamp)(votesAmount);
+  const auths = times(() => timestamp)(authsAmount);
+  return { auths, details: timestamp, votes };
+}
+
 export const repliers = {
   inventory: inventoryReply,
+  policy: policyReply,
   summaries: summariesReply,
-  policy: policyReply
+  timestamps: timestampsReply
 };

--- a/teste2e/cypress/support/ticketvote/commands.js
+++ b/teste2e/cypress/support/ticketvote/commands.js
@@ -15,4 +15,5 @@ Cypress.Commands.add("useTicketvoteApi", (config = {}) => {
   cy.ticketvoteMiddleware("summaries", config.summaries);
   cy.ticketvoteMiddleware("inventory", config.inventory);
   cy.ticketvoteMiddleware("policy", config.policy);
+  cy.ticketvoteMiddleware("timestamps", config.timestamps);
 });

--- a/teste2e/cypress/support/ticketvote/generate.js
+++ b/teste2e/cypress/support/ticketvote/generate.js
@@ -1,3 +1,5 @@
+import faker from "faker";
+
 export function Results({ yes = 0, no = 0 } = {}) {
   return [
     {
@@ -29,4 +31,12 @@ export function Summary({ results, status, type = 0 } = {}) {
   this.passpercentage = type ? 1 : 0;
   this.results = type ? new Results(results) : 0;
   this.bestblock = 200;
+}
+
+export function Timestamp({ data } = {}) {
+  this.data = JSON.stringify(data || { key: faker.random.word() });
+  this.digest = faker.datatype.hexaDecimal(128, false, /[0-9a-z]/);
+  this.txid = faker.datatype.hexaDecimal(64, false, /[0-9a-z]/);
+  this.merkleroot = faker.datatype.hexaDecimal(64, false, /[0-9a-z]/);
+  this.proofs = faker.random.arrayElements();
 }


### PR DESCRIPTION
Closes #2684

Introduced by #2622

This diff fixes the Votes Timestamps `timestampspagesize` policy error,
caused by the incorrect props destruction on
`DownloadVotesTimestamps.jsx` component. Also, it adds e2e tests in
order to prevent this from happening further.

<img width="832" alt="Screen Shot 2021-12-01 at 7 04 44 PM" src="https://user-images.githubusercontent.com/22639213/144321521-55d91fef-2957-4d77-818f-2ff7e7908117.png">