### PR TITLE
fix: Drafts submission and metadata issues.

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -225,7 +225,19 @@ export const onEditInvoice =
   };
 
 export const onSaveDraftProposal =
-  ({ name, description, rfpDeadline, type, rfpLink, files, draftId }) =>
+  ({
+    name,
+    description,
+    rfpDeadline,
+    type,
+    rfpLink,
+    files,
+    draftId,
+    startDate,
+    endDate,
+    amount,
+    domain
+  }) =>
   (dispatch) => {
     resetNewProposalData();
     const id = draftId || uniqueID("draft");
@@ -238,7 +250,11 @@ export const onSaveDraftProposal =
         type,
         rfpLink,
         timestamp: Math.floor(Date.now() / 1000),
-        id
+        id,
+        startDate,
+        endDate,
+        amount,
+        domain
       })
     );
     return id;

--- a/src/components/ProposalForm/DraftSaver.jsx
+++ b/src/components/ProposalForm/DraftSaver.jsx
@@ -40,7 +40,6 @@ const DraftSaver = ({
       mapBlobToFile
     );
     const newFiles = [...values.files, ...files];
-
     const id = onSave({ draftId, ...values, files: newFiles, description });
     // first time saving this draft
     if (!draftId) {
@@ -79,8 +78,18 @@ const DraftSaver = ({
       const foundDraftProposal =
         !!draftProposals && draftId && draftProposals[draftId];
       if (foundDraftProposal && !dirty) {
-        const { name, files, type, description, rfpDeadline, rfpLink } =
-          foundDraftProposal;
+        const {
+          name,
+          files,
+          type,
+          description,
+          rfpDeadline,
+          rfpLink,
+          startDate,
+          endDate,
+          amount,
+          domain
+        } = foundDraftProposal;
         const { text, markdownFiles } = replaceImgDigestByBlob(
           { description, files },
           mapBlobToFile
@@ -94,7 +103,11 @@ const DraftSaver = ({
           files: filteredFiles,
           type,
           rfpDeadline,
-          rfpLink
+          rfpLink,
+          startDate,
+          endDate,
+          amount,
+          domain
         });
       }
     },

--- a/src/reducers/models/proposals.js
+++ b/src/reducers/models/proposals.js
@@ -296,7 +296,10 @@ const proposals = (state = DEFAULT_STATE, action) =>
               ),
               update(
                 ["allProposalsByUserId", action.payload.userid],
-                (userProposals = []) => [action.payload, ...userProposals]
+                (userProposals = {}) => {
+                  const token = shortRecordToken(proposalToken(action.payload));
+                  return { [token]: action.payload, ...userProposals };
+                }
               ),
               update(
                 ["numOfProposalsByUserId", action.payload.userid],


### PR DESCRIPTION
Closes #2725 
Closes #2727 

This diff fixes the submission error due to incorrect object spread
on `proposals` reducer model, and adds proposal metadata to
drafts scope, so we can also save it.

### UI Changes Screenshot

![2725-drafts-issues](https://user-images.githubusercontent.com/22639213/154724332-af4ac884-aea6-44ac-abde-ec5ff8bd3e37.gif)

