### PR TITLE
legacy: Minor proposals UX improvements

### DIFF
--- a/src/components/Proposal/Proposal.jsx
+++ b/src/components/Proposal/Proposal.jsx
@@ -261,8 +261,7 @@ const Proposal = React.memo(function Proposal({
         className={classNames(
           (isAbandoned || isCensored) && styles.abandonedProposal,
           isNotExtendedRfpOrSubmission && styles.rfpProposal
-        )}
-      >
+        )}>
         {({
           Author,
           Event,
@@ -300,8 +299,7 @@ const Proposal = React.memo(function Proposal({
                   truncate
                   isLegacy={isLegacy}
                   linesBeforeTruncate={2}
-                  url={proposalURL}
-                >
+                  url={proposalURL}>
                   {name || shortToken}
                 </Title>
               }
@@ -319,8 +317,7 @@ const Proposal = React.memo(function Proposal({
                     placement={mobile ? "left" : "right"}
                     content="You have to revoke the voting authorization to edit the proposal"
                     className={styles.disabled}
-                    contentClassName={styles.authorizeTooltip}
-                  >
+                    contentClassName={styles.authorizeTooltip}>
                     <Edit tabIndex={-1} />
                   </Tooltip>
                 ) : null
@@ -354,7 +351,7 @@ const Proposal = React.memo(function Proposal({
                   ) : (
                     !showEditedDate && (
                       <span data-testid="proposal-published-timestamp">
-                        <Event event="published" timestamp={timestamp} />
+                        <Event event="submitted" timestamp={timestamp} />
                       </span>
                     )
                   )}
@@ -367,8 +364,7 @@ const Proposal = React.memo(function Proposal({
                     <Text
                       id={`proposal-${shortToken}-version`}
                       className={styles.version}
-                      truncate
-                    >{`version ${version}`}</Text>
+                      truncate>{`version ${version}`}</Text>
                   )}
                   {showExtendedVersionPicker && (
                     <VersionPicker
@@ -418,15 +414,13 @@ const Proposal = React.memo(function Proposal({
                     <Tooltip
                       placement="bottom"
                       content={`block ${startblockheight} to ${endblockheight}`}
-                      contentClassName={styles.quorumTooltip}
-                    >
+                      contentClassName={styles.quorumTooltip}>
                       <Text
                         className={classNames(
                           "hide-on-mobile",
                           styles.blocksLeft
                         )}
-                        size="small"
-                      >
+                        size="small">
                         {`${voteBlocksLeft} block${
                           voteBlocksLeft > 1 ? "s" : ""
                         } left`}
@@ -519,8 +513,7 @@ const Proposal = React.memo(function Proposal({
               <Row className={styles.lastRow} justify="space-between">
                 <LinkSection
                   className={styles.downloadLinksWrapper}
-                  title="Available Downloads"
-                >
+                  title="Available Downloads">
                   <DownloadRecord
                     fileName={`${shortToken}-v${version}`}
                     content={proposal}

--- a/src/components/ProposalForm/ProposalForm.jsx
+++ b/src/components/ProposalForm/ProposalForm.jsx
@@ -75,8 +75,7 @@ const Rules = () => (
         <Link
           href="https://docs.decred.org/contributing/contributor-compensation/"
           target="_blank"
-          rel="noopener noreferrer"
-        >
+          rel="noopener noreferrer">
           here
         </Link>
       </ListItem>
@@ -86,8 +85,7 @@ const Rules = () => (
         <Link
           href="https://docs.decred.org/governance/politeia/proposal-guidelines/"
           target="_blank"
-          rel="noopener noreferrer"
-        >
+          rel="noopener noreferrer">
           Proposal Guidelines
         </Link>
       </ListItem>
@@ -209,6 +207,13 @@ const ProposalForm = React.memo(function ProposalForm({
   const hasError = errors && errors.global;
   useScrollTo("record-submission-error-message", hasError);
 
+  function getEndDateMinTimestamp() {
+    return values.startDate
+      ? // One day from startDate in ms
+        (convertObjectToUnixTimestamp(values.startDate) + 86400) * 1000
+      : sumNowAndDuration(startdatemin);
+  }
+
   return (
     <form onSubmit={handleSubmit}>
       <Message kind="warning" className="margin-bottom-m">
@@ -222,8 +227,7 @@ const ProposalForm = React.memo(function ProposalForm({
         className={classNames(
           styles.typeRow,
           isRFPSubmission && styles.typeRowNoMargin
-        )}
-      >
+        )}>
         <SelectField
           name="type"
           onChange={handleSelectFiledChange("type")}
@@ -247,8 +251,7 @@ const ProposalForm = React.memo(function ProposalForm({
               className={styles.tooltipWrapper}
               placement={smallTablet ? "left" : "bottom"}
               content="The deadline for the RFP submissions,
-              it can be edited at any point before the voting has been started and should be at least two weeks from now."
-            >
+              it can be edited at any point before the voting has been started and should be at least two weeks from now.">
               <div className={styles.iconWrapper}>
                 <Icon type="info" size={smallTablet ? "md" : "lg"} />
               </div>
@@ -285,8 +288,7 @@ const ProposalForm = React.memo(function ProposalForm({
               className={styles.tooltipWrapper}
               placement="left"
               content="The token for the RFP you are submitting on,
-              it can be found on the RFP proposal page."
-            >
+              it can be found on the RFP proposal page.">
               <div className={styles.iconWrapper}>
                 <Icon type="info" size={smallTablet ? "md" : "lg"} />
               </div>
@@ -331,7 +333,7 @@ const ProposalForm = React.memo(function ProposalForm({
             tabIndex={1}
             className={classNames(styles.endDate, "margin-bottom-m")}
             value={values.endDate}
-            minTimestamp={sumNowAndDuration(startdatemin)}
+            minTimestamp={getEndDateMinTimestamp()}
             maxTimestamp={sumNowAndDuration(enddatemax)}
             name="endDate"
             placeholder="End Date"
@@ -410,8 +412,7 @@ const ProposalForm = React.memo(function ProposalForm({
           <Message
             id="record-submission-error-message"
             className={classNames(styles.errorRow, "margin-bottom-m")}
-            kind="error"
-          >
+            kind="error">
             {errors.global.toString()}
           </Message>
         </Row>
@@ -555,8 +556,7 @@ const ProposalFormWrapper = ({
         loading={!proposalFormValidation}
         validate={proposalFormValidation}
         isInitialValid={!initialErrors}
-        onSubmit={handleSubmit}
-      >
+        onSubmit={handleSubmit}>
         {(props) => (
           <ProposalForm
             {...{


### PR DESCRIPTION
This PR fixes 2 minor things to improve the UX:

1. Rename unvetted "published" label to "submitted";
    <img width="1254" alt="Screen Shot 2022-06-23 at 5 18 49 PM" src="https://user-images.githubusercontent.com/22639213/175392151-51e6c353-62cc-4ca7-8c46-70645ba6ec83.png">

2. Don't allow picking a proposal form end date < start date.
    <img width="376" alt="Screen Shot 2022-06-23 at 5 21 52 PM" src="https://user-images.githubusercontent.com/22639213/175392625-a98c1004-229a-4790-85d1-9c8f2020c600.png">

