### PR TITLE
fix(legacy): disabled edit button alignment

### DIFF
--- a/src/components/Proposal/Proposal.module.css
+++ b/src/components/Proposal/Proposal.module.css
@@ -6,6 +6,10 @@
   width: 22rem;
 }
 
+.disabled > a {
+  display: block;
+}
+
 .disabled > * {
   pointer-events: none;
 }


### PR DESCRIPTION
Before:
<img width="841" alt="Screen Shot 2022-07-20 at 5 20 14 PM" src="https://user-images.githubusercontent.com/22639213/180074214-852d1593-b729-4bcf-b557-43e153432d38.png">

After:
<img width="834" alt="Screen Shot 2022-07-20 at 5 19 30 PM" src="https://user-images.githubusercontent.com/22639213/180074164-6b816dee-74d6-4028-874f-2911e32a24f6.png">

