### PR TITLE
legacy: Fix invalid signature on user key verify

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -1233,22 +1233,21 @@ export const onUpdateUserKey = (currentUserID) =>
     return pki
       .generateKeys()
       .then((keys) =>
-        pki.loadKeys(currentUserID, keys).then(() =>
-          api
-            .updateKeyRequest(csrf, pki.toHex(keys.publicKey))
-            .then((response) => {
-              const { verificationtoken } = response;
-              if (verificationtoken) {
-                const isTestnet = sel.isTestNet(getState());
-                if (isTestnet) {
-                  dispatch(act.SHOULD_AUTO_VERIFY_KEY(true));
-                }
+        api
+          .updateKeyRequest(csrf, pki.toHex(keys.publicKey))
+          .then((response) => {
+            const { verificationtoken } = response;
+            if (verificationtoken) {
+              const isTestnet = sel.isTestNet(getState());
+              if (isTestnet) {
+                dispatch(act.SHOULD_AUTO_VERIFY_KEY(true));
               }
-              return dispatch(
-                act.RECEIVE_UPDATED_KEY({ ...response, success: true })
-              );
-            })
-        )
+            }
+            return dispatch(
+              act.RECEIVE_UPDATED_KEY({ ...response, success: true })
+            );
+          })
+          .then(() => pki.loadKeys(currentUserID, keys))
       )
       .catch((error) => {
         dispatch(act.RECEIVE_UPDATED_KEY(null, error));


### PR DESCRIPTION
Closes #2841 

This diff fixes an annoying bug constantly reported on support channel ([here's an example](https://matrix.to/#/!xUNvyzkFgiMjhvPbIi:decred.org/$EZcOJ2XoMzOTjYXMjm3_YiXjnRmpZxJw0jRGRS671QI?via=decred.org&via=matrix.org&via=planetdecred.org)), where new keys were generated on GUI **before** sending them to the server, leading to the following error message:

![2841-invalid-signature-idenitit](https://user-images.githubusercontent.com/22639213/183142240-8fa05cf3-5211-4af8-b341-01ebd6566fc2.png)


This issue gets fixed by updating user keys only when the `/user/key` request succeeds.

##### How to test on dev environment
1. Create a new user: `pictl usernew test@example.com test password --verify`
2. login
3. go to Account > Identity
4. open the network panel on your browser to get the `verificationtoken`
5. Click on the "Create new identity" button
6. write down the `verificationtoken` (on production mode, the verification token will be sent to user's email).
7. Create another identity (you can do that multiple times)
8. Navigate to `/user/key/verify?verificationtoken=<your-verificationtoken>`
9. Done! (on current master, that's when the bug happens).