### PR TITLE
fix: Avoid duplicate inventories tokens

### DIFF
--- a/plugins-structure/packages/core/src/records/inventory/recordsInventory.test.js
+++ b/plugins-structure/packages/core/src/records/inventory/recordsInventory.test.js
@@ -209,7 +209,7 @@ describe("Given the recordsInventorySlice", () => {
             vetted: { public: publicTokens },
             unvetted: {},
           };
-          fetchRecordsInventorySpy.mockResolvedValueOnce(resValue);
+          fetchRecordsInventorySpy.mockResolvedValue(resValue);
 
           await preloadedStore.dispatch(fetchRecordsInventory(params));
 
@@ -222,7 +222,17 @@ describe("Given the recordsInventorySlice", () => {
           expect(fetchRecordsInventorySpy).toBeCalledWith(
             objAfterTransformation
           );
-          const state = preloadedStore.getState();
+          let state = preloadedStore.getState();
+          expect(state.recordsInventory.vetted.public.tokens).toEqual([
+            "fakeToken",
+          ]);
+          expect(state.recordsInventory.vetted.public.lastPage).toEqual(1);
+          expect(state.recordsInventory.vetted.public.status).toEqual(
+            "succeeded/hasMore"
+          );
+          // duplicate request
+          await preloadedStore.dispatch(fetchRecordsInventory(params));
+          state = preloadedStore.getState();
           expect(state.recordsInventory.vetted.public.tokens).toEqual([
             "fakeToken",
           ]);

--- a/plugins-structure/packages/core/src/records/inventory/recordsInventorySlice.js
+++ b/plugins-structure/packages/core/src/records/inventory/recordsInventorySlice.js
@@ -13,6 +13,7 @@ import {
   validateInventoryPageSize,
   validateRecordStateAndStatus,
 } from "../validation";
+import uniq from "lodash/uniq";
 
 const initialObj = {
   tokens: [],
@@ -98,9 +99,12 @@ const recordsInventorySlice = createSlice({
           state[stringState][readableStatus].status = "succeeded/isDone";
         }
         state[stringState][readableStatus].lastPage = page;
-        state[stringState][readableStatus].tokens.push(
-          ...recordsInventory[stringState][readableStatus]
-        );
+        const newTokens = [
+          ...state[stringState][readableStatus].tokens,
+          ...recordsInventory[stringState][readableStatus],
+        ];
+        // Avoid duplicate tokens
+        state[stringState][readableStatus].tokens = uniq(newTokens);
       })
       .addCase(fetchRecordsInventory.rejected, (state, action) => {
         state.status = "failed";

--- a/plugins-structure/packages/ticketvote/src/ticketvote/inventory/inventory.test.js
+++ b/plugins-structure/packages/ticketvote/src/ticketvote/inventory/inventory.test.js
@@ -137,9 +137,11 @@ describe("Given the recordsInventorySlice", () => {
       expect(state.unauthorized.status).toEqual("succeeded/isDone");
     });
     it("should update tokens, last page and status (succeeded/hasMore for tokens.length == inventorypagesize)", async () => {
-      const fakeToken = "fakeToken";
+      const unauthorized = Array(20)
+        .fill("")
+        .map((_, i) => `fakeToken-${i}`);
       const resValue = {
-        vetted: { unauthorized: Array(20).fill(fakeToken) },
+        vetted: { unauthorized },
         bestblock: 420,
       };
       fetchInventorySpy.mockResolvedValueOnce(resValue);
@@ -148,7 +150,21 @@ describe("Given the recordsInventorySlice", () => {
 
       expect(fetchInventorySpy).toBeCalled();
       const state = store.getState().ticketvoteInventory;
-      expect(state.unauthorized.tokens).toEqual(Array(20).fill(fakeToken));
+      expect(state.unauthorized.tokens).toEqual(unauthorized);
+      expect(state.unauthorized.lastPage).toEqual(1);
+      expect(state.unauthorized.status).toEqual("succeeded/hasMore");
+    });
+    it("should avoid duplicate tokens", async () => {
+      const fakeToken = "fakeToken";
+      const resValue = {
+        vetted: { unauthorized: Array(20).fill(fakeToken) },
+        bestBlock: 420,
+      };
+      fetchInventorySpy.mockResolvedValueOnce(resValue);
+      await store.dispatch(fetchTicketvoteInventory(params));
+      expect(fetchInventorySpy).toBeCalled();
+      const state = store.getState().ticketvoteInventory;
+      expect(state.unauthorized.tokens).toEqual([fakeToken]);
       expect(state.unauthorized.lastPage).toEqual(1);
       expect(state.unauthorized.status).toEqual("succeeded/hasMore");
     });

--- a/plugins-structure/packages/ticketvote/src/ticketvote/inventory/inventory.test.js
+++ b/plugins-structure/packages/ticketvote/src/ticketvote/inventory/inventory.test.js
@@ -160,10 +160,17 @@ describe("Given the recordsInventorySlice", () => {
         vetted: { unauthorized: Array(20).fill(fakeToken) },
         bestBlock: 420,
       };
-      fetchInventorySpy.mockResolvedValueOnce(resValue);
+      fetchInventorySpy.mockResolvedValue(resValue);
       await store.dispatch(fetchTicketvoteInventory(params));
       expect(fetchInventorySpy).toBeCalled();
-      const state = store.getState().ticketvoteInventory;
+      let state = store.getState().ticketvoteInventory;
+      expect(state.unauthorized.tokens).toEqual([fakeToken]);
+      expect(state.unauthorized.lastPage).toEqual(1);
+      expect(state.unauthorized.status).toEqual("succeeded/hasMore");
+      // duplicate request
+      await store.dispatch(fetchTicketvoteInventory(params));
+      state = store.getState().ticketvoteInventory;
+      expect(fetchInventorySpy).toBeCalled();
       expect(state.unauthorized.tokens).toEqual([fakeToken]);
       expect(state.unauthorized.lastPage).toEqual(1);
       expect(state.unauthorized.status).toEqual("succeeded/hasMore");

--- a/plugins-structure/packages/ticketvote/src/ticketvote/inventory/inventorySlice.js
+++ b/plugins-structure/packages/ticketvote/src/ticketvote/inventory/inventorySlice.js
@@ -9,6 +9,7 @@ import {
   validateTicketvoteInventoryPageSize,
   validateTicketvoteStatus,
 } from "../../lib/validation";
+import uniq from "lodash/uniq";
 
 const initialStatusInventory = {
   tokens: [],
@@ -80,7 +81,12 @@ const ticketvoteInventorySlice = createSlice({
           state[readableStatus].status = "succeeded/isDone";
         }
         state[readableStatus].lastPage = page;
-        state[readableStatus].tokens.push(...inventory[readableStatus]);
+        // remove duplicate tokens
+        const newTokens = [
+          ...state[readableStatus].tokens,
+          ...inventory[readableStatus],
+        ];
+        state[readableStatus].tokens = uniq(newTokens);
       })
       .addCase(fetchTicketvoteInventory.rejected, (state, action) => {
         state.status = "failed";


### PR DESCRIPTION
Closes #2772 

This PR fixes the duplicate tokens issue on both records and ticketvote
inventories with unit tests to ensure inventory will be only composed by
uniq tokens
