### PR TITLE
feat(cli): add plugins flag to newapp command

### DIFF
--- a/plugins-structure/packages/cli/README.md
+++ b/plugins-structure/packages/cli/README.md
@@ -6,9 +6,11 @@ line structure and arguments.
 
 ## Overview
 
-1. [Setup](#setup)
-2. [New Plugin](#creating-a-new-plugin)
-3. [New App](#creating-a-new-application)
+- [Politeiagui CLI](#politeiagui-cli)
+  - [Overview](#overview)
+  - [Setup](#setup)
+  - [Creating a new plugin](#creating-a-new-plugin)
+  - [Creating a new application](#creating-a-new-application)
 
 ## Setup
 
@@ -72,7 +74,7 @@ Creating a new `ticketvote` plugin:
 $ pgui newplugin ticketvote
 
 Creating a new plugin: ticketvote
-Directory: /Users/victorguedes/Documents/decred/politeiagui/plugins-structure/packages/ticketvote
+Directory: /Directory/plugins-structure/packages/ticketvote
 
 
 
@@ -133,8 +135,13 @@ Usage: pgui newapp [options] [app-name]
 Creates a new app-shell
 
 Options:
-  -p, --port <port>  port number (default: 3000)
-  -h, --help         display help for command
+  -p, --port <port> port number (default: 3000)
+
+  --plugins [plugins] list of plugins comma separated. Will be ignored if a config file is provided. Example: ticketvote,comments
+
+  --config [config] custom config file relative to this folder. Example: ./config.json
+
+  -h, --help  display help for command
 ```
 
 Creating a new Proposals app
@@ -142,7 +149,7 @@ Creating a new Proposals app
 ```bash
 $ pgui newapp proposals
 Creating a new app: proposals
-Directory: /Users/victorguedes/Documents/decred/politeiagui/plugins-structure/apps/proposals
+Directory: /Directory/apps/proposals
 
 
 
@@ -162,6 +169,7 @@ apps/proposals
 │   └── public
 │       └── index.html
 ├── webpack.common.js
+├── config.json
 ├── webpack.dev.js
 └── webpack.prod.js
 ```
@@ -189,10 +197,45 @@ Let's take a look under the `package.json`:
     "start": "webpack serve --config webpack.dev.js --open"
   },
   "dependencies": {
-    "@politeiagui/core": "1.0.0"
+    "@politeiagui/core": "1.0.0",
+    "@politeiagui/common-ui": "1.0.0"
   },
   "devDependencies": {
     "webpack-bundle-analyzer": "^4.4.2"
   }
 }
 ```
+
+And your `config.json` will look like this:
+
+```json
+{
+  "plugins": {}
+}
+```
+
+You can provide a config file to tell which plugins you want. To add the ticketvote plugin, for example, you can use this config file:
+
+```json
+{
+  "plugins": {
+    "ticketvote": {
+      "version": "1.0.0"
+    }
+  }
+}
+```
+
+With the following command:
+
+```bash
+$ pgui newapp proposals --config="./config-example.json"
+```
+
+You can also pass a list of comma-separated plugins via the plugins option. For example:
+
+```bash
+$ pgui newapp proposals --plugins="comments,ticketvote"
+```
+
+Notice that if you send both a plugins list and a config file, the plugins list will be ignored.

--- a/plugins-structure/packages/cli/lib/cmdnewapp.js
+++ b/plugins-structure/packages/cli/lib/cmdnewapp.js
@@ -66,11 +66,12 @@ module.exports = function newApp(appName, { port, plugins, config }) {
     if (!config) {
       appPlugins = plugins.split(",");
       for (let plugin of appPlugins) {
-        const pluginDepName = `@politeiagui/${plugin}`;
+        const trimmedPlugin = plugin.trim();
+        const pluginDepName = `@politeiagui/${trimmedPlugin}`;
         try {
-          const pluginDepVersion = getPluginVersion(plugin);
+          const pluginDepVersion = getPluginVersion(trimmedPlugin);
           pluginsDeps[pluginDepName] = pluginDepVersion;
-          pluginsConfig[plugin] = { version: pluginDepVersion };
+          pluginsConfig[trimmedPlugin] = { version: pluginDepVersion };
         } catch (e) {
           console.log(e);
           return;

--- a/plugins-structure/packages/cli/lib/cmdnewapp.js
+++ b/plugins-structure/packages/cli/lib/cmdnewapp.js
@@ -1,10 +1,7 @@
-const fs = require("fs");
 const path = require("path");
-const os = require("os");
 
 const {
   createSrcFiles,
-  getPluginVersion,
   validatePlugins,
   validateAppName,
   validateConfig,

--- a/plugins-structure/packages/cli/lib/cmdnewapp.js
+++ b/plugins-structure/packages/cli/lib/cmdnewapp.js
@@ -21,7 +21,7 @@ module.exports = function newApp(appName, { port, plugins, config }) {
     console.error("Error: Plugins must be a string");
     return;
   }
-  if (typeof config !== "string") {
+  if (config && typeof config !== "string") {
     console.error("Error: Config must be a string");
     return;
   }

--- a/plugins-structure/packages/cli/lib/cmdnewapp.js
+++ b/plugins-structure/packages/cli/lib/cmdnewapp.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const path = require("path");
+const os = require("os");
 
 const {
   replaceFileValuesFromMap,
@@ -36,18 +37,20 @@ module.exports = function newApp(appName, { port, plugins }) {
   // create app package.json
   const appPlugins = plugins.split(",");
   const pluginsDeps = {};
+  const pluginsConfig = {};
   for (let plugin of appPlugins) {
     const pluginDepName = `@politeiagui/${plugin}`;
     try {
       const pluginDepVersion = getPluginVersion(plugin);
       pluginsDeps[pluginDepName] = pluginDepVersion;
+      pluginsConfig[plugin] = pluginDepVersion;
     } catch (e) {
       console.log(e);
       return;
     }
   }
   fs.writeFileSync(
-    `${appPath}/package.json`,
+    path.join(appPath, "package.json"),
     JSON.stringify(
       {
         name: appName,
@@ -60,8 +63,17 @@ module.exports = function newApp(appName, { port, plugins }) {
       },
       null,
       2
-    )
+    ) + +os.EOL
   );
+  // create plugins.config.json
+  const pluginsConfigJson = {
+    ...pluginsConfig,
+  };
+  fs.writeFileSync(
+    path.join(appPath, "plugins.config.json"),
+    JSON.stringify(pluginsConfigJson, null, 2) + os.EOL
+  );
+
   // create webpack config files
   const wpDev = replaceFileValuesFromMap(`${baseAppPath}/webpack.dev.js`, {
     __PORT__: +port,

--- a/plugins-structure/packages/cli/lib/cmdnewapp.js
+++ b/plugins-structure/packages/cli/lib/cmdnewapp.js
@@ -3,142 +3,51 @@ const path = require("path");
 const os = require("os");
 
 const {
-  replaceFileValuesFromMap,
-  copyFile,
+  createSrcFiles,
   getPluginVersion,
+  validatePlugins,
+  validateAppName,
+  validateConfig,
+  loadConfigFile,
+  createNewApp,
+  createPackageJsonFile,
+  createConfigFile,
+  createWebpackConfigFiles,
+  createTestConfigFiles,
+  getPluginsDepsAndConfig,
 } = require("./utils");
 
 const baseAppPackageJSON = require("../app/package.json");
 const baseAppPath = path.resolve(__dirname, "../app");
 
 module.exports = function newApp(appName, { port, plugins, config }) {
-  let defaultApp = false;
-  if (!appName) {
-    console.error("Error: Please specify the app name");
+  try {
+    let configFile;
+    const isDefaultApp = !plugins && !config;
+
+    validateAppName(appName);
+    validatePlugins(plugins);
+    validateConfig(config);
+    if (config) configFile = loadConfigFile(config);
+    const { pluginsDeps, pluginsConfig } = getPluginsDepsAndConfig({
+      isDefaultApp,
+      plugins,
+      configFile,
+    });
+    const appPath = createNewApp(appName);
+    createPackageJsonFile({
+      appName,
+      baseAppPackageJSON,
+      pluginsDeps,
+      appPath,
+    });
+    createConfigFile({ appPath, config, pluginsConfig });
+    createWebpackConfigFiles({ appPath, port, baseAppPath });
+    createTestConfigFiles({ appPath, baseAppPath });
+    createSrcFiles({ appPath, appName, baseAppPath });
+  } catch (e) {
+    console.error(e);
     return;
   }
-  if (plugins && typeof plugins !== "string") {
-    console.error("Error: Plugins must be a string");
-    return;
-  }
-  if (config && typeof config !== "string") {
-    console.error("Error: Config must be a string");
-    return;
-  }
-  if (!plugins && !config) {
-    defaultApp = true;
-  }
-
-  let configFile;
-  if (typeof config === "string" && config) {
-    const configExists = fs.existsSync(path.resolve(__dirname, config));
-    if (!configExists) {
-      console.error("Error: Could not find config file");
-      return;
-    } else {
-      configFile = require(config);
-    }
-  }
-
-  const appShellPath = path.resolve(__dirname, "../../../apps/");
-  const appPath = path.resolve(appShellPath, appName);
-  const appExists = fs.existsSync(appPath);
-  if (appExists) {
-    console.error(`Error: App ${appName} already exists on ${appShellPath}`);
-    return;
-  }
-
-  console.log(`Creating a new app: ${appName}`);
-  console.log(`Directory: ${appPath}`);
-  console.log(`\n\n`);
-  console.log("Creating app files...");
-
-  // create app dir
-  fs.mkdirSync(appPath);
-  fs.mkdirSync(`${appPath}/src`);
-  fs.mkdirSync(`${appPath}/src/public`);
-
-  // create app package.json
-  const pluginsDeps = {};
-  const pluginsConfig = {};
-  if (!defaultApp) {
-    let appPlugins;
-    if (!config) {
-      appPlugins = plugins.split(",");
-      for (let plugin of appPlugins) {
-        const trimmedPlugin = plugin.trim();
-        const pluginDepName = `@politeiagui/${trimmedPlugin}`;
-        try {
-          const pluginDepVersion = getPluginVersion(trimmedPlugin);
-          pluginsDeps[pluginDepName] = pluginDepVersion;
-          pluginsConfig[trimmedPlugin] = { version: pluginDepVersion };
-        } catch (e) {
-          console.log(e);
-          return;
-        }
-      }
-    } else {
-      appPlugins = configFile.plugins;
-      for (let plugin in appPlugins) {
-        const pluginDepName = `@politeiagui/${plugin}`;
-        pluginsDeps[pluginDepName] = appPlugins[plugin].version;
-      }
-    }
-  }
-
-  fs.writeFileSync(
-    path.join(appPath, "package.json"),
-    JSON.stringify(
-      {
-        name: appName,
-        ...baseAppPackageJSON,
-        dependencies: {
-          "@politeiagui/core": "1.0.0",
-          "@politeiagui/common-ui": "1.0.0",
-          ...pluginsDeps,
-        },
-      },
-      null,
-      2
-    ) + os.EOL
-  );
-
-  // create config.json if one is not provided
-  if (!config) {
-    const configJson = {
-      plugins: {
-        ...pluginsConfig,
-      },
-    };
-    fs.writeFileSync(
-      path.join(appPath, "config.json"),
-      JSON.stringify(configJson, null, 2) + os.EOL
-    );
-  } else {
-    // copy if it is provided
-    fs.copyFileSync(config, `${appPath}/config.json`);
-  }
-
-  // create webpack config files
-  const wpDev = replaceFileValuesFromMap(`${baseAppPath}/webpack.dev.js`, {
-    __PORT__: +port,
-  });
-  fs.writeFileSync(`${appPath}/webpack.dev.js`, wpDev);
-  copyFile("webpack.common.js", appPath, baseAppPath);
-  copyFile("webpack.prod.js", appPath, baseAppPath);
-  // create test config files
-  copyFile("jest.config.js", appPath, baseAppPath);
-
-  // create src files
-  const indexHtml = replaceFileValuesFromMap(
-    `${baseAppPath}/src/public/index.html`,
-    { __APP_NAME__: appName }
-  );
-  const indexJs = replaceFileValuesFromMap(`${baseAppPath}/src/index.js`, {
-    __APP_NAME__: appName,
-  });
-  fs.writeFileSync(`${appPath}/src/public/index.html`, indexHtml);
-  fs.writeFileSync(`${appPath}/src/index.js`, indexJs);
-
   console.log("Done!");
 };

--- a/plugins-structure/packages/cli/lib/cmdnewplugin.js
+++ b/plugins-structure/packages/cli/lib/cmdnewplugin.js
@@ -7,6 +7,10 @@ const basePluginPackageJSON = require("../plugin/package.json");
 const basePluginPath = path.resolve(__dirname, "../plugin");
 
 module.exports = function newPlugin(pluginName, { port }) {
+  if (!pluginName) {
+    console.error("Please specify the app name");
+    return;
+  }
   const packagePath = path.resolve(__dirname, "../../../packages/");
   const pluginPath = path.resolve(packagePath, pluginName);
   const pluginExists = fs.existsSync(pluginPath);

--- a/plugins-structure/packages/cli/lib/config-example.json
+++ b/plugins-structure/packages/cli/lib/config-example.json
@@ -1,0 +1,7 @@
+{
+  "plugins": {
+    "ticketvote": {
+      "version": "1.0.0"
+    }
+  }
+}

--- a/plugins-structure/packages/cli/lib/pgui.js
+++ b/plugins-structure/packages/cli/lib/pgui.js
@@ -15,7 +15,13 @@ function execute() {
     .action(cmdnewplugin);
 
   program
-    .command("newapp [app-name]")
+    .command("newapp")
+    .argument("[app-name]", "The name of your new app")
+    .option(
+      "--plugins [plugins]",
+      "list of plugins comma separated. Example: ticketvote,comments",
+      "ticketvote"
+    )
     .option("-p, --port <port>", "port number", 3000)
     .description("Creates a new app-shell")
     .action(cmdnewapp);

--- a/plugins-structure/packages/cli/lib/pgui.js
+++ b/plugins-structure/packages/cli/lib/pgui.js
@@ -19,8 +19,11 @@ function execute() {
     .argument("[app-name]", "The name of your new app")
     .option(
       "--plugins [plugins]",
-      "list of plugins comma separated. Example: ticketvote,comments",
-      "ticketvote"
+      "list of plugins comma separated. Will be ignored if a config file is provided. Example: ticketvote,comments"
+    )
+    .option(
+      "--config [config]",
+      "custom config file relative to this folder. Example: ./config.json"
     )
     .option("-p, --port <port>", "port number", 3000)
     .description("Creates a new app-shell")

--- a/plugins-structure/packages/cli/lib/utils.js
+++ b/plugins-structure/packages/cli/lib/utils.js
@@ -114,6 +114,8 @@ function createPackageJsonFile({
 }
 
 function createConfigFile({ appPath, config, pluginsConfig }) {
+  console.log("Creating config file...");
+  console.log("Plugins:");
   if (!config) {
     const configJson = {
       plugins: {
@@ -124,8 +126,11 @@ function createConfigFile({ appPath, config, pluginsConfig }) {
       path.join(appPath, "config.json"),
       JSON.stringify(configJson, null, 2) + os.EOL
     );
+    console.log(JSON.stringify(pluginsConfig, null, 2));
   } else {
     // copy if it is provided
+    const cfg = require(config);
+    console.log(JSON.stringify(cfg.plugins, null, 2));
     fs.copyFileSync(config, `${appPath}/config.json`);
   }
 }

--- a/plugins-structure/packages/cli/lib/utils.js
+++ b/plugins-structure/packages/cli/lib/utils.js
@@ -155,36 +155,29 @@ function createSrcFiles({ baseAppPath, appName, appPath }) {
   fs.writeFileSync(`${appPath}/src/index.js`, indexJs);
 }
 
-function getPluginsDepsAndConfig({
-  isDefaultApp,
-  config,
-  plugins,
-  configFile,
-}) {
+function getPluginsDepsAndConfig({ isDefaultApp, plugins, configFile }) {
   const pluginsDeps = {};
   const pluginsConfig = {};
   if (!isDefaultApp) {
+    let appPlugins;
     if (!configFile) {
-      let appPlugins;
-      if (!config) {
-        appPlugins = plugins.split(",");
-        for (let plugin of appPlugins) {
-          const trimmedPlugin = plugin.trim();
-          const pluginDepName = `@politeiagui/${trimmedPlugin}`;
-          try {
-            const pluginDepVersion = getPluginVersion(trimmedPlugin);
-            pluginsDeps[pluginDepName] = pluginDepVersion;
-            pluginsConfig[trimmedPlugin] = { version: pluginDepVersion };
-          } catch (e) {
-            throw e;
-          }
+      appPlugins = plugins.split(",");
+      for (let plugin of appPlugins) {
+        const trimmedPlugin = plugin.trim();
+        const pluginDepName = `@politeiagui/${trimmedPlugin}`;
+        try {
+          const pluginDepVersion = getPluginVersion(trimmedPlugin);
+          pluginsDeps[pluginDepName] = pluginDepVersion;
+          pluginsConfig[trimmedPlugin] = { version: pluginDepVersion };
+        } catch (e) {
+          throw e;
         }
-      } else {
-        appPlugins = configFile.plugins;
-        for (let plugin in appPlugins) {
-          const pluginDepName = `@politeiagui/${plugin}`;
-          pluginsDeps[pluginDepName] = appPlugins[plugin].version;
-        }
+      }
+    } else {
+      appPlugins = configFile.plugins;
+      for (let plugin in appPlugins) {
+        const pluginDepName = `@politeiagui/${plugin}`;
+        pluginsDeps[pluginDepName] = appPlugins[plugin].version;
       }
     }
   }

--- a/plugins-structure/packages/cli/lib/utils.js
+++ b/plugins-structure/packages/cli/lib/utils.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const path = require("path");
 
 function replaceFileValuesFromMap(filePath, replaceMap) {
   const fileString = fs.readFileSync(filePath)?.toString();
@@ -13,7 +14,28 @@ function copyFile(filename, targetPath, basePath) {
   fs.copyFileSync(`${basePath}/${filename}`, `${targetPath}/${filename}`);
 }
 
+function getPluginVersion(plugin) {
+  const pluginDepPath = path.resolve(__dirname, `../../../packages/${plugin}`);
+  if (!fs.existsSync(pluginDepPath)) {
+    throw Error(
+      `The plugin ${plugin} doesn't exist in the packages folder. Do you have a typo?`
+    );
+  }
+
+  const pluginPkgPath = path.join(pluginDepPath, "package.json");
+
+  if (!fs.existsSync(pluginPkgPath)) {
+    throw Error(
+      `The plugin ${plugin} doesn't have a package.json. It must have a valid package.json`
+    );
+  }
+
+  const pluginPkg = require(pluginPkgPath);
+  return pluginPkg.version;
+}
+
 module.exports = {
   replaceFileValuesFromMap,
   copyFile,
+  getPluginVersion,
 };

--- a/plugins-structure/packages/cli/lib/utils.js
+++ b/plugins-structure/packages/cli/lib/utils.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const path = require("path");
+const os = require("os");
 
 function replaceFileValuesFromMap(filePath, replaceMap) {
   const fileString = fs.readFileSync(filePath)?.toString();
@@ -34,8 +35,175 @@ function getPluginVersion(plugin) {
   return pluginPkg.version;
 }
 
+function validateAppName(appName) {
+  if (!appName) {
+    throw Error("Please specify the app name");
+  }
+}
+function validatePlugins(plugins) {
+  if (plugins && typeof plugins !== "string") {
+    throw Error("Plugins must be a string");
+  }
+}
+function validateConfig(config) {
+  if (config && typeof config !== "string") {
+    throw Error("Config must be a string");
+  }
+}
+
+function getAppPath(appName) {
+  const appShellPath = path.resolve(__dirname, "../../../apps/");
+  const appPath = path.resolve(appShellPath, appName);
+  const appExists = fs.existsSync(appPath);
+  if (appExists) {
+    throw Error(`App ${appName} already exists on ${appShellPath}`);
+  }
+  return appPath;
+}
+
+function loadConfigFile(config) {
+  const configExists = fs.existsSync(path.resolve(__dirname, config));
+  if (!configExists) {
+    throw Error("Could not find config file");
+  } else {
+    return require(config);
+  }
+}
+
+function createNewApp(appName) {
+  let appPath;
+  try {
+    appPath = getAppPath(appName);
+    console.log(`Creating a new app: ${appName}`);
+    console.log(`Directory: ${appPath}`);
+    console.log(`\n\n`);
+    console.log("Creating app files...");
+
+    // create app dir
+    fs.mkdirSync(appPath);
+    fs.mkdirSync(`${appPath}/src`);
+    fs.mkdirSync(`${appPath}/src/public`);
+  } catch (e) {
+    throw e;
+  }
+  return appPath;
+}
+
+function createPackageJsonFile({
+  baseAppPackageJSON,
+  appName,
+  appPath,
+  pluginsDeps,
+}) {
+  fs.writeFileSync(
+    path.join(appPath, "package.json"),
+    JSON.stringify(
+      {
+        name: appName,
+        ...baseAppPackageJSON,
+        dependencies: {
+          "@politeiagui/core": "1.0.0",
+          "@politeiagui/common-ui": "1.0.0",
+          ...pluginsDeps,
+        },
+      },
+      null,
+      2
+    ) + os.EOL
+  );
+}
+
+function createConfigFile({ appPath, config, pluginsConfig }) {
+  if (!config) {
+    const configJson = {
+      plugins: {
+        ...pluginsConfig,
+      },
+    };
+    fs.writeFileSync(
+      path.join(appPath, "config.json"),
+      JSON.stringify(configJson, null, 2) + os.EOL
+    );
+  } else {
+    // copy if it is provided
+    fs.copyFileSync(config, `${appPath}/config.json`);
+  }
+}
+
+function createWebpackConfigFiles({ port, baseAppPath, appPath }) {
+  const wpDev = replaceFileValuesFromMap(`${baseAppPath}/webpack.dev.js`, {
+    __PORT__: +port,
+  });
+  fs.writeFileSync(`${appPath}/webpack.dev.js`, wpDev);
+  copyFile("webpack.common.js", appPath, baseAppPath);
+  copyFile("webpack.prod.js", appPath, baseAppPath);
+}
+
+function createTestConfigFiles({ appPath, baseAppPath }) {
+  copyFile("jest.config.js", appPath, baseAppPath);
+}
+
+function createSrcFiles({ baseAppPath, appName, appPath }) {
+  const indexHtml = replaceFileValuesFromMap(
+    `${baseAppPath}/src/public/index.html`,
+    { __APP_NAME__: appName }
+  );
+  const indexJs = replaceFileValuesFromMap(`${baseAppPath}/src/index.js`, {
+    __APP_NAME__: appName,
+  });
+  fs.writeFileSync(`${appPath}/src/public/index.html`, indexHtml);
+  fs.writeFileSync(`${appPath}/src/index.js`, indexJs);
+}
+
+function getPluginsDepsAndConfig({
+  isDefaultApp,
+  config,
+  plugins,
+  configFile,
+}) {
+  const pluginsDeps = {};
+  const pluginsConfig = {};
+  if (!isDefaultApp) {
+    if (!configFile) {
+      let appPlugins;
+      if (!config) {
+        appPlugins = plugins.split(",");
+        for (let plugin of appPlugins) {
+          const trimmedPlugin = plugin.trim();
+          const pluginDepName = `@politeiagui/${trimmedPlugin}`;
+          try {
+            const pluginDepVersion = getPluginVersion(trimmedPlugin);
+            pluginsDeps[pluginDepName] = pluginDepVersion;
+            pluginsConfig[trimmedPlugin] = { version: pluginDepVersion };
+          } catch (e) {
+            throw e;
+          }
+        }
+      } else {
+        appPlugins = configFile.plugins;
+        for (let plugin in appPlugins) {
+          const pluginDepName = `@politeiagui/${plugin}`;
+          pluginsDeps[pluginDepName] = appPlugins[plugin].version;
+        }
+      }
+    }
+  }
+  return { pluginsDeps, pluginsConfig };
+}
+
 module.exports = {
   replaceFileValuesFromMap,
   copyFile,
   getPluginVersion,
+  validateAppName,
+  validatePlugins,
+  validateConfig,
+  createNewApp,
+  loadConfigFile,
+  createPackageJsonFile,
+  createConfigFile,
+  createSrcFiles,
+  createWebpackConfigFiles,
+  createTestConfigFiles,
+  getPluginsDepsAndConfig,
 };

--- a/plugins-structure/packages/cli/package.json
+++ b/plugins-structure/packages/cli/package.json
@@ -2,14 +2,12 @@
   "name": "@politeiagui/cli",
   "version": "1.0.0",
   "description": "politeiagui cli",
+  "license": "MIT",
   "keywords": [
     "pgui",
     "politeiagui-cli",
     "@politeiagui/cli"
   ],
-  "author": "Victor Guedes <victorgcramos@gmail.com>",
-  "homepage": "https://github.com/decred/politeiagui#readme",
-  "license": "ISC",
   "main": "lib/pgui.js",
   "directories": {
     "lib": "lib",
@@ -18,10 +16,6 @@
   "files": [
     "lib"
   ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/decred/politeiagui.git"
-  },
   "scripts": {
     "prettier": "prettier \"**/*.js\"",
     "format": "yarn prettier --write",
@@ -32,9 +26,6 @@
     "test:dev": "npm run test:format && npm run test:eslint && cross-env NODE_OPTIONS=--experimental-vm-modules jest --watchAll --no-cache",
     "test": "is-ci \"test:ci\" \"test:dev\"",
     "test:coverage": "yarn test:ci; open coverage/lcov-report/index.html"
-  },
-  "bugs": {
-    "url": "https://github.com/decred/politeiagui/issues"
   },
   "bin": {
     "pgui": "lib/pgui.js"


### PR DESCRIPTION
This PR aims to extend the `newapp` CLI to accept a `plugins` flag with a list of comma separated plugins to add to the app.

Todo:

- [x] Add plugins flag to CLI
- [x] Add plugins to the `package.json` of the newly created app
- [x] Create basic config template

Decided to create a basic api for plugins config file and implement template after we have a better idea how all core packages will be integrated. 