### PR TITLE
test(core): Unit tests for appSetup and pluginSetup

### DIFF
--- a/plugins-structure/packages/core/src/appSetup.test.js
+++ b/plugins-structure/packages/core/src/appSetup.test.js
@@ -1,0 +1,69 @@
+import { appSetup } from "./appSetup";
+import { pluginSetup } from "./pluginSetup";
+import { store } from "./storeSetup";
+import { router } from "./router";
+
+const reducer = () => ({});
+const action = jest.fn();
+jest.spyOn(console, "error").mockImplementation();
+
+const plugin = pluginSetup({
+  services: [{ id: "custom/service1", action }],
+  reducers: [
+    { key: "customReducer", reducer },
+    { key: "customReducer2", reducer },
+  ],
+  name: "custom",
+});
+
+describe("Given appSetup method", () => {
+  describe("when only app plugins are defined", () => {
+    let myApp;
+    beforeEach(() => {
+      myApp = appSetup({ plugins: [plugin] });
+    });
+    it("should setup app correctly", () => {
+      expect(myApp).toHaveProperty(
+        "config",
+        "init",
+        "getConfig",
+        "createRoute"
+      );
+    });
+    it("should connect plugin's reducers", () => {
+      expect(store.getState()).toHaveProperty("customReducer");
+      expect(store.getState()).toHaveProperty("customReducer2");
+    });
+    it("should create route correctly and allow navigation", async () => {
+      const view = jest.fn();
+      const route = myApp.createRoute({ path: "/", view, cleanup: jest.fn() });
+
+      await myApp.init({ routes: [route] });
+      router.navigateTo("/");
+
+      expect(view).toBeCalled();
+    });
+  });
+  describe("when listeners and plugins are defined on app setup", () => {
+    const effect = jest.fn();
+    const myApp = appSetup({
+      plugins: [plugin],
+      listeners: [{ type: "customReducer/fetch", effect }],
+    });
+    it("should listen to customReducer/fetch", async () => {
+      await myApp.init({
+        routes: [
+          {
+            path: "/",
+            view: jest.fn(),
+            cleanup: jest.fn(),
+          },
+        ],
+      });
+      router.navigateTo("/");
+      expect(effect).not.toBeCalled();
+      store.dispatch({ type: "customReducer/fetch" });
+      expect(effect).toBeCalled();
+    });
+  });
+});

--- a/plugins-structure/packages/core/src/pluginSetup.test.js
+++ b/plugins-structure/packages/core/src/pluginSetup.test.js
@@ -1,0 +1,60 @@
+import { pluginSetup } from "./pluginSetup";
+
+const reducer = jest.fn();
+const action = jest.fn();
+
+const validReducers = [{ key: "customReducer", reducer }];
+const services = [{ id: "custom/service1", action }];
+
+const validSetup = {
+  services,
+  reducers: validReducers,
+  name: "custom",
+};
+
+describe("Given pluginSetup method", () => {
+  it("should create and setup plugins correctly", () => {
+    const customPlugin = pluginSetup(validSetup);
+    expect(customPlugin).toHaveProperty(
+      "reducers",
+      "services",
+      "name",
+      "initialize"
+    );
+  });
+  it("should throw error when some parameter is incorrect", () => {
+    expect(() =>
+      pluginSetup({
+        services: [{ foo: "bar" }],
+        reducers: validReducers,
+        name: "custom",
+      })
+    ).toThrowError(
+      "`services` must be an array of objects where the id key is required"
+    );
+    expect(() =>
+      pluginSetup({
+        services,
+        reducers: [{ foo: "bar" }],
+        name: "custom",
+      })
+    ).toThrowError("`reducers` must be array of { key, reducer }");
+    expect(() =>
+      pluginSetup({
+        services: [{ foo: "bar" }],
+        reducers: validReducers,
+        name: null,
+      })
+    ).toThrowError("`name` is required and must be a string");
+  });
+  it("should initialize some service and execute its action", async () => {
+    const customPlugin = pluginSetup(validSetup);
+    await customPlugin.initialize("custom/service1");
+    expect(action).toBeCalledTimes(1);
+  });
+  it("should not execute actions when id does not match a plugin service", async () => {
+    const customPlugin = pluginSetup(validSetup);
+    await customPlugin.initialize("custom/notMatch");
+    expect(action).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This PR adds unit tests for both `appSetup` and `pluginSetup` methods.

App Setup:
- [x] app setup only with plugins defined
- [x] app listeners
- [x] apps route navigation
- [ ] routes listeners
- [ ] routes services
- [ ] incorrect params and config

Plugins Setup:
- [x] regular plugin setup
- [x] initialize service
- [x] incorrect params and config  