### PR TITLE
comments: Remove formik and use react-hook-form

### DIFF
--- a/plugins-structure/apps/politeia/src/pages/Details/Details.js
+++ b/plugins-structure/apps/politeia/src/pages/Details/Details.js
@@ -40,7 +40,14 @@ function Details({ token }) {
             onFetchVersion={onFetchPreviousVersions}
             onFetchRecordTimestamps={onFetchRecordTimestamps}
           />
-          <Comments comments={comments} scrollOnLoad={shouldScrollToComments} />
+          <Comments
+            comments={comments}
+            // Mocking onReply until user layer is done.
+            onReply={(comment, parentid) => {
+              console.log(`Replying ${parentid}:`, comment);
+            }}
+            scrollOnLoad={shouldScrollToComments}
+          />
         </>
       )}
     </SingleContentPage>

--- a/plugins-structure/package.json
+++ b/plugins-structure/package.json
@@ -63,6 +63,7 @@
     "pi-ui": "https://github.com/decred/pi-ui",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-hook-form": "^7.30.0",
     "react-redux": "^7.2.4",
     "stream-browserify": "^3.0.0"
   }

--- a/plugins-structure/packages/comments/package.json
+++ b/plugins-structure/packages/comments/package.json
@@ -38,8 +38,9 @@
     "start": "webpack serve --config webpack.dev.js --open"
   },
   "dependencies": {
-    "@politeiagui/core": "1.0.0",
     "@politeiagui/common-ui": "1.0.0",
-    "js-file-download": "^0.4.12"
+    "@politeiagui/core": "1.0.0",
+    "js-file-download": "^0.4.12",
+    "react-hook-form": "^7.30.0"
   }
 }

--- a/plugins-structure/packages/comments/package.json
+++ b/plugins-structure/packages/comments/package.json
@@ -40,7 +40,6 @@
   "dependencies": {
     "@politeiagui/common-ui": "1.0.0",
     "@politeiagui/core": "1.0.0",
-    "js-file-download": "^0.4.12",
-    "react-hook-form": "^7.30.0"
+    "js-file-download": "^0.4.12"
   }
 }

