### PR TITLE
multi: fix minor navigation and links issues

### DIFF
--- a/plugins-structure/apps/politeia/src/components/Header/Header.js
+++ b/plugins-structure/apps/politeia/src/components/Header/Header.js
@@ -19,8 +19,12 @@ function Header() {
   return (
     <Navbar logo={<PoliteiaLogo />} drawerContent={<About />}>
       <ThemeToggle />
-      <a href="/user/login">Log in</a>
-      <a href="/user/signup">Sign up</a>
+      <a href="/user/login" data-link>
+        Log in
+      </a>
+      <a href="/user/signup" data-link>
+        Sign up
+      </a>
     </Navbar>
   );
 }

--- a/plugins-structure/apps/politeia/src/components/Header/Header.js
+++ b/plugins-structure/apps/politeia/src/components/Header/Header.js
@@ -1,25 +1,17 @@
 import React from "react";
-import { router } from "@politeiagui/core/router";
-import { Navbar, ThemeToggle, theme } from "@politeiagui/common-ui/layout";
 import { useSelector } from "react-redux";
-import { DEFAULT_DARK_THEME_NAME, Text } from "pi-ui";
+import { DEFAULT_DARK_THEME_NAME } from "pi-ui";
+import { Navbar, ThemeToggle, theme } from "@politeiagui/common-ui/layout";
 import LogoLight from "../../public/assets/images/pi-logo-light.svg";
 import LogoDark from "../../public/assets/images/pi-logo-dark.svg";
 import About from "../Static/About";
-import styles from "./styles.module.css";
 
 function PoliteiaLogo() {
   const themeName = useSelector(theme.select);
   return (
-    <div
-      onClick={() => router.navigateTo("/")}
-      className={styles.logo}
-      data-testid="politeia-logo"
-    >
-      <Text>
-        {themeName === DEFAULT_DARK_THEME_NAME ? <LogoDark /> : <LogoLight />}
-      </Text>
-    </div>
+    <a data-link href="/" data-testid="politeia-logo">
+      {themeName === DEFAULT_DARK_THEME_NAME ? <LogoDark /> : <LogoLight />}
+    </a>
   );
 }
 

--- a/plugins-structure/apps/politeia/src/components/Header/styles.module.css
+++ b/plugins-structure/apps/politeia/src/components/Header/styles.module.css
@@ -1,3 +1,0 @@
-.logo {
-  cursor: pointer;
-}

