### PR TITLE
fix: Handle block heights for unvetted proposals.

### DIFF
--- a/src/components/Proposal/Proposal.jsx
+++ b/src/components/Proposal/Proposal.jsx
@@ -160,7 +160,7 @@ const Proposal = React.memo(function Proposal({
     startDate,
     endDate
   } = proposal;
-  const { startblockheight, endblockheight } = voteSummary;
+  const { startblockheight, endblockheight } = voteSummary || {};
   const isAdmin = useSelector(sel.currentUserIsAdmin);
   const isVetted = state === PROPOSAL_STATE_VETTED;
   const isRfp = !!linkby || type === PROPOSAL_TYPE_RFP;


### PR DESCRIPTION
Closes #2714 

This diff fixes the `startblockheight` error caused by undefined
vote summaries on unvetted proposals.

## UI Changes

Before:
![image](https://user-images.githubusercontent.com/22639213/150818725-38b7c24f-090e-45e1-b2ce-bd4a286a87ce.png)

After:
<img width="1341" alt="Screen Shot 2022-01-24 at 1 03 16 PM" src="https://user-images.githubusercontent.com/22639213/150818760-79f0a59c-fc12-453e-9d97-bf083996b17f.png">

