### PR TITLE
[WIP] multi: Add Proposal New page

### DIFF
--- a/plugins-structure/apps/politeia/src/pages/New/New.js
+++ b/plugins-structure/apps/politeia/src/pages/New/New.js
@@ -1,0 +1,61 @@
+import React from "react";
+import { RecordForm } from "@politeiagui/common-ui";
+
+const PROPOSAL_TYPE_OPTIONS = [
+  { label: "Regular Proposal", value: 1 },
+  { label: "RFP Proposal", value: 2 },
+  { label: "RFP Submission", value: 3 },
+];
+
+// TODO: Get domains from pi policy
+const PROPOSAL_DOMAIN_OPTIONS = [
+  { label: "Development", value: "development" },
+  { label: "Marketing", value: "marketing" },
+  { label: "Research", value: "research" },
+  { label: "Design", value: "design" },
+];
+
+function New() {
+  function handleSubmit(data) {
+    console.log(data);
+  }
+  function handleSave(data) {
+    console.log("saving...", data);
+  }
+  return (
+    <RecordForm
+      onSubmit={handleSubmit}
+      initialValues={{ name: "", amount: "" }}
+    >
+      {({
+        TextInput,
+        SelectInput,
+        MarkdownInput,
+        SubmitButton,
+        SaveButton,
+      }) => {
+        return (
+          <div>
+            <SelectInput
+              options={PROPOSAL_TYPE_OPTIONS}
+              name="type"
+              placeholder="Proposal Type"
+            />
+            <TextInput name="name" placeholder="Proposal Name" />
+            <TextInput name="amount" placeholder="Amount (USD)" />
+            <SelectInput
+              options={PROPOSAL_DOMAIN_OPTIONS}
+              name="domain"
+              placeholder="Domain"
+            />
+            <MarkdownInput name="body" />
+            <SaveButton onSave={handleSave} />
+            <SubmitButton />
+          </div>
+        );
+      }}
+    </RecordForm>
+  );
+}
+
+export default New;

--- a/plugins-structure/apps/politeia/src/pages/index.js
+++ b/plugins-structure/apps/politeia/src/pages/index.js
@@ -1,3 +1,4 @@
 import Home from "./Home/Home";
+import New from "./New/New";
 
-export { Home };
+export { Home, New };

--- a/plugins-structure/apps/politeia/src/routes/routes.js
+++ b/plugins-structure/apps/politeia/src/routes/routes.js
@@ -1,4 +1,4 @@
-import { Home } from "../pages";
+import { Home, New } from "../pages";
 import { ticketvoteConstants } from "@politeiagui/ticketvote";
 import homeReducer from "../pages/Home/homeSlice";
 import { createAppRoute } from "./utils";
@@ -13,5 +13,10 @@ export const routes = [
     path: "/",
     reducers: [...ticketvoteConstants.reducersArray, homeReducerObj],
     Component: Home,
+  }),
+  createAppRoute({
+    path: "/record/new",
+    reducers: [],
+    Component: New,
   }),
 ];

--- a/plugins-structure/packages/common-ui/package.json
+++ b/plugins-structure/packages/common-ui/package.json
@@ -26,6 +26,7 @@
     "diff": "^5.0.0",
     "html-react-parser": "^1.4.8",
     "node-html-parser": "^5.3.3",
+    "react-hook-form": "^7.30.0",
     "react-markdown": "^6.0.3",
     "remark-gfm": "1.0.0",
     "xss-filters": "^1.2.7"

--- a/plugins-structure/packages/common-ui/src/components/Markdown/MarkdownEditor/MarkdownEditor.module.css
+++ b/plugins-structure/packages/common-ui/src/components/Markdown/MarkdownEditor/MarkdownEditor.module.css
@@ -22,7 +22,7 @@
 }
 .headers {
   display: flex;
-  padding: 0.5rem;
+  padding-bottom: 0.5rem;
   align-items: center;
   justify-content: space-between;
 }

