### PR TITLE
fix(legacy): RFP submissions ctrl+click bug

### DIFF
--- a/src/containers/Proposal/helpers.js
+++ b/src/containers/Proposal/helpers.js
@@ -352,8 +352,11 @@ export const getCommentsUrl = (token, isJsEnabled) =>
 export const getAuthorUrl = (userid, isJsEnabled) =>
   isJsEnabled ? `/user/${userid}` : `${NOJS_ROUTE_PREFIX}/user/${userid}`;
 
-export const goToFullProposal = (history, proposalURL) => () =>
-  history.push(proposalURL);
+export const goToFullProposal = (history, proposalURL) => (e) => {
+  if (!e.metaKey && !e.ctrlKey) {
+    return history.push(proposalURL);
+  }
+};
 
 /**
  * Returns the proposal list with RFP Proposal linked to RFP submissions


### PR DESCRIPTION
Closes #2814 

![2814-ctrl-link-rfp-submissions](https://user-images.githubusercontent.com/22639213/179825096-91e40955-54ca-4969-afdb-38d765bd33e4.gif)
