### PR TITLE
fix: Avoid proposals list submissions requests

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -510,40 +510,24 @@ export const onFetchProposalsBatch = ({
       const commentsCount =
         fetchCommentCounts && response.find((res) => res && res.counts).counts;
 
-      const proposalsWithCommentCountsAndSubmissions = await Object.keys(
-        proposals
-      ).reduce(async (acc, curr) => {
-        const { linkby } = parseRawProposal(proposals[curr]);
-        if (linkby) {
-          // proposal is a RFP
-          const { submissions } = await api.proposalSubmissions(curr); // get submissions
-          return {
-            ...(await acc),
-            [curr]: {
-              ...proposals[curr],
-              linkedfrom: submissions,
-              commentsCount: commentsCount[curr]
-            }
-          };
-        } else {
-          // proposal is not a RFP
-          return {
-            ...(await acc),
-            [curr]: {
-              ...proposals[curr],
-              commentsCount: commentsCount[curr]
-            }
-          };
-        }
-      }, {});
+      const proposalsWithCommentCounts = Object.keys(proposals).reduce(
+        (acc, curr) => ({
+          ...acc,
+          [curr]: {
+            ...proposals[curr],
+            commentsCount: commentsCount[curr]
+          }
+        }),
+        {}
+      );
       dispatch(
         act.RECEIVE_PROPOSALS_BATCH({
-          proposals: proposalsWithCommentCountsAndSubmissions,
+          proposals: proposalsWithCommentCounts,
           userid
         })
       );
       return [
-        parseRawProposalsBatch(proposalsWithCommentCountsAndSubmissions),
+        parseRawProposalsBatch(proposalsWithCommentCounts),
         summaries,
         proposalSummaries
       ];

--- a/src/hooks/api/useProposalsBatch.js
+++ b/src/hooks/api/useProposalsBatch.js
@@ -15,7 +15,6 @@ import values from "lodash/fp/values";
 import compact from "lodash/fp/compact";
 import uniq from "lodash/fp/uniq";
 import map from "lodash/fp/map";
-import reduce from "lodash/fp/reduce";
 import flow from "lodash/fp/flow";
 import isEmpty from "lodash/fp/isEmpty";
 import isUndefined from "lodash/fp/isUndefined";
@@ -39,14 +38,6 @@ const getRfpLinks = (proposals) =>
   flow(
     values,
     map((p) => p.linkto),
-    uniq,
-    compact
-  )(proposals);
-
-const getRfpSubmissions = (proposals) =>
-  flow(
-    values,
-    reduce((acc, p) => [...acc, ...(p.linkedfrom || [])], []),
     uniq,
     compact
   )(proposals);
@@ -334,11 +325,7 @@ export default function useProposalsBatch({
             setRemainingTokens([...unfetchedTokens, ...next]);
             if (fetchRfpLinks) {
               const rfpLinks = getRfpLinks(fetchedProposals);
-              const rfpSubmissions = getRfpSubmissions(fetchedProposals);
-              const unfetchedRfpLinks = getUnfetchedTokens(proposals, [
-                ...rfpLinks,
-                ...rfpSubmissions
-              ]);
+              const unfetchedRfpLinks = getUnfetchedTokens(proposals, rfpLinks);
               if (!isEmpty(unfetchedRfpLinks)) {
                 setRemainingTokens([
                   ...unfetchedRfpLinks,


### PR DESCRIPTION
Closes #2697 

This diff removes the unnecessary submissions call on proposals list 
page. Since submissions are never displayed on proposals list screen
(only displayed on proposal details), we can remove it.

## Changes

Requests log **before** changes:
<img width="415" alt="Screen Shot 2021-12-20 at 4 59 53 PM" src="https://user-images.githubusercontent.com/22639213/146825494-de691050-451b-4b0e-a0ce-563683da75c2.png">

Requests log **after** changes
<img width="286" alt="Screen Shot 2021-12-20 at 4 58 09 PM" src="https://user-images.githubusercontent.com/22639213/146825500-006c8d8b-e7d7-4068-b64a-ae496350ef48.png">