--- a/plugins-structure/packages/common-ui/src/components/RecordForm/RecordForm.js
+++ b/plugins-structure/packages/common-ui/src/components/RecordForm/RecordForm.js
@@ -1,0 +1,117 @@
+import React from "react";
+import {
+  Controller,
+  FormProvider,
+  useForm,
+  useFormContext,
+} from "react-hook-form";
+import { BoxTextInput, Button, Card, Select } from "pi-ui";
+import styles from "./styles.module.css";
+import { MarkdownEditor } from "../Markdown";
+
+function TextInput({
+  name = "name",
+  placeholder,
+  min,
+  max,
+  minLength,
+  maxLength,
+  pattern,
+  validate,
+  required,
+}) {
+  return (
+    <Controller
+      name={name}
+      rules={{
+        min,
+        max,
+        minLength,
+        maxLength,
+        pattern,
+        validate,
+        required,
+      }}
+      render={({ field: { onChange, value } }) => (
+        <BoxTextInput
+          onChange={onChange}
+          value={value}
+          placeholder={placeholder}
+          inputClassName={styles.input}
+        />
+      )}
+    />
+  );
+}
+
+function SelectInput({ name = "select", options, ...props }) {
+  return (
+    <Controller
+      name={name}
+      render={({ field: { onChange, value } }) => (
+        <Select
+          options={options}
+          value={value}
+          onChange={onChange}
+          className={styles.select}
+          {...props}
+        />
+      )}
+    />
+  );
+}
+
+function MarkdownInput({ name, initialValue, ...props }) {
+  return (
+    <Controller
+      name={name}
+      render={({ field: { onChange } }) => (
+        <MarkdownEditor
+          wrapperClassName={styles.markdownInput}
+          onChange={onChange}
+          initialValue={initialValue}
+          {...props}
+        />
+      )}
+    />
+  );
+}
+
+function SubmitButton({ children = "Submit", ...props }) {
+  return (
+    <Button type="submit" className={styles.button} {...props}>
+      {children}
+    </Button>
+  );
+}
+
+function SaveButton({ children = "Save", onSave = () => {}, ...props }) {
+  const { getValues } = useFormContext();
+  function handleSave() {
+    onSave(getValues());
+  }
+  return (
+    <Button kind="secondary" onClick={handleSave} {...props}>
+      {children}
+    </Button>
+  );
+}
+
+export function RecordForm({ initialValues, children, onSubmit }) {
+  const methods = useForm({ defaultValues: initialValues });
+  return (
+    <Card paddingSize="small">
+      <FormProvider {...methods}>
+        <form onSubmit={methods.handleSubmit(onSubmit)} className={styles.form}>
+          {children({
+            TextInput,
+            SelectInput,
+            MarkdownInput,
+            SubmitButton,
+            SaveButton,
+          })}
+        </form>
+      </FormProvider>
+    </Card>
+  );
+}

--- a/plugins-structure/packages/common-ui/src/components/RecordForm/index.js
+++ b/plugins-structure/packages/common-ui/src/components/RecordForm/index.js
@@ -1,0 +1,1 @@
+export * from "./RecordForm";

--- a/plugins-structure/packages/common-ui/src/components/RecordForm/styles.module.css
+++ b/plugins-structure/packages/common-ui/src/components/RecordForm/styles.module.css
@@ -1,0 +1,31 @@
+.form {
+  display: flex;
+  flex-flow: column;
+}
+
+.input {
+  padding-left: 1rem !important;
+}
+
+.input::-webkit-input-placeholder {
+  color: hsl(0, 0%, 50%);
+}
+
+.markdownInput {
+  margin-top: 1rem;
+  margin-bottom: 2.3rem;
+}
+
+.select {
+  padding: 0 !important;
+  margin-top: 1rem;
+  margin-bottom: 2.3rem;
+}
+
+.select > div {
+  min-height: 4rem;
+}
+
+.button {
+  margin-top: 1rem;
+}

--- a/plugins-structure/packages/common-ui/src/components/index.js
+++ b/plugins-structure/packages/common-ui/src/components/index.js
@@ -2,4 +2,5 @@ export * from "./Join";
 export * from "./DateTooltip";
 export * from "./Event";
 export * from "./RecordCard";
+export * from "./RecordForm";
 export * from "./RecordsList";

--- a/plugins-structure/yarn.lock
+++ b/plugins-structure/yarn.lock
@@ -10459,6 +10459,11 @@ react-dom@^17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
+react-hook-form@^7.30.0:
+  version "7.30.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.30.0.tgz#c9e2fd54d3627e43bd94bf38ef549df2e80c1371"
+  integrity sha512-DzjiM6o2vtDGNMB9I4yCqW8J21P314SboNG1O0obROkbg7KVS0I7bMtwSdKyapnCPjHgnxc3L7E5PEdISeEUcQ==
+
 react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
⏳ Work in Progress... ⏳ 

This PR implements the Proposal New page, using the also implemented
RecordForm structure.

#### Pi
- [x] Add Proposal New page (`/record/new`)
- [ ] Use single page layout (#2748)
- [ ] Add "Create Proposal" Banner
- [ ] Get domains from pi policy (https://github.com/decred/politeiagui/pull/2723/commits/e8ede2991ff4f6c5984f9656440c62a20e9f439d)

#### Common-ui
- [x] Use react-hook-form instead of Formik.
- [x] Text Input
- [x] Markdown Input
- [x] Select Input
- [ ] Date Picker input


### Preview
<img width="1374" alt="Screen Shot 2022-04-19 at 7 14 49 PM" src="https://user-images.githubusercontent.com/22639213/164110503-65d3c9fd-f348-4e63-bc44-69e9df5c44f2.png">

