### PR TITLE
feat(common-ui): Add Modal Confirm and Provider

### DIFF
--- a/plugins-structure/packages/common-ui/src/components/Modal/ModalConfirm.js
+++ b/plugins-structure/packages/common-ui/src/components/Modal/ModalConfirm.js
@@ -1,0 +1,97 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import { Button, Icon, Message, Modal, Text } from "pi-ui";
+import { useModal } from "./ModalProvider";
+import styles from "./styles.module.css";
+
+export const ModalConfirm = React.memo(
+  ({
+    show,
+    onClose,
+    onSubmit,
+    title,
+    message,
+    successTitle,
+    successMessage,
+    onCloseSuccess,
+  }) => {
+    const [success, setSuccess] = useState();
+    const [error, setError] = useState();
+    const [, close] = useModal();
+    const modalTitle = (success && successTitle) || title;
+    async function handleSubmit() {
+      try {
+        await onSubmit();
+        setSuccess(true);
+      } catch (error) {
+        setError(error);
+      }
+    }
+    async function handleCloseSuccess() {
+      try {
+        await onCloseSuccess();
+        close();
+      } catch (error) {
+        setError(error);
+      }
+    }
+    async function handleClose() {
+      try {
+        await onClose();
+        close();
+      } catch (error) {
+        setError(error);
+      }
+    }
+    return (
+      <Modal
+        show={show}
+        onClose={handleClose}
+        title={modalTitle}
+        iconComponent={
+          !success ? (
+            <Icon type="info" size={26} />
+          ) : (
+            <Icon type="checkmark" size={26} />
+          )
+        }
+      >
+        {error && <Message kind="error">{error.toString()}</Message>}
+        {!success ? (
+          <div className={styles.modalContent}>
+            <Text>{message}</Text>
+            <div className={styles.modalButtons}>
+              <Button onClick={handleSubmit}>Confirm</Button>
+            </div>
+          </div>
+        ) : (
+          <div className={styles.modalContent}>
+            <Text>{successMessage}</Text>
+            <div className={styles.modalButtons}>
+              <Button onClick={handleCloseSuccess}>Ok</Button>
+            </div>
+          </div>
+        )}
+      </Modal>
+    );
+  }
+);
+
+ModalConfirm.propTypes = {
+  title: PropTypes.string,
+  message: PropTypes.node,
+  show: PropTypes.bool,
+  onClose: PropTypes.func,
+  onCloseSuccess: PropTypes.func,
+  onSubmit: PropTypes.func,
+  successTitle: PropTypes.string,
+  successMessage: PropTypes.node,
+};
+
+ModalConfirm.defaultProps = {
+  title: "Confirm Action",
+  message: "Are you sure?",
+  onCloseSuccess: () => {},
+  onSubmit: () => {},
+  onClose: () => {},
+};

--- a/plugins-structure/packages/common-ui/src/components/Modal/ModalConfirm.js
+++ b/plugins-structure/packages/common-ui/src/components/Modal/ModalConfirm.js
@@ -4,78 +4,76 @@ import { Button, Icon, Message, Modal, Text } from "pi-ui";
 import { useModal } from "./ModalProvider";
 import styles from "./styles.module.css";
 
