### PR TITLE
[WIP] Decouple listeners effects

### DIFF
--- a/plugins-structure/apps/politeia/src/pages/Home/common/StatusList.js
+++ b/plugins-structure/apps/politeia/src/pages/Home/common/StatusList.js
@@ -34,6 +34,7 @@ function StatusList({
     summaries,
     fetchNextBatch,
     recordsInOrder,
+    recordsPageSize,
   } = useStatusList({ inventory, inventoryStatus, status });
 
   function handleFetchMore() {
@@ -56,6 +57,7 @@ function StatusList({
         hasMore={hasMoreToFetch}
         onFetchMore={handleFetchMore}
         isLoading={homeStatus === "loading"}
+        childrenThreshold={recordsPageSize}
         loadingSkeleton={
           <LoadingSkeleton inventory={inventory} records={recordsInOrder} />
         }

--- a/plugins-structure/apps/politeia/src/pages/Home/useStatusList.js
+++ b/plugins-structure/apps/politeia/src/pages/Home/useStatusList.js
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { fetchNextBatch } from "./actions";
 import { selectHomeStatus } from "./selectors";
 import { records } from "@politeiagui/core/records";
+import { recordsPolicy } from "@politeiagui/core/records/policy";
 import { ticketvoteSummaries } from "@politeiagui/ticketvote/summaries";
 import { commentsCount } from "@politeiagui/comments/count";
 
@@ -11,6 +12,9 @@ function useStatusList({ status, inventory, inventoryStatus }) {
   const homeStatus = useSelector(selectHomeStatus);
   const countComments = useSelector(commentsCount.selectAll);
   const summaries = useSelector(ticketvoteSummaries.selectAll);
+  const recordsPageSize = useSelector((state) =>
+    recordsPolicy.selectRule(state, "recordspagesize")
+  );
   const recordsInOrder = useSelector((state) =>
     records.selectByTokensBatch(state, inventory)
   );
@@ -39,6 +43,7 @@ function useStatusList({ status, inventory, inventoryStatus }) {
     summaries,
     fetchNextBatch,
     recordsInOrder,
+    recordsPageSize,
   };
 }
 

--- a/plugins-structure/packages/comments/package.json
+++ b/plugins-structure/packages/comments/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./src/index.js",
     "./api": "./src/lib/api.js",
+    "./effects": "./src/effects/index.js",
     "./comments": "./src/comments/comments/index.js",
     "./count": "./src/comments/count/index.js",
     "./policy": "./src/comments/policy/index.js",

--- a/plugins-structure/packages/comments/src/effects/index.js
+++ b/plugins-structure/packages/comments/src/effects/index.js
@@ -1,0 +1,26 @@
+import { commentsCount } from "../comments/count";
+import { getTokensToFetch } from "@politeiagui/core/records/utils";
+import isEmpty from "lodash/isEmpty";
+
+export async function fetchNextComments(state, dispatch, { inventoryList }) {
+  const {
+    commentsCount: { byToken, status },
+    commentsPolicy: {
+      policy: { countpagesize },
+    },
+  } = state;
+
+  const commentsCountToFetch = getTokensToFetch({
+    inventoryList,
+    lookupTable: byToken,
+    pageSize: countpagesize,
+  });
+
+  if (status !== "loading" && !isEmpty(commentsCountToFetch)) {
+    await dispatch(
+      commentsCount.fetch({
+        tokens: commentsCountToFetch,
+      })
+    );
+  }
+}

--- a/plugins-structure/packages/common-ui/src/components/InfiniteScroller/InfiniteScroller.js
+++ b/plugins-structure/packages/common-ui/src/components/InfiniteScroller/InfiniteScroller.js
@@ -43,13 +43,14 @@ function InfiniteScroller({
   hasMore,
   isLoading,
   loadMore,
+  childrenThreshold,
   loadingSkeleton,
 }) {
   return (
     <>
       <div className={className}>
         {children}
-        {children.length > 0 && (
+        {children.length >= childrenThreshold && (
           <AppendObservableElement
             hasMore={hasMore}
             isLoading={isLoading}
@@ -66,9 +67,14 @@ InfiniteScroller.propType = {
   children: PropTypes.array.isRequired,
   loadingSkeleton: PropTypes.node,
   className: PropTypes.string,
+  childrenThreshold: PropTypes.number,
   hasMore: PropTypes.bool.isRequired,
   isLoading: PropTypes.bool.isRequired,
   loadMore: PropTypes.func.isRequired,
+};
+
+InfiniteScroller.defaultProps = {
+  childrenThreshold: 1,
 };
 
 export default InfiniteScroller;

--- a/plugins-structure/packages/common-ui/src/components/RecordsList/RecordsList.js
+++ b/plugins-structure/packages/common-ui/src/components/RecordsList/RecordsList.js
@@ -8,6 +8,7 @@ export function RecordsList({
   onFetchMore,
   isLoading,
   loadingSkeleton,
+  childrenThreshold,
 }) {
   function handleLoadMore() {
     onFetchMore();
@@ -19,6 +20,7 @@ export function RecordsList({
       loadMore={handleLoadMore}
       isLoading={isLoading}
       loadingSkeleton={loadingSkeleton}
+      childrenThreshold={childrenThreshold}
     >
       {children}
     </InfiniteScroller>

--- a/plugins-structure/packages/core/package.json
+++ b/plugins-structure/packages/core/package.json
@@ -7,6 +7,7 @@
     "./api": "./src/api/index.js",
     "./client": "./src/client/index.js",
     "./records": "./src/records/records/index.js",
+    "./records/effects": "./src/records/effects/index.js",
     "./records/utils": "./src/records/utils.js",
     "./records/constants": "./src/records/constants.js",
     "./records/validation": "./src/records/validation.js",

--- a/plugins-structure/packages/core/src/records/effects/index.js
+++ b/plugins-structure/packages/core/src/records/effects/index.js
@@ -1,0 +1,31 @@
+import { records } from "../records";
+import { getTokensToFetch } from "@politeiagui/core/records/utils";
+import isEmpty from "lodash/isEmpty";
+
+export async function fetchNextRecords(
+  state,
+  dispatch,
+  { inventoryList, filenames }
+) {
+  const {
+    records: { records: recordsObj, status },
+    recordsPolicy: {
+      policy: { recordspagesize },
+    },
+  } = state;
+
+  const recordsToFetch = getTokensToFetch({
+    inventoryList,
+    lookupTable: recordsObj,
+    pageSize: recordspagesize,
+  });
+
+  if (status !== "loading" && !isEmpty(recordsToFetch)) {
+    dispatch(
+      records.fetch({
+        tokens: recordsToFetch,
+        filenames,
+      })
+    );
+  }
+}

--- a/plugins-structure/packages/ticketvote/package.json
+++ b/plugins-structure/packages/ticketvote/package.json
@@ -7,6 +7,7 @@
     ".": "./src/index.js",
     "./api": "./src/lib/api.js",
     "./routes": "./src/routes/index.js",
+    "./effects": "./src/effects/index.js",
     "./details": "./src/ticketvote/details/index.js",
     "./inventory": "./src/ticketvote/inventory/index.js",
     "./policy": "./src/ticketvote/policy/index.js",

--- a/plugins-structure/packages/ticketvote/src/effects/index.js
+++ b/plugins-structure/packages/ticketvote/src/effects/index.js
@@ -1,0 +1,30 @@
+import { ticketvoteSummaries } from "../ticketvote/summaries";
+import { getTokensToFetch } from "@politeiagui/core/records/utils";
+import isEmpty from "lodash/isEmpty";
+
+export async function fetchNextTicketvoteSummaries(
+  state,
+  dispatch,
+  { inventoryList }
+) {
+  const {
+    ticketvoteSummaries: { byToken, status },
+    ticketvotePolicy: {
+      policy: { summariespagesize },
+    },
+  } = state;
+
+  const voteSummariesToFetch = getTokensToFetch({
+    inventoryList,
+    lookupTable: byToken,
+    pageSize: summariespagesize,
+  });
+
+  if (status !== "loading" && !isEmpty(voteSummariesToFetch)) {
+    await dispatch(
+      ticketvoteSummaries.fetch({
+        tokens: voteSummariesToFetch,
+      })
+    );
+  }
+}


### PR DESCRIPTION
With this PR plugins can export pluggable `effects` that can be used inside a `listener` `effect` to do whatever the plugin want. This way we can reduce the overhead to create integrations. Example:

A common integration is to fetch records, comments counts and ticketvote summaries when the scroll hits the end of the page. Currently we have a listener listening to a `fetchNextBatch` action that is fired by the `InfiniteScroller` when it hits the end of the records loaded. This works great but we are doing all our fetching logic in the listener callback effect. That's not ideal since we want the developer to be able to easily compose plugins. With this PR I decoupled the fetching logic from the listener effect. Now plugins can export effects and the developer can just import and use them inside a listener accordingly. This is a work in progress and I'm planning on creating an util to allow the developer to register listeners and a "chain of effects" easily.

![image](https://user-images.githubusercontent.com/13955303/176261027-21b20b22-6df3-46e7-a25d-83ff8ba160bb.png)