--- a/plugins-structure/apps/politeia/src/components/Proposal/ProposalDetails.js
+++ b/plugins-structure/apps/politeia/src/components/Proposal/ProposalDetails.js
@@ -125,11 +125,12 @@ const ProposalDetails = ({
               onFetchRecordTimestamps={onFetchRecordTimestamps}
             />
             <div className={styles.footerButtons}>
-              <ButtonIcon
-                type="markdown"
-                onClick={handleShowRawMarkdown}
-                viewBox="0 0 208 128"
-              />
+              <a
+                href={`/record/${getShortToken(proposalDetails.token)}/raw`}
+                data-link
+              >
+                <ButtonIcon type="markdown" viewBox="0 0 208 128" />
+              </a>
               <ButtonIcon type="link" onClick={handleShowRawMarkdown} />
             </div>
           </>

--- a/plugins-structure/apps/politeia/src/components/Proposal/common/ProposalSubtitle.js
+++ b/plugins-structure/apps/politeia/src/components/Proposal/common/ProposalSubtitle.js
@@ -15,7 +15,7 @@ function ProposalSubtitle({
   const { publishedat, editedat } = timestamps;
   return (
     <Join>
-      <Link href={`user/${userid}`} data-testid="proposal-username">
+      <Link data-link href={`user/${userid}`} data-testid="proposal-username">
         {username}
       </Link>
       {publishedat && (

--- a/plugins-structure/apps/politeia/src/pages/Details/Details.js
+++ b/plugins-structure/apps/politeia/src/pages/Details/Details.js
@@ -36,7 +36,6 @@ function Details({ token }) {
     recordDetailsError,
     voteSummaryError,
     commentsError,
-    billingStatusChange,
     proposalStatusChanges,
   } = useProposalDetails({ token });
   // TODO: this can be moved somewhere else
@@ -51,28 +50,30 @@ function Details({ token }) {
           errors={[recordDetailsError, voteSummaryError, commentsError]}
         />
       )}
-      {fullToken && record && detailsStatus === "succeeded" && (
-        <>
-          <ProposalDetails
-            record={record}
-            voteSummary={voteSummary}
-            proposalSummary={proposalSummary}
-            billingStatusChange={billingStatusChange}
-            proposalStatusChanges={proposalStatusChanges}
-            onFetchRecordTimestamps={onFetchRecordTimestamps}
-          />
-          {comments && (
-            <Comments
-              comments={comments}
-              // Mocking onReply until user layer is done.
-              onReply={(comment, parentid) => {
-                console.log(`Replying ${parentid}:`, comment);
-              }}
-              scrollOnLoad={shouldScrollToComments}
+      {fullToken &&
+        record &&
+        detailsStatus === "succeeded" &&
+        record.detailsFetched && (
+          <>
+            <ProposalDetails
+              record={record}
+              voteSummary={voteSummary}
+              proposalSummary={proposalSummary}
+              proposalStatusChanges={proposalStatusChanges}
+              onFetchRecordTimestamps={onFetchRecordTimestamps}
             />
-          )}
-        </>
-      )}
+            {comments && (
+              <Comments
+                comments={comments}
+                // Mocking onReply until user layer is done.
+                onReply={(comment, parentid) => {
+                  console.log(`Replying ${parentid}:`, comment);
+                }}
+                scrollOnLoad={shouldScrollToComments}
+              />
+            )}
+          </>
+        )}
     </SingleContentPage>
   );
 }

--- a/plugins-structure/apps/politeia/src/pages/Details/useProposalDetails.js
+++ b/plugins-structure/apps/politeia/src/pages/Details/useProposalDetails.js
@@ -6,7 +6,7 @@ import { selectDetailsStatus } from "./selectors";
 import { records } from "@politeiagui/core/records";
 import { ticketvoteSummaries } from "@politeiagui/ticketvote/summaries";
 import { recordComments } from "@politeiagui/comments/comments";
-import { piBilling, piSummaries, proposals } from "../../pi";
+import { piSummaries, proposals } from "../../pi";
 
 function useProposalDetails({ token }) {
   const dispatch = useDispatch();
@@ -26,9 +26,6 @@ function useProposalDetails({ token }) {
   );
   const proposalSummary = useSelector((state) =>
     piSummaries.selectByToken(state, fullToken)
-  );
-  const billingStatusChange = useSelector((state) =>
-    piBilling.selectLastByToken(state, fullToken)
   );
 
   const recordDetailsError = useSelector(records.selectError);
@@ -65,7 +62,6 @@ function useProposalDetails({ token }) {
     proposalSummary,
     record,
     voteSummary,
-    billingStatusChange,
     proposalStatusChanges,
   };
 }

--- a/plugins-structure/apps/politeia/src/pages/Home/Home.js
+++ b/plugins-structure/apps/politeia/src/pages/Home/Home.js
@@ -1,5 +1,4 @@
 import React from "react";
-import { router } from "@politeiagui/core/router";
 import { MultiContentPage, TabsBanner } from "@politeiagui/common-ui/layout";
 import { getURLSearchParams } from "../../utils/getURLSearchParams";
 import { About } from "../../components";
@@ -16,6 +15,12 @@ const TAB_LABELS = {
 };
 
 const TAB_VALUES = Object.values(TAB_LABELS);
+
+const tabs = TAB_VALUES.map((tab) => (
+  <a href={`/?tab=${tab}`} data-link>
+    {tab}
+  </a>
+));
 
 /**
  * Returns the appropriate component to render according to the search param.
@@ -34,19 +39,13 @@ function renderChild({ tab, ...props }) {
 function Home() {
   const { tab } = getURLSearchParams();
 
-  function handleSelectTab(index) {
-    const selectedTab = TAB_VALUES[index];
-    router.navigateTo(`/?tab=${selectedTab}`);
-  }
-
   return (
     <MultiContentPage
       banner={
         <TabsBanner
-          onSelectTab={handleSelectTab}
           title="Proposals"
           activeTab={TAB_VALUES.indexOf(tab || TAB_LABELS.underReview)}
-          tabs={TAB_VALUES}
+          tabs={tabs}
         />
       }
       sidebar={<About />}

--- a/plugins-structure/packages/core/src/router/helpers.js
+++ b/plugins-structure/packages/core/src/router/helpers.js
@@ -124,3 +124,22 @@ export function isExternalLink(url) {
   tmp.href = url;
   return tmp.hostname && tmp.hostname !== window.top.location.hostname;
 }
+
+/**
+ * isCurrentPathname returns if given `url` corresponds to current window
+ * location pathname for same origin
+ * @param {String} url
+ * @returns {String} pathname
+ */
+export function isCurrentPathname(url) {
+  try {
+    const { origin, pathname, search } = new URL(url);
+    return (
+      window.location.origin === origin &&
+      window.location.pathname === pathname &&
+      window.location.search === search
+    );
+  } catch (_) {
+    return url === window.location.pathname;
+  }
+}

--- a/plugins-structure/packages/core/src/router/router.js
+++ b/plugins-structure/packages/core/src/router/router.js
@@ -3,6 +3,8 @@ import isArray from "lodash/fp/isArray";
 import {
   findMatch,
   getParams,
+  isCurrentPathname,
+  isExternalLink,
   pathToRegex,
   searchSelectorElement,
 } from "./helpers";
@@ -19,9 +21,14 @@ export const router = (function () {
   let title = null;
 
   function push(url) {
+    // Avoid pushing state for external links
+    if (isExternalLink(url)) {
+      window.location.href = url;
+      return;
+    }
     if (!window.history.pushState) return;
     // Don't run if already current page
-    if (window.location.pathname === url) return;
+    if (isCurrentPathname(url)) return;
     // We are not sending a URL state (first param)
     // because we don't need it. All info we need in
     // the route is in the redux store or sent via


### PR DESCRIPTION
This PR fixes some small navigation issues:

### Hyperlinks 

Some buttons on our application behaves as links, therefore users
normally expect them to have the universal hyperlink rendering, such
as opening the page on another blank tab, copying its address and
other related stuff.

This PR replaces all button-links by hyperlinks `<a>` tags.

### Same URL Navigation

There are 2 different types of URL formatting that our application 
should receive: full URL paths, and only pathnames.

This PR handles both cases for navigation to the current window
location path.

### Navigation flickering

Removes navigation flickering on Details page when proposals are
cached and `index.md` file was still not fetched, usually when
navigating between Home and Details pages.

This PR now checks if record details was fetched before displaying
the details card.

Closes #2796 


