### PR TITLE
Update chat link

### DIFF
--- a/src/components/EmailSentMessage.jsx
+++ b/src/components/EmailSentMessage.jsx
@@ -23,8 +23,8 @@ const EmailSentMessage = ({
     <P>
       If you're sure you should have received an email, join the
       #support:decred.org channel on{" "}
-      <Link href="https://www.decred.org/matrix/">Matrix</Link> to get
-      assistance from Politeia administrators.
+      <Link href="https://chat.decred.org">Matrix</Link> to getassistance from
+      Politeia administrators.
     </P>
   </>
 );

--- a/src/components/EmailSentMessage.jsx
+++ b/src/components/EmailSentMessage.jsx
@@ -23,7 +23,7 @@ const EmailSentMessage = ({
     <P>
       If you're sure you should have received an email, join the
       #support:decred.org channel on{" "}
-      <Link href="https://chat.decred.org">Matrix</Link> to getassistance from
+      <Link href="https://chat.decred.org">Matrix</Link> to get assistance from
       Politeia administrators.
     </P>
   </>


### PR DESCRIPTION
https://decred.org/matrix is an overly verbose relic from before we hosted our own instance of Element at https://chat.decred.org