### PR TITLE
fix: Fetch usernames only for censored comments.

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -1114,6 +1114,7 @@ export const onCensorComment = (
   reason
 ) =>
   withCsrf((dispatch, _, csrf) => {
+    let publickey;
     dispatch(
       act.REQUEST_CENSOR_COMMENT({ commentid, token, state, sectionId })
     );
@@ -1121,11 +1122,20 @@ export const onCensorComment = (
       api.makeCensoredComment(state, token, reason, commentid)
     )
       .then((comment) => api.signCensorComment(userid, comment))
-      .then((comment) => api.censorComment(csrf, comment))
+      .then((comment) => {
+        publickey = comment.publickey;
+        return api.censorComment(csrf, comment);
+      })
       .then(({ comment: { receipt, commentid, token } }) => {
         if (receipt) {
           dispatch(
-            act.RECEIVE_CENSOR_COMMENT({ commentid, token, sectionId, reason })
+            act.RECEIVE_CENSOR_COMMENT({
+              commentid,
+              token,
+              sectionId,
+              reason,
+              publickey
+            })
           );
         }
       })

--- a/src/containers/Comments/Comment/Comment.jsx
+++ b/src/containers/Comments/Comment/Comment.jsx
@@ -106,7 +106,7 @@ const Comment = ({
   );
 
   const { username: censoredByUsername } = useUserByPublicKey({
-    userPubKey: censoredBy
+    userPubKey: censored && censoredBy
   });
 
   const { themeName } = useTheme();

--- a/src/reducers/models/comments.js
+++ b/src/reducers/models/comments.js
@@ -279,11 +279,13 @@ const comments = (state = DEFAULT_STATE, action) =>
             )(state);
           },
           [act.RECEIVE_CENSOR_COMMENT]: () => {
-            const { commentid, token, sectionId, reason } = action.payload;
+            const { commentid, token, sectionId, reason, publickey } =
+              action.payload;
             const censorTargetComment = (comment) => {
               if (comment.commentid !== commentid) return comment;
               return {
                 ...comment,
+                publickey,
                 deleted: true,
                 comment: "",
                 reason


### PR DESCRIPTION
This commit fixes a bug and fetches the usernames only of censored
comments, before this the usernames of all comments were fetched.

---

Closes #2709.