--- a/plugins-structure/packages/comments/src/ui/CommentCard/CommentCard.js
+++ b/plugins-structure/packages/comments/src/ui/CommentCard/CommentCard.js
@@ -25,7 +25,6 @@ export const CommentCard = ({
   userLink,
   userVote,
   onComment,
-  parentId,
   disableReply,
 }) => {
   const [showThread, setShowThread] = useState(true);
@@ -79,7 +78,7 @@ export const CommentCard = ({
           )}
         </div>
         <div className={styles.footer}>
-          {!disableReply && (
+          {!disableReply && !comment.deleted && (
             <span
               className={styles.reply}
               data-testid="comment-reply"
@@ -95,7 +94,9 @@ export const CommentCard = ({
           )}
         </div>
       </Card>
-      {showForm && <CommentForm onComment={onComment} parentId={parentId} />}
+      {showForm && (
+        <CommentForm onComment={onComment} parentId={comment.commentid} />
+      )}
       {showThread && (
         <div className={styles.thread} data-testid="comment-thread">
           {children}

--- a/plugins-structure/packages/comments/src/ui/CommentForm/CommentForm.js
+++ b/plugins-structure/packages/comments/src/ui/CommentForm/CommentForm.js
@@ -1,49 +1,48 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Button, TextArea } from "pi-ui";
-import { Formik } from "formik";
+import { Button } from "pi-ui";
+import { Controller, useForm } from "react-hook-form";
+import { MarkdownEditor } from "@politeiagui/common-ui";
 import styles from "./styles.module.css";
 
-export const CommentForm = ({ onComment, onCancel, parentId }) => {
-  async function handleSubmitComment({ comment }, actions) {
+export const CommentForm = ({
+  onComment,
+  onCancel,
+  parentId,
+  disableSubmit,
+}) => {
+  const { handleSubmit, control, setError, watch } = useForm();
+
+  async function handleComment({ comment }) {
     try {
-      actions.setSubmitting(true);
       await onComment(comment, parentId);
-      actions.setSubmitting(false);
     } catch (error) {
-      actions.setSubmitting(false);
-      actions.setFieldError("comment", error.message);
+      setError("comment", error);
     }
   }
+  const comment = watch("comment");
+  const enableSubmit = comment && comment !== "" && !disableSubmit;
+
   return (
-    <Formik onSubmit={handleSubmitComment} initialValues={{ comment: "" }}>
-      {(props) => (
-        <form onSubmit={props.handleSubmit} className={styles.commentForm}>
-          {/* TODO: Use Markdown Editor */}
-          <TextArea
-            name="comment"
-            id="comment-text-area"
-            onChange={props.handleChange}
-            error={props.errors.comment}
-          />
-          <div className={styles.commentButtons}>
-            {onCancel && (
-              <Button onClick={onCancel} kind="secondary">
-                Cancel
-              </Button>
-            )}
-            <Button
-              type="submit"
-              kind={
-                props.isSubmitting || props.isValid ? "primary" : "disabled"
-              }
-            >
-              Add Comment
-            </Button>
-          </div>
-        </form>
-      )}
-    </Formik>
+    <form onSubmit={handleSubmit(handleComment)} className={styles.commentForm}>
+      <Controller
+        control={control}
+        name="comment"
+        render={({ field: { onChange } }) => (
+          <MarkdownEditor onChange={onChange} hideButtonsMenu />
+        )}
+      />
+      <div className={styles.commentButtons}>
+        {onCancel && (
+          <Button onClick={onCancel} kind="secondary">
+            Cancel
+          </Button>
+        )}
+        <Button type="submit" kind={enableSubmit ? "primary" : "disabled"}>
+          Add Comment
+        </Button>
+      </div>
+    </form>
   );
 };
 

--- a/plugins-structure/packages/comments/src/ui/CommentForm/styles.module.css
+++ b/plugins-structure/packages/comments/src/ui/CommentForm/styles.module.css
@@ -2,6 +2,7 @@
   padding: 1rem 1.4rem;
 }
 .commentButtons {
+  margin-top: 1rem;
   display: flex;
   justify-content: end;
 }

--- a/plugins-structure/packages/comments/src/ui/Comments/Comments.js
+++ b/plugins-structure/packages/comments/src/ui/Comments/Comments.js
@@ -14,6 +14,8 @@ export const Comments = ({
   showCensor,
   parentId,
   scrollOnLoad,
+  onReply,
+  disableReply,
 }) => {
   const [sortedComments, setSortedComments] = useState(Object.values(comments));
   const [threadSchema, setThreadSchema] = useState();
@@ -60,6 +62,8 @@ export const Comments = ({
           threadSchema={threadSchema}
           parentId={parentId}
           onCensor={onCensor}
+          onReply={onReply}
+          disableReply={disableReply}
         />
       </div>
     </div>
@@ -73,8 +77,11 @@ Comments.propTypes = {
   onCensor: PropTypes.func,
   showCensor: PropTypes.bool,
   parentId: PropTypes.number,
+  onReply: PropTypes.func,
+  disableReply: PropTypes.bool,
 };
 
 Comments.defaultProps = {
   parentId: 0,
+  onReply: () => {},
 };

--- a/plugins-structure/packages/comments/src/ui/Comments/CommentsList.js
+++ b/plugins-structure/packages/comments/src/ui/Comments/CommentsList.js
@@ -9,6 +9,8 @@ export const CommentsList = ({
   onCensor,
   threadSchema,
   userVotes,
+  onReply,
+  disableReply,
 }) => {
   if (!threadSchema || !threadSchema[parentId]) {
     return null;
@@ -21,7 +23,8 @@ export const CommentsList = ({
       threadLength={threadSchema[childId]?.length}
       showCensor={showCensor}
       userVote={userVotes[childId]}
-      parentId={parentId}
+      onComment={onReply}
+      disableReply={disableReply}
     >
       <CommentsList
         comments={comments}
@@ -30,6 +33,8 @@ export const CommentsList = ({
         parentId={childId}
         threadSchema={threadSchema}
         userVotes={userVotes}
+        onReply={onReply}
+        disableReply={disableReply}
       />
     </CommentCard>
   ));

--- a/plugins-structure/yarn.lock
+++ b/plugins-structure/yarn.lock
@@ -10454,6 +10454,11 @@ react-dom@^17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
+react-hook-form@^7.30.0:
+  version "7.30.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.30.0.tgz#c9e2fd54d3627e43bd94bf38ef549df2e80c1371"
+  integrity sha512-DzjiM6o2vtDGNMB9I4yCqW8J21P314SboNG1O0obROkbg7KVS0I7bMtwSdKyapnCPjHgnxc3L7E5PEdISeEUcQ==
+
 react-infinite-scroller@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/react-infinite-scroller/-/react-infinite-scroller-1.2.6.tgz#8b80233226dc753a597a0eb52621247f49b15f18"


### PR DESCRIPTION
This diff fixes the currently broken CommentForm component by 
removing the unused formik package and using react-hook-form.