-export const ModalConfirm = React.memo(
-  ({
-    show,
-    onClose,
-    onSubmit,
-    title,
-    message,
-    successTitle,
-    successMessage,
-    onCloseSuccess,
-  }) => {
-    const [success, setSuccess] = useState();
-    const [error, setError] = useState();
-    const [, close] = useModal();
-    const modalTitle = (success && successTitle) || title;
-    async function handleSubmit() {
-      try {
-        await onSubmit();
-        setSuccess(true);
-      } catch (error) {
-        setError(error);
-      }
+export const ModalConfirm = ({
+  show,
+  onClose,
+  onSubmit,
+  title,
+  message,
+  successTitle,
+  successMessage,
+  onCloseSuccess,
+}) => {
+  const [success, setSuccess] = useState();
+  const [error, setError] = useState();
+  const [, close] = useModal();
+  const modalTitle = (success && successTitle) || title;
+  async function handleSubmit() {
+    try {
+      await onSubmit();
+      setSuccess(true);
+    } catch (error) {
+      setError(error);
     }
-    async function handleCloseSuccess() {
-      try {
-        await onCloseSuccess();
-        close();
-      } catch (error) {
-        setError(error);
-      }
-    }
-    async function handleClose() {
-      try {
-        await onClose();
-        close();
-      } catch (error) {
-        setError(error);
-      }
-    }
-    return (
-      <Modal
-        show={show}
-        onClose={handleClose}
-        title={modalTitle}
-        iconComponent={
-          !success ? (
-            <Icon type="info" size={26} />
-          ) : (
-            <Icon type="checkmark" size={26} />
-          )
-        }
-      >
-        {error && <Message kind="error">{error.toString()}</Message>}
-        {!success ? (
-          <div className={styles.modalContent}>
-            <Text>{message}</Text>
-            <div className={styles.modalButtons}>
-              <Button onClick={handleSubmit}>Confirm</Button>
-            </div>
-          </div>
-        ) : (
-          <div className={styles.modalContent}>
-            <Text>{successMessage}</Text>
-            <div className={styles.modalButtons}>
-              <Button onClick={handleCloseSuccess}>Ok</Button>
-            </div>
-          </div>
-        )}
-      </Modal>
-    );
   }
-);
+  async function handleCloseSuccess() {
+    try {
+      await onCloseSuccess();
+      close();
+    } catch (error) {
+      setError(error);
+    }
+  }
+  async function handleClose() {
+    try {
+      await onClose();
+      close();
+    } catch (error) {
+      setError(error);
+    }
+  }
+  return (
+    <Modal
+      show={show}
+      onClose={handleClose}
+      title={modalTitle}
+      iconComponent={
+        !success ? (
+          <Icon type="info" size={26} />
+        ) : (
+          <Icon type="checkmark" size={26} />
+        )
+      }
+    >
+      {error && <Message kind="error">{error.toString()}</Message>}
+      {!success ? (
+        <div className={styles.modalContent}>
+          <Text>{message}</Text>
+          <div className={styles.modalButtons}>
+            <Button onClick={handleSubmit}>Confirm</Button>
+          </div>
+        </div>
+      ) : (
+        <div className={styles.modalContent}>
+          <Text>{successMessage}</Text>
+          <div className={styles.modalButtons}>
+            <Button onClick={handleCloseSuccess}>Ok</Button>
+          </div>
+        </div>
+      )}
+    </Modal>
+  );
+};
 
 ModalConfirm.propTypes = {
   title: PropTypes.string,

--- a/plugins-structure/packages/common-ui/src/components/Modal/ModalProvider.js
+++ b/plugins-structure/packages/common-ui/src/components/Modal/ModalProvider.js
@@ -1,0 +1,66 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useReducer,
+  useRef,
+} from "react";
+
+export const modalContext = createContext({ component: () => null, props: {} });
+
+export const useModal = () => useContext(modalContext);
+
+const initialState = {
+  component: () => null,
+  props: {
+    show: false,
+  },
+};
+
+function toggleReducer(state) {
+  return { toggle: !state.toggle };
+}
+
+export function ModalProvider({ children }) {
+  const modalStack = useRef([]);
+  const modalToDisplay = useRef(initialState);
+  // Modals are refs, and refs doesn't trigger component re-render. This
+  // will force the state update, hence a modal update.
+  const [, toggleDisplay] = useReducer(toggleReducer, { toggle: false });
+
+  const handleOpenModal = useCallback(function (
+    modal,
+    props = {},
+    { overlay } = {}
+  ) {
+    const newModal = { component: modal, props: { show: true, ...props } };
+    if (!modalStack.current || overlay) {
+      modalStack.current && modalStack.current.push(newModal);
+      modalToDisplay.current = newModal;
+      toggleDisplay();
+    } else if (modalToDisplay.current && !modalToDisplay.current.props.show) {
+      modalToDisplay.current = newModal;
+      toggleDisplay();
+    }
+  },
+  []);
+
+  const handleCloseModal = useCallback(function () {
+    modalStack.current && modalStack.current.pop();
+    const previousModal = modalStack.current && modalStack.current.pop();
+    modalToDisplay.current = previousModal || initialState;
+    toggleDisplay();
+  }, []);
+
+  const props = {
+    onClose: handleCloseModal,
+    ...modalToDisplay.current.props,
+  };
+
+  return (
+    <modalContext.Provider value={[handleOpenModal, handleCloseModal]}>
+      {children}
+      <modalToDisplay.current.component {...props} />
+    </modalContext.Provider>
+  );
+}

--- a/plugins-structure/packages/common-ui/src/components/Modal/index.js
+++ b/plugins-structure/packages/common-ui/src/components/Modal/index.js
@@ -1,0 +1,2 @@
+export * from "./ModalProvider";
+export * from "./ModalConfirm";

--- a/plugins-structure/packages/common-ui/src/components/Modal/styles.module.css
+++ b/plugins-structure/packages/common-ui/src/components/Modal/styles.module.css
@@ -1,0 +1,14 @@
+.modalContent {
+  display: flex;
+  flex-flow: column;
+}
+
+.modalContent > *:not(.modalButtons) {
+  padding: 1rem 0;
+}
+
+.modalButtons {
+  width: 100%;
+  display: flex;
+  justify-content: end;
+}

--- a/plugins-structure/packages/common-ui/src/components/index.js
+++ b/plugins-structure/packages/common-ui/src/components/index.js
@@ -1,5 +1,6 @@
 export * from "./Join";
 export * from "./DateTooltip";
 export * from "./Event";
+export * from "./Modal";
 export * from "./RecordCard";
 export * from "./RecordsList";

--- a/plugins-structure/packages/common-ui/src/dev/index.js
+++ b/plugins-structure/packages/common-ui/src/dev/index.js
@@ -7,6 +7,7 @@ import {
   createEditorCommand,
 } from "../components/Markdown";
 import {
+  Button,
   ButtonIcon,
   DEFAULT_DARK_THEME_NAME,
   DEFAULT_LIGHT_THEME_NAME,
@@ -19,6 +20,7 @@ import {
   useTheme,
 } from "pi-ui";
 import "pi-ui/dist/index.css";
+import { ModalConfirm, ModalProvider, useModal } from "../components";
 
 const themes = {
   [DEFAULT_LIGHT_THEME_NAME]: { ...defaultLightTheme },
@@ -111,14 +113,34 @@ function ThemeButtons() {
   );
 }
 
+function ModalButton() {
+  const [open] = useModal();
+  return (
+    <Button
+      onClick={() =>
+        open(ModalConfirm, {
+          onSubmit: () => {
+            console.log("confirmed");
+          },
+        })
+      }
+    >
+      Open Modal
+    </Button>
+  );
+}
+
 ReactDOM.render(
   <ThemeProvider themes={themes} defaultThemeName={DEFAULT_DARK_THEME_NAME}>
-    <ThemeButtons />
-    <h1>Markdown</h1>
-    <br />
-    <div id="markdown-diff-wrapper">
-      <MdTest />
-    </div>
+    <ModalProvider>
+      <ModalButton />
+      <ThemeButtons />
+      <h1>Markdown</h1>
+      <br />
+      <div id="markdown-diff-wrapper">
+        <MdTest />
+      </div>
+    </ModalProvider>
   </ThemeProvider>,
   document.querySelector("#root")
 );

--- a/plugins-structure/packages/common-ui/src/dev/index.js
+++ b/plugins-structure/packages/common-ui/src/dev/index.js
@@ -137,6 +137,7 @@ ReactDOM.render(
     <ModalProvider>
       <MultiContentPage sidebar={<ThemeButtons />} banner={<h1>Markdown</h1>}>
         <div id="markdown-diff-wrapper">
+          <ModalButton />
           <MdTest />
         </div>
       </MultiContentPage>


### PR DESCRIPTION
This Diff adds `ModalProvider` and `ModalConfirm` components
on common-ui package.

### Preview

<img width="631" alt="Screen Shot 2022-04-14 at 12 50 15 PM" src="https://user-images.githubusercontent.com/22639213/163426826-856f2afa-2bd1-4eab-8300-fd8c959c451a.png">

### Usage

You can open and close modals using the `useModal` hook:

```javascript
import { ModalConfirm, ModalProvider, useModal } from "../components";

function ModalButton() {
  const [open] = useModal();
  return (
    <Button
      onClick={() => open(ModalConfirm)}
    >
      Open Modal
    </Button>
  );
}

function App() {
  return (
    <ModalProvider>
      <ModalButton />
    </ModalProvider>
  );
}
```
