### PR TITLE
multi: Proposals List with Infinite Scroller

### DIFF
--- a/plugins-structure/apps/politeia/src/pages/Home/common/StatusList.js
+++ b/plugins-structure/apps/politeia/src/pages/Home/common/StatusList.js
@@ -1,7 +1,6 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo } from "react";
 import { records } from "@politeiagui/core/records";
 import { ticketvoteSummaries } from "@politeiagui/ticketvote/summaries";
-import { H1 } from "pi-ui";
 import { RecordsList } from "@politeiagui/common-ui";
 import { useDispatch, useSelector } from "react-redux";
 import { fetchNextBatch, selectLastToken, selectStatus } from "../homeSlice";
@@ -47,28 +46,24 @@ function StatusList({
 
   const summaries = useSelector(ticketvoteSummaries.selectAll);
 
+  const hasMoreToFetch = useMemo(
+    () => (hasMoreRecords && fetchStatus === "succeeded") || hasMoreInventory,
+    [hasMoreRecords, hasMoreInventory, fetchStatus]
+  );
+
   return (
-    <div>
-      <H1>{status}</H1>
-      <RecordsList>
-        {recordsInOrder.map((record) => {
-          const { token } = record.censorshiprecord;
-          return (
-            <ProposalCard
-              key={token}
-              record={record}
-              voteSummary={summaries[token]}
-            />
-          );
-        })}
-      </RecordsList>
-      <button
-        disabled={!hasMoreRecords && !hasMoreInventory}
-        onClick={handleFetchMore}
-      >
-        Fetch more
-      </button>
-    </div>
+    <RecordsList hasMore={hasMoreToFetch} onFetchMore={handleFetchMore}>
+      {recordsInOrder.map((record) => {
+        const { token } = record.censorshiprecord;
+        return (
+          <ProposalCard
+            key={token}
+            record={record}
+            voteSummary={summaries[token]}
+          />
+        );
+      })}
+    </RecordsList>
   );
 }
 

--- a/plugins-structure/packages/common-ui/package.json
+++ b/plugins-structure/packages/common-ui/package.json
@@ -26,6 +26,7 @@
     "diff": "^5.0.0",
     "html-react-parser": "^1.4.8",
     "node-html-parser": "^5.3.3",
+    "react-infinite-scroller": "^1.2.6",
     "react-markdown": "^6.0.3",
     "remark-gfm": "1.0.0",
     "xss-filters": "^1.2.7"

--- a/plugins-structure/packages/common-ui/src/components/RecordsList/RecordsList.js
+++ b/plugins-structure/packages/common-ui/src/components/RecordsList/RecordsList.js
@@ -1,6 +1,20 @@
 import React from "react";
+import InfiniteScroll from "react-infinite-scroller";
 import styles from "./styles.module.css";
 
-export function RecordsList({ children }) {
-  return <ul className={styles.recordsList}>{children}</ul>;
+export function RecordsList({ children, hasMore, onFetchMore }) {
+  function handleLoadMore() {
+    onFetchMore();
+  }
+  return (
+    <InfiniteScroll
+      className={styles.recordsList}
+      hasMore={hasMore}
+      useWindow={true}
+      initialLoad={true}
+      loadMore={handleLoadMore}
+    >
+      {children}
+    </InfiniteScroll>
+  );
 }

--- a/plugins-structure/yarn.lock
+++ b/plugins-structure/yarn.lock
@@ -10303,7 +10303,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.6.0, prop-types@^15.6.2:
+prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -10458,6 +10458,13 @@ react-dom@^17.0.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     scheduler "^0.20.2"
+
+react-infinite-scroller@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/react-infinite-scroller/-/react-infinite-scroller-1.2.6.tgz#8b80233226dc753a597a0eb52621247f49b15f18"
+  integrity sha512-mGdMyOD00YArJ1S1F3TVU9y4fGSfVVl6p5gh/Vt4u99CJOptfVu/q5V/Wlle72TMgYlBwIhbxK5wF0C/R33PXQ==
+  dependencies:
+    prop-types "^15.5.8"
 
 react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"


### PR DESCRIPTION
This diff adds the [`InfiniteScroller` component](https://github.com/danbovey/react-infinite-scroller) on `RecordsList`.

Our current (and also legacy) politeia app on production uses the
infinite scroller to fetch paginated records. Since our new plugin-architecture
app hasn't implemented that yet, proposals fetching was being triggered
by a temporary button.

### Preview

![infinite-scroller-under-review](https://user-images.githubusercontent.com/22639213/164042703-62a3d672-9d70-45f6-89a5-12ab17076656.gif)
 