### PR TITLE
multi: Add Proposal Loader + Store Listeners

### DIFF
--- a/plugins-structure/apps/politeia/src/components/Proposal/ProposalLoader.js
+++ b/plugins-structure/apps/politeia/src/components/Proposal/ProposalLoader.js
@@ -1,0 +1,21 @@
+import React from "react";
+import { RecordCard } from "@politeiagui/common-ui";
+import styles from "./styles.module.css";
+
+const Block = () => <div className={styles.block} />;
+
+function ProposalLoader() {
+  return (
+    <div className={styles.loaderWrapper}>
+      <RecordCard
+        title={<Block />}
+        titleWithoutLink
+        rightHeader={<Block />}
+        subtitle={<Block />}
+        thirdRow={<Block />}
+      />
+    </div>
+  );
+}
+
+export default ProposalLoader;

--- a/plugins-structure/apps/politeia/src/components/Proposal/styles.module.css
+++ b/plugins-structure/apps/politeia/src/components/Proposal/styles.module.css
@@ -2,3 +2,64 @@
   margin-top: 2rem;
   margin-bottom: 2rem;
 }
+
+.loaderWrapper {
+  margin-bottom: var(--spacing-medium);
+}
+
+.block {
+  width: 100%;
+  min-height: var(--font-size-xxlarge);
+  background-color: var(--dimmed-card-background);
+  min-width: 10rem;
+  animation: fadeIn linear 1s alternate infinite;
+  -webkit-animation: fadeIn linear 1s alternate infinite;
+  -moz-animation: fadeIn linear 1s alternate infinite;
+  -o-animation: fadeIn linear 1s alternate infinite;
+  -ms-animation: fadeIn linear 1s alternate infinite;
+}
+
+@keyframes fadeIn {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@-moz-keyframes fadeIn {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@-webkit-keyframes fadeIn {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@-o-keyframes fadeIn {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@-ms-keyframes fadeIn {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}

--- a/plugins-structure/apps/politeia/src/components/index.js
+++ b/plugins-structure/apps/politeia/src/components/index.js
@@ -1,4 +1,5 @@
 import Header from "./Header/Header";
 import ProposalCard from "./Proposal/ProposalCard";
+import ProposalLoader from "./Proposal/ProposalLoader";
 
-export { Header, ProposalCard };
+export { Header, ProposalCard, ProposalLoader };

--- a/plugins-structure/apps/politeia/src/index.js
+++ b/plugins-structure/apps/politeia/src/index.js
@@ -72,12 +72,12 @@ function initializeApi() {
 }
 
 function handleApi() {
-  const state = store.getState();
-  const status = api.selectStatus(state);
-  if (status === "loading") {
-    document.querySelector("#root").innerHTML = "<h1>Loading api...</h1>";
-  }
-  if (status === "succeeded" && !routerInitialized) {
+  // const state = store.getState();
+  // const status = api.selectStatus(state);
+  // if (status === "loading") {
+  //   document.querySelector("#root").innerHTML = "<h1>Loading api...</h1>";
+  // }
+  if (!routerInitialized) {
     routerInitialized = true;
     router.init({ routes });
   }

--- a/plugins-structure/apps/politeia/src/index.js
+++ b/plugins-structure/apps/politeia/src/index.js
@@ -72,11 +72,6 @@ function initializeApi() {
 }
 
 function handleApi() {
-  // const state = store.getState();
-  // const status = api.selectStatus(state);
-  // if (status === "loading") {
-  //   document.querySelector("#root").innerHTML = "<h1>Loading api...</h1>";
-  // }
   if (!routerInitialized) {
     routerInitialized = true;
     router.init({ routes });

--- a/plugins-structure/apps/politeia/src/pages/Home/Home.js
+++ b/plugins-structure/apps/politeia/src/pages/Home/Home.js
@@ -1,6 +1,8 @@
 import React from "react";
+import { useDispatch, useSelector } from "react-redux";
 import { recordsPolicy } from "@politeiagui/core/records/policy";
 import { router } from "@politeiagui/core/router";
+import { api } from "@politeiagui/core/api";
 import { MultiContentPage, TabsBanner } from "@politeiagui/common-ui/layout";
 import { ticketvotePolicy } from "@politeiagui/ticketvote/policy";
 import { getURLSearchParams } from "../../utils/getURLSearchParams";
@@ -8,6 +10,8 @@ import UnderReview from "./UnderReview/UnderReview";
 import Approved from "./Approved/Approved";
 import Rejected from "./Rejected/Rejected";
 import Abandoned from "./Abandoned/Abandoned";
+
+import { useStoreEffect } from "@politeiagui/core/listeners";
 
 const TAB_LABELS = {
   underReview: "Under Review",
@@ -34,15 +38,24 @@ function renderChild({ tab, ...props }) {
 
 function Home() {
   const { tab } = getURLSearchParams();
-  const { policyStatus: recordsPolicyStatus } = recordsPolicy.useFetch();
-  const { policyStatus: ticketvotePolicyStatus } = ticketvotePolicy.useFetch();
+  const dispatch = useDispatch();
+  const recordsPolicyStatus = useSelector(recordsPolicy.selectStatus);
+  const ticketvotePolicyStatus = useSelector(ticketvotePolicy.selectStatus);
+
   function handleSelectTab(index) {
     const selectedTab = TAB_VALUES[index];
     router.navigateTo(`/?tab=${selectedTab}`);
   }
+
+  useStoreEffect(() => {
+    if (recordsPolicyStatus === "idle") dispatch(ticketvotePolicy.fetch());
+    if (ticketvotePolicyStatus === "idle") dispatch(recordsPolicy.fetch());
+  }, [api.fetch.fulfilled]);
+
   const loading =
     recordsPolicyStatus !== "succeeded" ||
     ticketvotePolicyStatus !== "succeeded";
+
   return (
     <MultiContentPage
       banner={

--- a/plugins-structure/apps/politeia/src/pages/Home/common/RecordsStatusList.js
+++ b/plugins-structure/apps/politeia/src/pages/Home/common/RecordsStatusList.js
@@ -12,7 +12,7 @@ function RecordsStatusList({ status, onRenderNextStatus }) {
     page,
   });
 
-  return inventoryStatus !== "idle" && inventoryStatus !== "loading" ? (
+  return (
     <StatusList
       status={status}
       onFetchNextInventoryPage={handleFetchNextInventoryPage}
@@ -20,8 +20,6 @@ function RecordsStatusList({ status, onRenderNextStatus }) {
       inventory={inventory}
       onRenderNextStatus={onRenderNextStatus}
     />
-  ) : (
-    "Loading ..."
   );
 }
 

--- a/plugins-structure/apps/politeia/src/pages/Home/common/StatusList.js
+++ b/plugins-structure/apps/politeia/src/pages/Home/common/StatusList.js
@@ -4,7 +4,8 @@ import { ticketvoteSummaries } from "@politeiagui/ticketvote/summaries";
 import { RecordsList } from "@politeiagui/common-ui";
 import { useDispatch, useSelector } from "react-redux";
 import { fetchNextBatch, selectLastToken, selectStatus } from "../homeSlice";
-import { ProposalCard } from "../../../components";
+import { ProposalCard, ProposalLoader } from "../../../components";
+import max from "lodash/max";
 
 function StatusList({
   status,
@@ -47,23 +48,35 @@ function StatusList({
   const summaries = useSelector(ticketvoteSummaries.selectAll);
 
   const hasMoreToFetch = useMemo(
-    () => (hasMoreRecords && fetchStatus === "succeeded") || hasMoreInventory,
+    () => fetchStatus === "succeeded" && (hasMoreRecords || hasMoreInventory),
     [hasMoreRecords, hasMoreInventory, fetchStatus]
   );
 
+  const loadingPlaceholdersCount = max([
+    inventory.length - 1 - lastTokenPos,
+    0,
+  ]);
+
   return (
-    <RecordsList hasMore={hasMoreToFetch} onFetchMore={handleFetchMore}>
-      {recordsInOrder.map((record) => {
-        const { token } = record.censorshiprecord;
-        return (
-          <ProposalCard
-            key={token}
-            record={record}
-            voteSummary={summaries[token]}
-          />
-        );
-      })}
-    </RecordsList>
+    <div>
+      <RecordsList hasMore={hasMoreToFetch} onFetchMore={handleFetchMore}>
+        {recordsInOrder.map((record) => {
+          const { token } = record.censorshiprecord;
+          return (
+            <ProposalCard
+              key={token}
+              record={record}
+              voteSummary={summaries[token]}
+            />
+          );
+        })}
+      </RecordsList>
+      {Array(loadingPlaceholdersCount)
+        .fill("")
+        .map((_, i) => (
+          <ProposalLoader key={i} />
+        ))}
+    </div>
   );
 }
 

--- a/plugins-structure/jsconfig.json
+++ b/plugins-structure/jsconfig.json
@@ -7,6 +7,7 @@
       "@politeiagui/core/router": ["./packages/core/src/router/index.js"],
       "@politeiagui/core/client": ["./packages/core/src/client/index.js"],
       "@politeiagui/core/routes": ["./packages/core/src/routes/index.js"],
+      "@politeiagui/core/listeners": ["./packages/core/src/listeners/index.js"],
       "@politeiagui/core/records": [
         "./packages/core/src/records/records/index.js"
       ],

--- a/plugins-structure/packages/common-ui/src/components/RecordCard/RecordCard.js
+++ b/plugins-structure/packages/common-ui/src/components/RecordCard/RecordCard.js
@@ -10,14 +10,19 @@ export function RecordCard({
   secondRow,
   thirdRow,
   footer,
+  titleWithoutLink,
 }) {
   return (
     <Card className={styles.card}>
       <Row>
         <Column xs={12} sm={7}>
-          <a href={`/records/${token}`} data-link className={styles.title}>
+          {titleWithoutLink ? (
             <H2>{title}</H2>
-          </a>
+          ) : (
+            <a href={`/records/${token}`} data-link className={styles.title}>
+              <H2>{title}</H2>
+            </a>
+          )}
         </Column>
         <Column xs={12} sm={5} className={styles.rightHeader}>
           {rightHeader}

--- a/plugins-structure/packages/core/package.json
+++ b/plugins-structure/packages/core/package.json
@@ -13,7 +13,8 @@
     "./records/inventory": "./src/records/inventory/index.js",
     "./records/policy": "./src/records/policy/index.js",
     "./router": "./src/router/index.js",
-    "./routes": "./src/routes/index.js"
+    "./routes": "./src/routes/index.js",
+    "./listeners": "./src/listeners/index.js"
   },
   "babel": {
     "env": {

--- a/plugins-structure/packages/core/src/listeners/index.js
+++ b/plugins-structure/packages/core/src/listeners/index.js
@@ -1,0 +1,2 @@
+export * from "./useStoreEffect";
+export * from "./listeners";

--- a/plugins-structure/packages/core/src/listeners/listeners.js
+++ b/plugins-structure/packages/core/src/listeners/listeners.js
@@ -1,0 +1,19 @@
+import { createListenerMiddleware, isAnyOf } from "@reduxjs/toolkit";
+
+const listener = createListenerMiddleware();
+
+export const listenerMiddleware = listener.middleware;
+
+export function addStoreEffect(fn, actionCreators) {
+  let actionsCalled = 0;
+  listener.startListening({
+    effect: (action, listenerApi) => {
+      if (actionsCalled === actionCreators.length - 1) {
+        return fn(action, listenerApi);
+      } else {
+        actionsCalled++;
+      }
+    },
+    matcher: isAnyOf(...actionCreators),
+  });
+}

--- a/plugins-structure/packages/core/src/listeners/useStoreEffect.js
+++ b/plugins-structure/packages/core/src/listeners/useStoreEffect.js
@@ -1,0 +1,6 @@
+import { useEffect } from "react";
+import { addStoreEffect } from "./listeners";
+
+export function useStoreEffect(fn, actionCreators) {
+  useEffect(() => addStoreEffect(fn, actionCreators), [fn, actionCreators]);
+}

--- a/plugins-structure/packages/core/src/storeSetup.js
+++ b/plugins-structure/packages/core/src/storeSetup.js
@@ -6,6 +6,8 @@ import recordsReducer from "./records/records/recordsSlice";
 import policyReducer from "./records/policy/policySlice";
 import apiReducer from "./api/apiSlice";
 
+import { listenerMiddleware } from "./listeners";
+
 // Define the Reducers that will always be present in the application
 const staticReducers = {
   api: apiReducer,
@@ -33,7 +35,7 @@ function configureCustomStore(initialState) {
           thunk: {
             extraArgument: client,
           },
-        }),
+        }).concat([listenerMiddleware]),
     },
     initialState
   );

--- a/plugins-structure/yarn.lock
+++ b/plugins-structure/yarn.lock
@@ -2059,14 +2059,14 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.15.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.15.3", "@babel/runtime@^7.8.4":
   version "7.15.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.3.tgz#2e1c2880ca118e5b2f9988322bd8a7656a32502b"
   integrity sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.17.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
   integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
@@ -3469,14 +3469,14 @@
     "@react-spring/types" "~9.4.4"
 
 "@reduxjs/toolkit@^1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.6.1.tgz#7bc83b47352a663bf28db01e79d17ba54b98ade9"
-  integrity sha512-pa3nqclCJaZPAyBhruQtiRwtTjottRrVJqziVZcWzI73i6L3miLTtUyWfauwv08HWtiXLx1xGyGt+yLFfW/d0A==
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.8.1.tgz#94ee1981b8cf9227cda40163a04704a9544c9a9f"
+  integrity sha512-Q6mzbTpO9nOYRnkwpDlFOAbQnd3g7zj7CtHAZWz5SzE5lcV97Tf8f3SzOO8BoPOMYBFgfZaqTUZqgGu+a0+Fng==
   dependencies:
-    immer "^9.0.1"
-    redux "^4.1.0"
-    redux-thunk "^2.3.0"
-    reselect "^4.0.0"
+    immer "^9.0.7"
+    redux "^4.1.2"
+    redux-thunk "^2.4.1"
+    reselect "^4.1.5"
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
@@ -7398,10 +7398,10 @@ ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
-immer@^9.0.1:
-  version "9.0.5"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.5.tgz#a7154f34fe7064f15f00554cc94c66cc0bf453ec"
-  integrity sha512-2WuIehr2y4lmYz9gaQzetPR2ECniCifk4ORaQbU3g5EalLt+0IVTosEPJ5BoYl/75ky2mivzdRzV8wWgQGOSYQ==
+immer@^9.0.7:
+  version "9.0.12"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.12.tgz#2d33ddf3ee1d247deab9d707ca472c8c942a0f20"
+  integrity sha512-lk7UNmSbAukB5B6dh9fnh5D0bJTOFKxVg2cyJWTYrWRfhLrLMBquONcUs3aFq507hNoIZEDDh8lb8UtOizSMhA==
 
 import-fresh@^3.0.0, import-fresh@^3.1.0, import-fresh@^3.2.1:
   version "3.3.0"
@@ -10711,15 +10711,22 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
-redux-thunk@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
-  integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
+redux-thunk@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.1.tgz#0dd8042cf47868f4b29699941de03c9301a75714"
+  integrity sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==
 
-redux@^4.0.0, redux@^4.1.0:
+redux@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.1.tgz#76f1c439bb42043f985fbd9bf21990e60bd67f47"
   integrity sha512-hZQZdDEM25UY2P493kPYuKqviVwZ58lEmGQNeQ+gXa+U0gYPUBf7NKYazbe3m+bs/DzM/ahN12DbF+NG8i0CWw==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+
+redux@^4.1.2:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.0.tgz#46f10d6e29b6666df758780437651eeb2b969f13"
+  integrity sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==
   dependencies:
     "@babel/runtime" "^7.9.2"
 
@@ -10899,10 +10906,10 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
-reselect@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
-  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
+reselect@^4.0.0, reselect@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.5.tgz#852c361247198da6756d07d9296c2b51eddb79f6"
+  integrity sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This PR adds loading placeholders for loading proposals. Fixes https://github.com/decred/politeiagui/pull/2748#issuecomment-1106785947

<img width="1305" alt="Screen Shot 2022-04-26 at 8 38 37 PM" src="https://user-images.githubusercontent.com/22639213/165409919-e2340c7b-856e-43ba-aa16-3f5a2ddd9a2d.png">


It also introduces the new `useStoreEffect` hook, which uses the also implemented `addStoreEffect` listener to our Store.

#### Usage

You can use the `addStoreEffect` outside the React scope, and trigger a side effect when some action is dispatched. In the following example, we will add a listener, using the regarded method, to log a "Hello" message on the console after `api` is fetched:

```javascript
addStoreEffect(() => {
  console.log("Hello!");
}, [api.fetch.fulfilled]);
```

Easy, huh?

If you're using it on some react component, and don't want it to be triggered on every render, you can use the `useStoreEffect` hook. In the following example, we will fetch records and ticketvote policies after api is fetched:

```javascript
 useStoreEffect(() => {
    dispatch(ticketvotePolicy.fetch());
    dispatch(recordsPolicy.fetch());
  }, [api.fetch.fulfilled]);
```