### PR TITLE
multi: Add proposal author updates

### DIFF
--- a/plugins-structure/apps/politeia/cypress/e2e/pageDetails.cy.js
+++ b/plugins-structure/apps/politeia/cypress/e2e/pageDetails.cy.js
@@ -333,28 +333,29 @@ describe("Given an RFP submission", () => {
 });
 
 describe("Given a proposal author update", () => {
+  const authorUpdates = [
+    {
+      extradata: JSON.stringify({
+        title: "Author update 1",
+      }),
+      extradatahint: "proposalupdate",
+      parentid: 0,
+      username,
+      timestamp: Date.now() / 1000 - 300,
+    },
+    {
+      extradata: JSON.stringify({
+        title: "Author update 2",
+      }),
+      extradatahint: "proposalupdate",
+      parentid: 0,
+      username,
+    },
+  ];
   beforeEach(() => {
     cy.mockResponse(
       "/api/comments/v1/comments",
-      mockComments({
-        amount: 5,
-        additionalComments: [
-          {
-            extradata: JSON.stringify({
-              title: "Author update 1",
-            }),
-            extradatahint: "proposalupdate",
-            parentid: 0,
-          },
-          {
-            extradata: JSON.stringify({
-              title: "Author update 2",
-            }),
-            extradatahint: "proposalupdate",
-            parentid: 0,
-          },
-        ],
-      })
+      mockComments({ amount: 5, additionalComments: authorUpdates })
     ).as("comments");
     cy.mockResponse(
       "/api/pi/v1/summaries",
@@ -365,10 +366,18 @@ describe("Given a proposal author update", () => {
       mockTicketvoteSummaries(approvedVoteSummary)
     ).as("voteSummaries");
   });
-  it("should display author updates on separate threads", () => {
+  it("should display author updates on separate threads ordered by timestamp", () => {
     cy.visit("/record/fake001");
     cy.wait(["@details", "@comments"]);
     cy.findAllByTestId("comments-section").should("have.length", 3);
+    const expectedThreadsTitlesOrder = [
+      "Author update 2",
+      "Author update 1",
+      "Comments",
+    ];
+    cy.findAllByTestId("comments-section-title").each((thread, i) => {
+      expect(thread).to.contain.text(expectedThreadsTitlesOrder[i]);
+    });
   });
 });
 

--- a/plugins-structure/apps/politeia/cypress/e2e/pageDetails.cy.js
+++ b/plugins-structure/apps/politeia/cypress/e2e/pageDetails.cy.js
@@ -332,6 +332,46 @@ describe("Given an RFP submission", () => {
   });
 });
 
+describe("Given a proposal author update", () => {
+  beforeEach(() => {
+    cy.mockResponse(
+      "/api/comments/v1/comments",
+      mockComments({
+        amount: 5,
+        additionalComments: [
+          {
+            extradata: JSON.stringify({
+              title: "Author update 1",
+            }),
+            extradatahint: "proposalupdate",
+            parentid: 0,
+          },
+          {
+            extradata: JSON.stringify({
+              title: "Author update 2",
+            }),
+            extradatahint: "proposalupdate",
+            parentid: 0,
+          },
+        ],
+      })
+    ).as("comments");
+    cy.mockResponse(
+      "/api/pi/v1/summaries",
+      mockPiSummaries({ status: "approved" })
+    ).as("piSummaries");
+    cy.mockResponse(
+      "/api/ticketvote/v1/summaries",
+      mockTicketvoteSummaries(approvedVoteSummary)
+    ).as("voteSummaries");
+  });
+  it("should display author updates on separate threads", () => {
+    cy.visit("/record/fake001");
+    cy.wait(["@details", "@comments"]);
+    cy.findAllByTestId("comments-section").should("have.length", 3);
+  });
+});
+
 describe("Given requests errors on Details page", () => {
   function errorMock() {
     return {

--- a/plugins-structure/apps/politeia/cypress/e2e/pageDetails.cy.js
+++ b/plugins-structure/apps/politeia/cypress/e2e/pageDetails.cy.js
@@ -316,7 +316,12 @@ describe("Given a proposal with comments", () => {
       piStatus: "active",
     });
   });
-  describe("when some comments are proposal author updates", () => {
+  describe("when details page view is full", () => {
+    it("should display the main comments thread", () => {
+      cy.visit("/record/fake001");
+      cy.wait(["@details", "@comments"]);
+      cy.findAllByTestId("comments-section").should("have.length", 1);
+    });
     it("should display author updates on separate threads ordered by timestamp", () => {
       cy.mockProposalCommentsRequest({ additionalComments: authorUpdates });
       cy.visit("/record/fake001");
@@ -330,6 +335,36 @@ describe("Given a proposal with comments", () => {
       cy.findAllByTestId("comments-section-title").each((thread, i) => {
         expect(thread).to.contain.text(expectedThreadsTitlesOrder[i]);
       });
+    });
+  });
+  describe("when details page view displays only a single thread", () => {
+    it("should display only one comments thread", () => {
+      cy.visit("/record/fake001/comment/1");
+      cy.wait(["@details", "@comments"]);
+      cy.findAllByTestId("comments-section").should("have.length", 1);
+      cy.findByTestId("comments-view-all-link")
+        .should("have.text", "view all comments")
+        .invoke("attr", "href")
+        .should("eq", "/record/fake001");
+    });
+    it("should display parent comment preview for reply subthread", () => {
+      cy.mockProposalCommentsRequest({
+        additionalComments: [{ parentid: 1 }, { parentid: 6 }],
+      });
+      cy.visit("/record/fake001/comment/6");
+      cy.wait(["@details", "@comments"]);
+      cy.findAllByTestId("comments-section").should("have.length", 1);
+      cy.findAllByTestId("comment-card-parent-preview").should(
+        "have.length",
+        1
+      );
+    });
+    it("should redirect to full proposal view when clicking on 'view all comments'", () => {
+      cy.mockProposalCommentsRequest({ amount: 10 });
+      cy.visit("/record/fake001/comment/1");
+      cy.wait(["@details", "@comments"]);
+      cy.findByTestId("comments-view-all-link").click();
+      cy.findAllByTestId("comment-card").should("have.length", 10);
     });
   });
 });

--- a/plugins-structure/apps/politeia/cypress/e2e/pageDetails.cy.js
+++ b/plugins-structure/apps/politeia/cypress/e2e/pageDetails.cy.js
@@ -367,6 +367,31 @@ describe("Given a proposal with comments", () => {
       cy.findAllByTestId("comment-card").should("have.length", 10);
     });
   });
+  describe("when comments thread is deep", () => {
+    const amount = 1;
+    const deepThread = Array(20)
+      .fill({ parentid: amount })
+      .map((c, i) => ({ parentid: c.parentid + i }));
+    beforeEach(() => {
+      cy.mockProposalCommentsRequest({
+        amount,
+        additionalComments: deepThread,
+      });
+      cy.visit("record/fake001");
+      cy.wait(["@details", "@comments"]);
+    });
+    it("should hide thread on depth == 6", () => {
+      cy.findAllByTestId("comment-card").should("have.length", 6);
+      cy.findByTestId("comment-card-footer-more-replies")
+        .should("include.text", "more reply")
+        .invoke("attr", "href")
+        .should("eq", "/record/fake001/comment/6");
+    });
+    it("should display all comments on flat mode", () => {
+      cy.findByTestId("comments-filter-flat-mode-button").click();
+      cy.findAllByTestId("comment-card").should("have.length", 21);
+    });
+  });
 });
 
 describe("Given requests errors on Details page", () => {

--- a/plugins-structure/apps/politeia/src/components/Proposal/ProposalDetails.js
+++ b/plugins-structure/apps/politeia/src/components/Proposal/ProposalDetails.js
@@ -24,7 +24,7 @@ import {
   ProposalSubtitle,
   ProposalTitle,
 } from "./common";
-import { Button, ButtonIcon, Message } from "pi-ui";
+import { Button, ButtonIcon, Message, classNames } from "pi-ui";
 import { getShortToken } from "@politeiagui/core/records/utils";
 import styles from "./styles.module.css";
 import { ModalProposalDiff } from "./ModalProposalDiff";
@@ -45,6 +45,7 @@ const ProposalDetails = ({
   rfpSubmissionsVoteSummaries,
   rfpSubmissionsProposalSummaries,
   rfpSubmissionsCommentsCounts,
+  hideBody,
 }) => {
   const [open] = useModal();
 
@@ -143,13 +144,22 @@ const ProposalDetails = ({
           </div>
         }
         thirdRow={
-          <div className={styles.proposalBody} data-testid="proposal-body">
-            <MarkdownRenderer body={body} filesBySrc={imagesByDigest} />
-            <ThumbnailGrid
-              files={imagesNotInText}
-              readOnly
-              onClick={handleOpenImageModal}
-            />
+          <div className={classNames(hideBody && styles.collapse)}>
+            <div className={styles.proposalBody} data-testid="proposal-body">
+              <MarkdownRenderer body={body} filesBySrc={imagesByDigest} />
+              <ThumbnailGrid
+                files={imagesNotInText}
+                readOnly
+                onClick={handleOpenImageModal}
+              />
+            </div>
+            {hideBody && (
+              <div className={styles.collapseMarker}>
+                <a data-link href={proposalLink}>
+                  see full proposal
+                </a>
+              </div>
+            )}
           </div>
         }
         fourthRow={

--- a/plugins-structure/apps/politeia/src/components/Proposal/ProposalDetails.js
+++ b/plugins-structure/apps/politeia/src/components/Proposal/ProposalDetails.js
@@ -33,7 +33,7 @@ import { PROPOSAL_STATUS_APPROVED } from "../../pi";
 
 const ExpandIcon = ({ link }) => (
   <a data-link href={link}>
-    <Icon type="expand" viewBox="0 0 450 450" height={60} width={60} />
+    <Icon type="expand" viewBox="0 0 450 450" height={30} width={30} />
   </a>
 );
 

--- a/plugins-structure/apps/politeia/src/components/Proposal/ProposalDetails.js
+++ b/plugins-structure/apps/politeia/src/components/Proposal/ProposalDetails.js
@@ -24,12 +24,18 @@ import {
   ProposalSubtitle,
   ProposalTitle,
 } from "./common";
-import { Button, ButtonIcon, Message, classNames } from "pi-ui";
+import { Button, ButtonIcon, Icon, Message, classNames } from "pi-ui";
 import { getShortToken } from "@politeiagui/core/records/utils";
 import styles from "./styles.module.css";
 import { ModalProposalDiff } from "./ModalProposalDiff";
 import { ProposalsCompact } from "./ProposalsCompact";
 import { PROPOSAL_STATUS_APPROVED } from "../../pi";
+
+const ExpandIcon = ({ link }) => (
+  <a data-link href={link}>
+    <Icon type="expand" viewBox="0 0 450 450" height={60} width={60} />
+  </a>
+);
 
 const ProposalDetails = ({
   record,
@@ -153,13 +159,7 @@ const ProposalDetails = ({
                 onClick={handleOpenImageModal}
               />
             </div>
-            {hideBody && (
-              <div className={styles.collapseMarker}>
-                <a data-link href={proposalLink}>
-                  see full proposal
-                </a>
-              </div>
-            )}
+            {hideBody && <ExpandIcon link={proposalLink} />}
           </div>
         }
         fourthRow={

--- a/plugins-structure/apps/politeia/src/components/Proposal/styles.module.css
+++ b/plugins-structure/apps/politeia/src/components/Proposal/styles.module.css
@@ -40,6 +40,31 @@
   padding-top: 2rem;
 }
 
+.collapse > .proposalBody {
+  overflow: hidden;
+  max-height: 10rem;
+}
+
+.collapseMarker {
+  width: 100%;
+  height: 4rem;
+  padding-top: 3rem;
+  position: relative;
+  top: -2rem;
+  background: linear-gradient(
+    0deg,
+    var(--card-background) 49%,
+    var(--color-shadow-light) 50%,
+    rgba(0, 0, 0, 0) 100%
+  );
+  text-align: center;
+  color: var(--text-color-light);
+}
+
+.collapseMarker:hover {
+  text-decoration: underline;
+}
+
 .rules > li {
   margin-top: 1rem;
 }

--- a/plugins-structure/apps/politeia/src/components/Proposal/styles.module.css
+++ b/plugins-structure/apps/politeia/src/components/Proposal/styles.module.css
@@ -41,28 +41,7 @@
 }
 
 .collapse > .proposalBody {
-  overflow: hidden;
-  max-height: 10rem;
-}
-
-.collapseMarker {
-  width: 100%;
-  height: 4rem;
-  padding-top: 3rem;
-  position: relative;
-  top: -2rem;
-  background: linear-gradient(
-    0deg,
-    var(--card-background) 49%,
-    var(--color-shadow-light) 50%,
-    rgba(0, 0, 0, 0) 100%
-  );
-  text-align: center;
-  color: var(--text-color-light);
-}
-
-.collapseMarker:hover {
-  text-decoration: underline;
+  display: none;
 }
 
 .rules > li {

--- a/plugins-structure/apps/politeia/src/pages/Details/Details.js
+++ b/plugins-structure/apps/politeia/src/pages/Details/Details.js
@@ -12,17 +12,27 @@ import { getURLSearchParams } from "../../utils/getURLSearchParams";
 import { keyCommentsThreadsBy } from "@politeiagui/comments/utils";
 
 function ErrorsMessages({ errors }) {
-  return errors.reduce((acc, cur) => {
+  return errors.reduce((acc, cur, i) => {
     if (cur) {
       return [
         ...acc,
-        <Message kind="error" data-testid="proposal-details-error">
+        <Message kind="error" key={i} data-testid="proposal-details-error">
           {cur}
         </Message>,
       ];
     }
     return acc;
   }, []);
+}
+
+function sortAuthorUpdatesKeysByTimestamp(authorUpdates) {
+  const getRootAuthorUpdate = (updateThread) =>
+    Object.values(updateThread).find((c) => c.parentid === 0);
+  return Object.keys(authorUpdates).sort(
+    (a, b) =>
+      getRootAuthorUpdate(authorUpdates[b]).timestamp -
+      getRootAuthorUpdate(authorUpdates[a]).timestamp
+  );
 }
 
 function Details({ token }) {
@@ -57,6 +67,9 @@ function Details({ token }) {
       : "main"
   );
 
+  const orderedAuthorUpdatesKeys =
+    sortAuthorUpdatesKeysByTimestamp(authorUpdates);
+
   return (
     <SingleContentPage className={styles.detailsWrapper}>
       {detailsStatus === "loading" && <ProposalLoader isDetails />}
@@ -84,7 +97,7 @@ function Details({ token }) {
               rfpSubmissionsProposalSummaries={rfpSubmissionsProposalsSummaries}
               rfpSubmissionsVoteSummaries={rfpSumbissionsVoteSummaries}
             />
-            {Object.keys(authorUpdates).map((update, i) => (
+            {orderedAuthorUpdatesKeys.map((update, i) => (
               <Comments
                 comments={authorUpdates[update]}
                 title={update}

--- a/plugins-structure/apps/politeia/src/pages/Details/Details.js
+++ b/plugins-structure/apps/politeia/src/pages/Details/Details.js
@@ -116,6 +116,7 @@ function Details({ token, commentid = 0 }) {
               title={update}
               key={i}
               recordOwner={record.username}
+              fullThreadUrl={`/record/${token}`}
             />
           ))}
           {mainCommentsThread && (
@@ -123,6 +124,7 @@ function Details({ token, commentid = 0 }) {
               parentId={+commentid}
               comments={mainCommentsThread}
               recordOwner={record.username}
+              fullThreadUrl={`/record/${token}`}
               // Mocking onReply until user layer is done.
               onReply={(comment, parentid) => {
                 console.log(`Replying ${parentid}:`, comment);

--- a/plugins-structure/apps/politeia/src/pages/Details/Details.js
+++ b/plugins-structure/apps/politeia/src/pages/Details/Details.js
@@ -9,6 +9,7 @@ import { ProposalDetails, ProposalLoader } from "../../components";
 import styles from "./styles.module.css";
 import useProposalDetails from "./useProposalDetails";
 import { getURLSearchParams } from "../../utils/getURLSearchParams";
+import { keyCommentsThreadsBy } from "@politeiagui/comments/utils";
 
 function ErrorsMessages({ errors }) {
   return errors.reduce((acc, cur) => {
@@ -49,6 +50,13 @@ function Details({ token }) {
   const params = getURLSearchParams();
   const shouldScrollToComments = !!params?.scrollToComments;
   useScrollToTop(shouldScrollToComments);
+
+  const { main, ...authorUpdates } = keyCommentsThreadsBy(comments, (root) =>
+    root.extradatahint === "proposalupdate"
+      ? JSON.parse(root.extradata).title
+      : "main"
+  );
+
   return (
     <SingleContentPage className={styles.detailsWrapper}>
       {detailsStatus === "loading" && <ProposalLoader isDetails />}
@@ -76,9 +84,16 @@ function Details({ token }) {
               rfpSubmissionsProposalSummaries={rfpSubmissionsProposalsSummaries}
               rfpSubmissionsVoteSummaries={rfpSumbissionsVoteSummaries}
             />
-            {comments && (
+            {Object.keys(authorUpdates).map((update) => (
               <Comments
-                comments={comments}
+                comments={authorUpdates[update]}
+                title={update}
+                key={update}
+              />
+            ))}
+            {main && (
+              <Comments
+                comments={main}
                 // Mocking onReply until user layer is done.
                 onReply={(comment, parentid) => {
                   console.log(`Replying ${parentid}:`, comment);

--- a/plugins-structure/apps/politeia/src/pages/Details/Details.js
+++ b/plugins-structure/apps/politeia/src/pages/Details/Details.js
@@ -114,8 +114,7 @@ function Details({ token, commentid = 0 }) {
               comments={authorUpdates[update]}
               parentId={+commentid}
               title={update}
-              key={update}
-              id={`author-update-${i + 1}`}
+              key={i}
               recordOwner={record.username}
             />
           ))}
@@ -128,7 +127,6 @@ function Details({ token, commentid = 0 }) {
               onReply={(comment, parentid) => {
                 console.log(`Replying ${parentid}:`, comment);
               }}
-              scrollOnLoad={shouldScrollToComments}
             />
           )}
         </>

--- a/plugins-structure/apps/politeia/src/pages/Details/Details.js
+++ b/plugins-structure/apps/politeia/src/pages/Details/Details.js
@@ -35,7 +35,7 @@ function sortAuthorUpdatesKeysByTimestamp(authorUpdates) {
   );
 }
 
-function Details({ token }) {
+function Details({ token, commentid }) {
   const {
     comments,
     detailsStatus,
@@ -58,7 +58,7 @@ function Details({ token }) {
   } = useProposalDetails({ token });
   // TODO: this can be moved somewhere else
   const params = getURLSearchParams();
-  const shouldScrollToComments = !!params?.scrollToComments;
+  const shouldScrollToComments = !!params?.scrollToComments || !!commentid;
   useScrollToTop(shouldScrollToComments);
 
   const { main, ...authorUpdates } = keyCommentsThreadsBy(comments, (root) =>
@@ -96,6 +96,7 @@ function Details({ token }) {
               rfpSubmissionsCommentsCounts={rfpSubmissionsCommentsCounts}
               rfpSubmissionsProposalSummaries={rfpSubmissionsProposalsSummaries}
               rfpSubmissionsVoteSummaries={rfpSumbissionsVoteSummaries}
+              hideBody={!!commentid}
             />
             {orderedAuthorUpdatesKeys.map((update, i) => (
               <Comments
@@ -107,6 +108,7 @@ function Details({ token }) {
             ))}
             {main && (
               <Comments
+                parentId={commentid}
                 comments={main}
                 recordOwner={record.username}
                 // Mocking onReply until user layer is done.

--- a/plugins-structure/apps/politeia/src/pages/Details/Details.js
+++ b/plugins-structure/apps/politeia/src/pages/Details/Details.js
@@ -84,11 +84,12 @@ function Details({ token }) {
               rfpSubmissionsProposalSummaries={rfpSubmissionsProposalsSummaries}
               rfpSubmissionsVoteSummaries={rfpSumbissionsVoteSummaries}
             />
-            {Object.keys(authorUpdates).map((update) => (
+            {Object.keys(authorUpdates).map((update, i) => (
               <Comments
                 comments={authorUpdates[update]}
                 title={update}
                 key={update}
+                id={`author-update-${i + 1}`}
               />
             ))}
             {main && (

--- a/plugins-structure/apps/politeia/src/routes/routes.js
+++ b/plugins-structure/apps/politeia/src/routes/routes.js
@@ -8,6 +8,7 @@ export const routes = [
   HomeRoute,
   NewProposalRoute,
   DetailsRoute,
+  { ...DetailsRoute, path: "/record/:token/comment/:commentid" },
   {
     path: "/record/:token/raw",
     view: async ({ token }) => {

--- a/plugins-structure/packages/comments/src/comments/utils.js
+++ b/plugins-structure/packages/comments/src/comments/utils.js
@@ -11,7 +11,7 @@ export function fetchPolicyIfIdle() {
 
 /**
  * getCommentsByParent returns an object tree with comment ids ordered by parent
- * ids. If thread is flat, all parent ids are 0.
+ * ids.
  * ****
  * Example:
  * ```javascript
@@ -20,25 +20,19 @@ export function fetchPolicyIfIdle() {
  *   { commentid: 2, parentid: 1, ... },
  *   { commentid: 3, parentid: 1, ... },
  * ];
- * const commentsByParent = getCommentsByParent(comments, false);
- * // { 0: [1], 1: [2, 3] }
- * const flatThreadSchema = getCommentsByParent(comments, true);
- * // { 0: [1, 2, 3] }
+ * const commentsByParent = getCommentsByParent(comments);
+ * // { 0: [1], 1: [2, 3], 2: [], 3: [] }
  * ```
  * @param {Array} comments comments array
- * @param {Boolean} isFlatMode
  * @returns {Object} thread schema
  */
-export function getCommentsByParent(comments, isFlatMode) {
+export function getCommentsByParent(comments) {
   const commentsByParent = comments.reduce((acc, comment) => {
-    let parentid = comment.parentid;
-    if (isFlatMode) {
-      parentid = 0;
-    }
+    const { parentid, commentid } = comment;
     return {
       ...acc,
-      [parentid]: [...(acc[parentid] || []), comment.commentid],
-      [comment.commentid]: acc[comment.commentid] || [],
+      [parentid]: [...(acc[parentid] || []), commentid],
+      [commentid]: acc[commentid] || [],
     };
   }, {});
   return commentsByParent;

--- a/plugins-structure/packages/comments/src/comments/utils.js
+++ b/plugins-structure/packages/comments/src/comments/utils.js
@@ -56,9 +56,9 @@ function groupCommentsByParentIds(comments, rootIteratee) {
 }
 
 /**
- * keyCommentsThreadsBy returns the parent comments organized by
- * `extradatahint` thread hint.
- * @param {Array} commentsById
+ * keyCommentsThreadsBy returns comments threads organized by their root parent
+ * ids, according to `rootIteratee` iteratee callback.
+ * @param {{ [commentid]: Comment }} commentsById
  * @param {function} rootIteratee callback iteratee to be applied on thread
  * parents
  */

--- a/plugins-structure/packages/comments/src/comments/utils.js
+++ b/plugins-structure/packages/comments/src/comments/utils.js
@@ -38,6 +38,7 @@ export function getCommentsByParent(comments, isFlatMode) {
     return {
       ...acc,
       [parentid]: [...(acc[parentid] || []), comment.commentid],
+      [comment.commentid]: acc[comment.commentid] || [],
     };
   }, {});
   return commentsByParent;

--- a/plugins-structure/packages/comments/src/comments/utils.test.js
+++ b/plugins-structure/packages/comments/src/comments/utils.test.js
@@ -1,5 +1,5 @@
-import { getCommentsByParent } from "./utils";
-import { random, range } from "lodash";
+import { getCommentsByParent, keyCommentsThreadsBy } from "./utils";
+import { keyBy, random, range } from "lodash";
 
 describe("Given getCommentsByParent util", () => {
   describe("when using a list with 3 comments", () => {
@@ -61,6 +61,60 @@ describe("Given getCommentsByParent util", () => {
       const flatThreadSchema = getCommentsByParent(comments, true);
       const expectedThread = { 0: range(1, 21) };
       expect(flatThreadSchema).toEqual(expectedThread);
+    });
+  });
+});
+
+describe("Given keyCommentsThreadsBy util", () => {
+  describe("when commentsById param is valid and iteratee is default", () => {
+    it("should return comments thread by root parent commentid", () => {
+      const commentsById = keyBy(
+        [
+          { commentid: 1, parentid: 0 },
+          { commentid: 2, parentid: 1 },
+          { commentid: 3, parentid: 0 },
+          { commentid: 4, parentid: 0 },
+          { commentid: 5, parentid: 4 },
+          { commentid: 6, parentid: 0 },
+        ],
+        "commentid"
+      );
+      const commentsByRootParentId = keyCommentsThreadsBy(commentsById);
+      expect(Object.keys(commentsByRootParentId)).toEqual(["1", "3", "4", "6"]);
+    });
+  });
+  describe("when iteratee groups thread parents using custom iteratee", () => {
+    it("should return comments by extradatahint", () => {
+      const commentsById = keyBy(
+        [
+          { commentid: 1, parentid: 0 },
+          { commentid: 2, parentid: 1 },
+          { commentid: 3, parentid: 0 },
+          { commentid: 4, parentid: 0, extradatahint: "hint" },
+          { commentid: 5, parentid: 4 },
+          { commentid: 6, parentid: 0, extradatahint: "hint" },
+        ],
+        "commentid"
+      );
+      const commentsByRootHint = keyCommentsThreadsBy(
+        commentsById,
+        (c) => c.extradatahint || "main"
+      );
+      expect(Object.keys(commentsByRootHint)).toEqual(["main", "hint"]);
+    });
+  });
+  describe("when commentsById param is invalid", () => {
+    it("should return an empty object for falsy values", () => {
+      expect(keyCommentsThreadsBy()).toEqual({});
+      expect(keyCommentsThreadsBy(false)).toEqual({});
+      expect(keyCommentsThreadsBy(null)).toEqual({});
+      expect(keyCommentsThreadsBy(undefined)).toEqual({});
+    });
+    it("should return an empty object when param is array", () => {
+      expect(keyCommentsThreadsBy([])).toEqual({});
+    });
+    it("should return an empty object when param is an empty object", () => {
+      expect(keyCommentsThreadsBy({})).toEqual({});
     });
   });
 });

--- a/plugins-structure/packages/comments/src/comments/utils.test.js
+++ b/plugins-structure/packages/comments/src/comments/utils.test.js
@@ -1,5 +1,5 @@
 import { getCommentsByParent, keyCommentsThreadsBy } from "./utils";
-import { keyBy, random, range } from "lodash";
+import { keyBy } from "lodash";
 
 describe("Given getCommentsByParent util", () => {
   describe("when using a list with 3 comments", () => {
@@ -9,12 +9,9 @@ describe("Given getCommentsByParent util", () => {
         { commentid: 2, parentid: 1 },
         { commentid: 3, parentid: 1 },
       ];
-      let expectedThread = { 0: [1], 1: [2, 3] };
-      const commentsByParent = getCommentsByParent(comments, false);
+      const expectedThread = { 0: [1], 1: [2, 3], 2: [], 3: [] };
+      const commentsByParent = getCommentsByParent(comments);
       expect(commentsByParent).toEqual(expectedThread);
-      const flatThreadSchema = getCommentsByParent(comments, true);
-      expectedThread = { 0: [1, 2, 3] };
-      expect(flatThreadSchema).toEqual(expectedThread);
     });
   });
   describe("when usign a 6 comments list without any children", () => {
@@ -23,16 +20,10 @@ describe("Given getCommentsByParent util", () => {
         { commentid: 1, parentid: 0 },
         { commentid: 2, parentid: 0 },
         { commentid: 3, parentid: 0 },
-        { commentid: 4, parentid: 0 },
-        { commentid: 5, parentid: 0 },
-        { commentid: 6, parentid: 0 },
       ];
-      let expectedThread = { 0: [1, 2, 3, 4, 5, 6] };
-      const commentsByParent = getCommentsByParent(comments, false);
+      const expectedThread = { 0: [1, 2, 3], 1: [], 2: [], 3: [] };
+      const commentsByParent = getCommentsByParent(comments);
       expect(commentsByParent).toEqual(expectedThread);
-      const flatThreadSchema = getCommentsByParent(comments, true);
-      expectedThread = { 0: [1, 2, 3, 4, 5, 6] };
-      expect(flatThreadSchema).toEqual(expectedThread);
     });
   });
   describe("when usign a 6 comments list where each comment is other's child", () => {
@@ -43,24 +34,10 @@ describe("Given getCommentsByParent util", () => {
         { commentid: 3, parentid: 2 },
         { commentid: 4, parentid: 3 },
         { commentid: 5, parentid: 4 },
-        { commentid: 6, parentid: 5 },
       ];
-      let expectedThread = { 0: [1], 1: [2], 2: [3], 3: [4], 4: [5], 5: [6] };
-      const commentsByParent = getCommentsByParent(comments, false);
+      const expectedThread = { 0: [1], 1: [2], 2: [3], 3: [4], 4: [5], 5: [] };
+      const commentsByParent = getCommentsByParent(comments);
       expect(commentsByParent).toEqual(expectedThread);
-      const flatThreadSchema = getCommentsByParent(comments, true);
-      expectedThread = { 0: [1, 2, 3, 4, 5, 6] };
-      expect(flatThreadSchema).toEqual(expectedThread);
-    });
-  });
-  describe("when getting a flat list using a random comments list of length 20", () => {
-    it("should return all comments flattened", () => {
-      const comments = Array(20)
-        .fill({})
-        .map((_, i) => ({ commentid: i + 1, parentid: random(0, i) }));
-      const flatThreadSchema = getCommentsByParent(comments, true);
-      const expectedThread = { 0: range(1, 21) };
-      expect(flatThreadSchema).toEqual(expectedThread);
     });
   });
 });

--- a/plugins-structure/packages/comments/src/dev/mocks/comments.js
+++ b/plugins-structure/packages/comments/src/dev/mocks/comments.js
@@ -1,3 +1,4 @@
+// TODO: Deprecate this hardcoded mock and use the new approach.
 export const commentsMock = {
   1: {
     userid: "0612f387-3777-4003-8f40-87b183f89032",

--- a/plugins-structure/packages/comments/src/dev/mocks/index.js
+++ b/plugins-structure/packages/comments/src/dev/mocks/index.js
@@ -3,11 +3,6 @@ import { faker } from "@faker-js/faker";
 export * from "./comments";
 export * from "./userVotes";
 
-function getThreadParent(id) {
-  if (id < 2) return id;
-  return Math.floor(id / 2);
-}
-
 export function mockCommentsCount() {
   return ({ tokens = [] }) => {
     const res = tokens.reduce(
@@ -43,28 +38,45 @@ export function mockCommentsPolicy({
   });
 }
 
-export function mockComments({ amount = 0, thread = false } = {}) {
+const baseCommentMock = {
+  userid: "1baadc76-3c9d-46be-8aac-15c944bab958",
+  username: "user_8a13d2b07b",
+  state: 2,
+  parentid: 0,
+  version: 1,
+  createdat: 1650381215,
+  timestamp: 1650381215,
+  upvotes: 0,
+  downvoted: 0,
+};
+
+export function mockComments({
+  amount = 0,
+  customCommentData = {},
+  additionalComments = [],
+} = {}) {
   return ({ token }) => {
     const comments = Array(amount)
       .fill({
-        userid: "1baadc76-3c9d-46be-8aac-15c944bab958",
-        username: "user_8a13d2b07b",
-        state: 2,
+        ...baseCommentMock,
+        ...customCommentData,
         token,
-        parentid: 0,
-        comment: "31efb976ac702977dddd56d52e03a2d7",
-        version: 1,
-        createdat: 1650381215,
-        timestamp: 1650381215,
-        upvotes: 0,
-        downvoted: 0,
+        comment: faker.lorem.paragraph(),
       })
       .map((comment, i) => ({
         ...comment,
         commentid: i + 1,
         comment: `Comment ${i + 1}: ${comment.comment}`,
-        parentid: thread ? getThreadParent(i + 1) : comment.parentid,
+        parentid: comment.parentid,
       }));
-    return { comments };
+    const moreComments = additionalComments.map((ac, i) => ({
+      ...baseCommentMock,
+      ...customCommentData,
+      ...ac,
+      comment: `Addidional Comment ${i + 1}: ${faker.lorem.paragraph()}`,
+      token,
+      commentid: amount + i + 1,
+    }));
+    return { comments: [...comments, ...moreComments] };
   };
 }

--- a/plugins-structure/packages/comments/src/dev/mocks/index.js
+++ b/plugins-structure/packages/comments/src/dev/mocks/index.js
@@ -38,17 +38,22 @@ export function mockCommentsPolicy({
   });
 }
 
-const baseCommentMock = {
-  userid: "1baadc76-3c9d-46be-8aac-15c944bab958",
-  username: "user_8a13d2b07b",
-  state: 2,
-  parentid: 0,
-  version: 1,
-  createdat: 1650381215,
-  timestamp: 1650381215,
-  upvotes: 0,
-  downvoted: 0,
-};
+export function mockComment(customData = {}) {
+  return {
+    userid: faker.datatype.uuid(),
+    username: faker.internet.userName(),
+    state: 2,
+    parentid: 0,
+    version: 1,
+    createdat: Date.now() / 1000,
+    timestamp: Date.now() / 1000,
+    upvotes: 0,
+    downvoted: 0,
+    comment: faker.lorem.paragraph(),
+    token: faker.git.shortSha(),
+    ...customData,
+  };
+}
 
 export function mockComments({
   amount = 0,
@@ -57,25 +62,18 @@ export function mockComments({
 } = {}) {
   return ({ token }) => {
     const comments = Array(amount)
-      .fill({
-        ...baseCommentMock,
-        ...customCommentData,
+      .fill({})
+      .map((_, i) => ({
+        ...mockComment(customCommentData),
         token,
-        comment: faker.lorem.paragraph(),
-      })
-      .map((comment, i) => ({
-        ...comment,
         commentid: i + 1,
-        comment: `Comment ${i + 1}: ${comment.comment}`,
-        parentid: comment.parentid,
       }));
     const moreComments = additionalComments.map((ac, i) => ({
-      ...baseCommentMock,
-      ...customCommentData,
-      ...ac,
+      ...mockComment(customCommentData),
       comment: `Addidional Comment ${i + 1}: ${faker.lorem.paragraph()}`,
       token,
       commentid: amount + i + 1,
+      ...ac,
     }));
     return { comments: [...comments, ...moreComments] };
   };

--- a/plugins-structure/packages/comments/src/setupTests.js
+++ b/plugins-structure/packages/comments/src/setupTests.js
@@ -12,6 +12,13 @@ jest.mock(
   { virtual: true }
 );
 jest.mock(
+  "@politeiagui/core/router",
+  () => ({
+    generatePath: () => "/path/",
+  }),
+  { virtual: true }
+);
+jest.mock(
   "@politeiagui/core/records",
   () => ({
     records: {
@@ -25,6 +32,7 @@ jest.mock(
   "@politeiagui/core",
   () => ({
     RECORDS_PAGE_SIZE: 5,
+    getShortToken: () => jest.fn(),
   }),
   { virtual: true }
 );

--- a/plugins-structure/packages/comments/src/ui/CommentCard/CommentCard.js
+++ b/plugins-structure/packages/comments/src/ui/CommentCard/CommentCard.js
@@ -42,8 +42,9 @@ export const CommentCard = ({
   disableReply,
   showParentCommentPreview,
   parentComment,
+  depth,
 }) => {
-  const [showThread, setShowThread] = useState(true);
+  const [showThread, setShowThread] = useState(depth !== 6);
   const [showForm, setShowForm] = useState(false);
   function handleCensorComment() {
     onCensor(comment);

--- a/plugins-structure/packages/comments/src/ui/CommentCard/CommentCard.js
+++ b/plugins-structure/packages/comments/src/ui/CommentCard/CommentCard.js
@@ -47,7 +47,7 @@ const CommentFooter = ({
   <div className={styles.footer}>
     <Join inline>
       {threadLength > 0 && !showThread && (
-        <a data-link href={url}>
+        <a data-link href={url} data-testid="comment-card-footer-more-replies">
           {threadLength} more repl{threadLength > 1 ? "ies" : "y"}
         </a>
       )}

--- a/plugins-structure/packages/comments/src/ui/CommentCard/CommentCard.js
+++ b/plugins-structure/packages/comments/src/ui/CommentCard/CommentCard.js
@@ -26,7 +26,12 @@ const ParentPreview = ({ parentComment, link }) => {
     omission: " [...]",
   });
   return (
-    <a className={styles.parentContext} data-link href={link}>
+    <a
+      className={styles.parentContext}
+      data-testid="comment-card-parent-preview"
+      data-link
+      href={link}
+    >
       @{parentComment.username}: {truncatedComment}
     </a>
   );

--- a/plugins-structure/packages/comments/src/ui/CommentCard/CommentCard.js
+++ b/plugins-structure/packages/comments/src/ui/CommentCard/CommentCard.js
@@ -5,6 +5,7 @@ import { Event, Join, MarkdownRenderer } from "@politeiagui/common-ui";
 import styles from "./styles.module.css";
 import { CommentVotes } from "./CommentVotes";
 import { CommentForm } from "../CommentForm";
+import truncate from "lodash/truncate";
 
 const CensorButton = ({ onCensor }) => (
   <span
@@ -16,6 +17,19 @@ const CensorButton = ({ onCensor }) => (
   </span>
 );
 
+const ParentPreview = ({ parentComment }) => {
+  const truncatedComment = truncate(parentComment.comment, {
+    length: 50,
+    separator: " ",
+    omission: " [...]",
+  });
+  return (
+    <div className={styles.parentContext}>
+      @{parentComment.username}: {truncatedComment}
+    </div>
+  );
+};
+
 export const CommentCard = ({
   comment,
   showCensor,
@@ -26,6 +40,8 @@ export const CommentCard = ({
   userVote,
   onComment,
   disableReply,
+  showParentCommentPreview,
+  parentComment,
 }) => {
   const [showThread, setShowThread] = useState(true);
   const [showForm, setShowForm] = useState(false);
@@ -47,6 +63,9 @@ export const CommentCard = ({
           comment.deleted && styles.censoredComment
         )}
       >
+        {showParentCommentPreview && parentComment && (
+          <ParentPreview parentComment={parentComment} />
+        )}
         <div className={styles.header}>
           <div className={styles.summary}>
             <Join>

--- a/plugins-structure/packages/comments/src/ui/CommentCard/CommentCard.js
+++ b/plugins-structure/packages/comments/src/ui/CommentCard/CommentCard.js
@@ -73,6 +73,7 @@ export const CommentCard = ({
   depth,
   recordOwner,
   commentPath,
+  isFlat,
 }) => {
   const [showForm, setShowForm] = useState(false);
   if (!comment) return children;
@@ -92,73 +93,76 @@ export const CommentCard = ({
   });
 
   return (
-    <div data-testid="comment-card">
-      <Card
-        className={classNames(
-          styles.commentCard,
-          comment.deleted && styles.censoredComment
-        )}
-      >
-        {showParentCommentPreview && parentComment && (
-          <ParentPreview
-            parentComment={parentComment}
-            link={generatePath(commentPath, {
-              token: getShortToken(comment.token),
-              commentid: parentComment.commentid,
-            })}
-          />
-        )}
-        <div className={styles.header}>
-          <div className={styles.summary}>
-            <Join>
-              <Link
-                href={userLink}
-                data-testid="comment-author"
-                className={classNames(isRecordOwner && styles.recordOwner)}
-              >
-                {comment.username}
-              </Link>
-              <Event event="" timestamp={comment.timestamp} />
-              {showCensor && !comment.deleted && (
-                <CensorButton onCensor={handleCensorComment} />
-              )}
-            </Join>
-          </div>
-          <CommentVotes
-            hide={comment.deleted}
-            upvotes={comment.upvotes}
-            userVote={userVote?.vote}
-            downvotes={comment.downvotes}
-          />
-        </div>
-        {/* TODO: get comment censorship user */}
-        <div className={styles.body} data-testid="comment-body">
-          {comment.deleted ? (
-            `Censored. Reason: ${comment.reason}`
-          ) : (
-            <MarkdownRenderer
-              body={comment.comment}
-              disallowedElements={["h1", "h2", "h3", "h4", "h5", "h6"]}
+    <>
+      <div data-testid="comment-card">
+        <Card
+          className={classNames(
+            styles.commentCard,
+            comment.deleted && styles.censoredComment
+          )}
+        >
+          {showParentCommentPreview && parentComment && (
+            <ParentPreview
+              parentComment={parentComment}
+              link={generatePath(commentPath, {
+                token: getShortToken(comment.token),
+                commentid: parentComment.commentid,
+              })}
             />
           )}
-        </div>
-        <CommentFooter
-          threadLength={threadLength}
-          disableReply={disableReply || comment.deleted}
-          url={commentUrl}
-          showThread={showThread}
-          toggleDisplayForm={toggleDisplayForm}
-        />
-        {showForm && (
-          <CommentForm onComment={onComment} parentId={comment.commentid} />
-        )}
-        {showThread && (
-          <div className={styles.thread} data-testid="comment-thread">
-            {children}
+          <div className={styles.header}>
+            <div className={styles.summary}>
+              <Join>
+                <Link
+                  href={userLink}
+                  data-testid="comment-author"
+                  className={classNames(isRecordOwner && styles.recordOwner)}
+                >
+                  {comment.username}
+                </Link>
+                <Event event="" timestamp={comment.timestamp} />
+                {showCensor && !comment.deleted && (
+                  <CensorButton onCensor={handleCensorComment} />
+                )}
+              </Join>
+            </div>
+            <CommentVotes
+              hide={comment.deleted}
+              upvotes={comment.upvotes}
+              userVote={userVote?.vote}
+              downvotes={comment.downvotes}
+            />
           </div>
-        )}
-      </Card>
-    </div>
+          {/* TODO: get comment censorship user */}
+          <div className={styles.body} data-testid="comment-body">
+            {comment.deleted ? (
+              `Censored. Reason: ${comment.reason}`
+            ) : (
+              <MarkdownRenderer
+                body={comment.comment}
+                disallowedElements={["h1", "h2", "h3", "h4", "h5", "h6"]}
+              />
+            )}
+          </div>
+          <CommentFooter
+            threadLength={threadLength}
+            disableReply={disableReply || comment.deleted}
+            url={commentUrl}
+            showThread={showThread}
+            toggleDisplayForm={toggleDisplayForm}
+          />
+          {showForm && (
+            <CommentForm onComment={onComment} parentId={comment.commentid} />
+          )}
+          {showThread && !isFlat && (
+            <div className={styles.thread} data-testid="comment-thread">
+              {children}
+            </div>
+          )}
+        </Card>
+      </div>
+      {isFlat && children}
+    </>
   );
 };
 

--- a/plugins-structure/packages/comments/src/ui/CommentCard/CommentCard.js
+++ b/plugins-structure/packages/comments/src/ui/CommentCard/CommentCard.js
@@ -6,6 +6,7 @@ import styles from "./styles.module.css";
 import { CommentVotes } from "./CommentVotes";
 import { CommentForm } from "../CommentForm";
 import truncate from "lodash/truncate";
+import { generatePath } from "@politeiagui/core/router";
 
 const CensorButton = ({ onCensor }) => (
   <span
@@ -44,20 +45,18 @@ export const CommentCard = ({
   parentComment,
   depth,
   recordOwner,
+  commentPath,
 }) => {
-  const [showThread, setShowThread] = useState(depth !== 6);
   const [showForm, setShowForm] = useState(false);
   function handleCensorComment() {
     onCensor(comment);
-  }
-  function toggleDisplayThread() {
-    setShowThread(!showThread);
   }
   function toggleDisplayForm() {
     setShowForm(!showForm);
   }
 
   const isRecordOwner = recordOwner === comment.username;
+  const showThread = depth !== 6;
 
   return (
     <div data-testid="comment-card">
@@ -104,22 +103,24 @@ export const CommentCard = ({
             />
           )}
         </div>
-        <div className={styles.footer}>
-          {!disableReply && !comment.deleted && (
-            <span
-              className={styles.reply}
-              data-testid="comment-reply"
-              onClick={toggleDisplayForm}
+        <Join inline className={styles.reply}>
+          {threadLength > 0 && !showThread && (
+            <a
+              data-link
+              href={generatePath(commentPath, {
+                token: comment.token,
+                commentid: comment.commentid,
+              })}
             >
-              Reply
+              {threadLength} more repl{threadLength > 1 ? "ies" : "y"}
+            </a>
+          )}
+          {!disableReply && !comment.deleted && (
+            <span data-testid="comment-reply" onClick={toggleDisplayForm}>
+              reply
             </span>
           )}
-          {threadLength > 0 && (
-            <span className={styles.collapse} onClick={toggleDisplayThread}>
-              {showThread ? "-" : `+${threadLength}`}
-            </span>
-          )}
-        </div>
+        </Join>
         {showForm && (
           <CommentForm onComment={onComment} parentId={comment.commentid} />
         )}
@@ -144,10 +145,12 @@ CommentCard.propTypes = {
   onComment: PropTypes.func,
   parentId: PropTypes.number,
   disableReply: PropTypes.bool,
+  commentPath: PropTypes.string,
 };
 
 CommentCard.defaultProps = {
   threadLength: 0,
   userLink: "/#user",
   onComment: () => {},
+  commentPath: "/record/:token/comment/:commentid",
 };

--- a/plugins-structure/packages/comments/src/ui/CommentCard/CommentCard.js
+++ b/plugins-structure/packages/comments/src/ui/CommentCard/CommentCard.js
@@ -35,14 +35,14 @@ const ParentPreview = ({ parentComment, link }) => {
 const CommentFooter = ({
   threadLength,
   disableReply,
-  link,
+  url,
   showThread,
   toggleDisplayForm,
 }) => (
   <div className={styles.footer}>
     <Join inline>
       {threadLength > 0 && !showThread && (
-        <a data-link href={link}>
+        <a data-link href={url}>
           {threadLength} more repl{threadLength > 1 ? "ies" : "y"}
         </a>
       )}
@@ -52,7 +52,7 @@ const CommentFooter = ({
         </span>
       )}
     </Join>
-    <a href={link} data-link className={styles.discussion}>
+    <a href={url} data-link className={styles.discussion}>
       <ButtonIcon type="link" />
     </a>
   </div>
@@ -86,7 +86,7 @@ export const CommentCard = ({
   const isRecordOwner = recordOwner === comment.username;
   const showThread = depth !== 6;
 
-  const commentLink = generatePath(commentPath, {
+  const commentUrl = generatePath(commentPath, {
     token: getShortToken(comment.token),
     commentid: comment.commentid,
   });
@@ -145,7 +145,7 @@ export const CommentCard = ({
         <CommentFooter
           threadLength={threadLength}
           disableReply={disableReply || comment.deleted}
-          link={commentLink}
+          url={commentUrl}
           showThread={showThread}
           toggleDisplayForm={toggleDisplayForm}
         />

--- a/plugins-structure/packages/comments/src/ui/CommentCard/CommentCard.test.js
+++ b/plugins-structure/packages/comments/src/ui/CommentCard/CommentCard.test.js
@@ -39,11 +39,11 @@ describe("Given CommentCard component", () => {
     });
     it("should display the reply button", () => {
       render(<CommentCard comment={comment} />);
-      expect(screen.getByTestId("comment-reply")).toHaveTextContent("Reply");
+      expect(screen.getByTestId("comment-reply")).toHaveTextContent(/reply/i);
     });
     it("should display the censor button", () => {
       render(<CommentCard comment={comment} showCensor={true} />);
-      expect(screen.getByTestId("comment-censor")).toHaveTextContent("Censor");
+      expect(screen.getByTestId("comment-censor")).toHaveTextContent(/censor/i);
     });
   });
   describe("given some censored comment", () => {

--- a/plugins-structure/packages/comments/src/ui/CommentCard/styles.module.css
+++ b/plugins-structure/packages/comments/src/ui/CommentCard/styles.module.css
@@ -47,8 +47,7 @@
 
 .reply {
   cursor: pointer;
-  margin-right: 1rem;
-  color: var(--tab-text-color) !important;
+  color: var(--text-color-light) !important;
 }
 
 .thread {

--- a/plugins-structure/packages/comments/src/ui/CommentCard/styles.module.css
+++ b/plugins-structure/packages/comments/src/ui/CommentCard/styles.module.css
@@ -101,3 +101,14 @@
 .hasVoted > svg > g > path {
   fill: var(--color-primary-dark) !important;
 }
+
+/* Parent Comment */
+.parentContext {
+  display: inline-block;
+  font-size: var(--font-size-small);
+  color: var(--text-color-light);
+  border-left: 0.3rem solid var(--text-color-light);
+  padding: 0 1rem;
+  margin-bottom: 1rem;
+  width: 100%;
+}

--- a/plugins-structure/packages/comments/src/ui/CommentCard/styles.module.css
+++ b/plugins-structure/packages/comments/src/ui/CommentCard/styles.module.css
@@ -27,6 +27,18 @@
 }
 
 .footer {
+  color: var(--text-color-light) !important;
+  display: flex;
+  align-items: center;
+}
+
+.footer > * {
+  cursor: pointer;
+}
+
+.footer .discussion {
+  justify-self: flex-end;
+  margin-left: auto;
   display: flex;
   align-items: center;
 }
@@ -43,11 +55,6 @@
 
 .recordOwner {
   color: var(--color-gold) !important;
-}
-
-.reply {
-  cursor: pointer;
-  color: var(--text-color-light) !important;
 }
 
 .thread {

--- a/plugins-structure/packages/comments/src/ui/Comments/Comments.js
+++ b/plugins-structure/packages/comments/src/ui/Comments/Comments.js
@@ -49,7 +49,7 @@ export const Comments = ({
       data-testid="comments-section"
     >
       <Card paddingSize="small" className={styles.header}>
-        <H2 className={styles.title}>
+        <H2 className={styles.title} data-testid="comments-section-title">
           {title} <span className={styles.count}>({commentsCount})</span>
         </H2>
         {!!commentsCount && (

--- a/plugins-structure/packages/comments/src/ui/Comments/Comments.js
+++ b/plugins-structure/packages/comments/src/ui/Comments/Comments.js
@@ -17,6 +17,7 @@ export const Comments = ({
   onReply,
   disableReply,
   title,
+  id,
 }) => {
   const [sortedComments, setSortedComments] = useState(Object.values(comments));
   const [commentsByParent, setCommentsByParent] = useState();
@@ -39,12 +40,12 @@ export const Comments = ({
 
   const commentsCount = Object.keys(comments).length;
 
-  useScrollTo("comments-wrapper", scrollOnLoad);
+  useScrollTo(id, scrollOnLoad);
 
   return (
     <div
       className={styles.commentsWrapper}
-      id="comments-wrapper"
+      id={id}
       data-testid="comments-section"
     >
       <Card paddingSize="small" className={styles.header}>
@@ -93,4 +94,5 @@ Comments.defaultProps = {
   onReply: () => {},
   title: "Comments",
   isFlatMode: false,
+  id: "comments-wrapper",
 };

--- a/plugins-structure/packages/comments/src/ui/Comments/Comments.js
+++ b/plugins-structure/packages/comments/src/ui/Comments/Comments.js
@@ -19,6 +19,7 @@ export const Comments = ({
   title,
   id,
   recordOwner,
+  commentPath,
 }) => {
   const [sortedComments, setSortedComments] = useState(Object.values(comments));
   const [commentsByParent, setCommentsByParent] = useState();
@@ -73,6 +74,7 @@ export const Comments = ({
           disableReply={disableReply}
           isFlat={isFlat}
           recordOwner={recordOwner}
+          commentPath={commentPath}
         />
       </div>
     </div>

--- a/plugins-structure/packages/comments/src/ui/Comments/Comments.js
+++ b/plugins-structure/packages/comments/src/ui/Comments/Comments.js
@@ -4,7 +4,6 @@ import { CommentsFilter, CommentsList } from "./";
 import { Card, H2 } from "pi-ui";
 import styles from "./styles.module.css";
 import { getCommentsByParent } from "../../comments/utils";
-import { useScrollTo } from "@politeiagui/common-ui/layout";
 
 export const Comments = ({
   comments,
@@ -13,11 +12,9 @@ export const Comments = ({
   onCensor,
   showCensor,
   parentId,
-  scrollOnLoad,
   onReply,
   disableReply,
   title,
-  id,
   recordOwner,
   commentPath,
 }) => {
@@ -41,15 +38,10 @@ export const Comments = ({
   }, [sortedComments, isFlat]);
 
   const commentsCount = Object.keys(comments).length;
+  const currentComment = comments[parentId];
 
-  useScrollTo(id, scrollOnLoad);
-
-  return (
-    <div
-      className={styles.commentsWrapper}
-      id={id}
-      data-testid="comments-section"
-    >
+  return parentId === 0 || currentComment ? (
+    <div className={styles.commentsWrapper} data-testid="comments-section">
       <Card paddingSize="small" className={styles.header}>
         <H2 className={styles.title} data-testid="comments-section-title">
           {title} <span className={styles.count}>({commentsCount})</span>
@@ -59,6 +51,7 @@ export const Comments = ({
             isFlat={isFlat}
             onSort={handleSortComments}
             onToggleFlatMode={handleToggleFlatMode}
+            hideFlatModeButton={!!currentComment}
           />
         )}
       </Card>
@@ -73,12 +66,13 @@ export const Comments = ({
           onReply={onReply}
           disableReply={disableReply}
           isFlat={isFlat}
+          previewId={currentComment?.commentid}
           recordOwner={recordOwner}
           commentPath={commentPath}
         />
       </div>
     </div>
-  );
+  ) : null;
 };
 
 Comments.propTypes = {
@@ -99,5 +93,4 @@ Comments.defaultProps = {
   onReply: () => {},
   title: "Comments",
   isFlatMode: false,
-  id: "comments-wrapper",
 };

--- a/plugins-structure/packages/comments/src/ui/Comments/Comments.js
+++ b/plugins-structure/packages/comments/src/ui/Comments/Comments.js
@@ -5,6 +5,14 @@ import { Card, H2 } from "pi-ui";
 import styles from "./styles.module.css";
 import { getCommentsByParent } from "../../comments/utils";
 
+const ViewAllLink = ({ url }) => (
+  <div className={styles.fullThreadLink}>
+    <a data-link data-testid="comments-view-all-link" href={url}>
+      view all comments
+    </a>
+  </div>
+);
+
 export const Comments = ({
   comments,
   isFlatMode,
@@ -54,13 +62,7 @@ export const Comments = ({
             onToggleFlatMode={handleToggleFlatMode}
           />
         )}
-        {currentComment && fullThreadUrl && (
-          <div className={styles.fullThreadLink}>
-            <a data-link href={fullThreadUrl}>
-              view all comments
-            </a>
-          </div>
-        )}
+        {currentComment && fullThreadUrl && <ViewAllLink url={fullThreadUrl} />}
       </Card>
       <div className={styles.commentsList}>
         <CommentsList

--- a/plugins-structure/packages/comments/src/ui/Comments/Comments.js
+++ b/plugins-structure/packages/comments/src/ui/Comments/Comments.js
@@ -34,9 +34,9 @@ export const Comments = ({
 
   // Update schema for every filter change
   useEffect(() => {
-    const schema = getCommentsByParent(sortedComments, isFlat);
+    const schema = getCommentsByParent(sortedComments);
     setCommentsByParent(schema);
-  }, [sortedComments, isFlat]);
+  }, [sortedComments]);
 
   const commentsCount = Object.keys(comments).length;
   const currentComment = comments[parentId];
@@ -52,7 +52,6 @@ export const Comments = ({
             isFlat={isFlat}
             onSort={handleSortComments}
             onToggleFlatMode={handleToggleFlatMode}
-            hideFlatModeButton={!!currentComment}
           />
         )}
         {currentComment && fullThreadUrl && (

--- a/plugins-structure/packages/comments/src/ui/Comments/Comments.js
+++ b/plugins-structure/packages/comments/src/ui/Comments/Comments.js
@@ -16,6 +16,7 @@ export const Comments = ({
   scrollOnLoad,
   onReply,
   disableReply,
+  title,
 }) => {
   const [sortedComments, setSortedComments] = useState(Object.values(comments));
   const [commentsByParent, setCommentsByParent] = useState();
@@ -48,7 +49,7 @@ export const Comments = ({
     >
       <Card paddingSize="small" className={styles.header}>
         <H2 className={styles.title}>
-          Comments <span className={styles.count}>({commentsCount})</span>
+          {title} <span className={styles.count}>({commentsCount})</span>
         </H2>
         {!!commentsCount && (
           <CommentsFilter
@@ -83,9 +84,11 @@ Comments.propTypes = {
   parentId: PropTypes.number,
   onReply: PropTypes.func,
   disableReply: PropTypes.bool,
+  title: PropTypes.string,
 };
 
 Comments.defaultProps = {
   parentId: 0,
   onReply: () => {},
+  title: "Comments",
 };

--- a/plugins-structure/packages/comments/src/ui/Comments/Comments.js
+++ b/plugins-structure/packages/comments/src/ui/Comments/Comments.js
@@ -17,6 +17,7 @@ export const Comments = ({
   title,
   recordOwner,
   commentPath,
+  fullThreadUrl,
 }) => {
   const [sortedComments, setSortedComments] = useState(Object.values(comments));
   const [commentsByParent, setCommentsByParent] = useState();
@@ -54,6 +55,13 @@ export const Comments = ({
             hideFlatModeButton={!!currentComment}
           />
         )}
+        {currentComment && fullThreadUrl && (
+          <div className={styles.fullThreadLink}>
+            <a data-link href={fullThreadUrl}>
+              view all comments
+            </a>
+          </div>
+        )}
       </Card>
       <div className={styles.commentsList}>
         <CommentsList
@@ -86,6 +94,8 @@ Comments.propTypes = {
   disableReply: PropTypes.bool,
   title: PropTypes.string,
   recordOwner: PropTypes.string,
+  commentPath: PropTypes.string,
+  fullThreadUrl: PropTypes.string,
 };
 
 Comments.defaultProps = {

--- a/plugins-structure/packages/comments/src/ui/Comments/Comments.js
+++ b/plugins-structure/packages/comments/src/ui/Comments/Comments.js
@@ -69,6 +69,7 @@ export const Comments = ({
           onCensor={onCensor}
           onReply={onReply}
           disableReply={disableReply}
+          isFlat={isFlat}
         />
       </div>
     </div>
@@ -91,4 +92,5 @@ Comments.defaultProps = {
   parentId: 0,
   onReply: () => {},
   title: "Comments",
+  isFlatMode: false,
 };

--- a/plugins-structure/packages/comments/src/ui/Comments/CommentsFilter.js
+++ b/plugins-structure/packages/comments/src/ui/Comments/CommentsFilter.js
@@ -52,6 +52,7 @@ export const CommentsFilter = ({ onSort, onToggleFlatMode, isFlat }) => {
           styles.flatButtonWrapper,
           isFlat && styles.flatModeActive
         )}
+        data-testid="comments-filter-flat-mode-button"
         onClick={onToggleFlatMode}
       >
         <Text

--- a/plugins-structure/packages/comments/src/ui/Comments/CommentsFilter.js
+++ b/plugins-structure/packages/comments/src/ui/Comments/CommentsFilter.js
@@ -19,12 +19,7 @@ const options = [
   },
 ];
 
-export const CommentsFilter = ({
-  onSort,
-  onToggleFlatMode,
-  isFlat,
-  hideFlatModeButton,
-}) => {
+export const CommentsFilter = ({ onSort, onToggleFlatMode, isFlat }) => {
   const [selected, setSelected] = useState(options[0]);
 
   function handleFilterChanges(option) {
@@ -52,24 +47,22 @@ export const CommentsFilter = ({
         onChange={handleFilterChanges}
         customStyles={{ container: () => ({ padding: "0" }) }}
       />
-      {!hideFlatModeButton && (
-        <div
+      <div
+        className={classNames(
+          styles.flatButtonWrapper,
+          isFlat && styles.flatModeActive
+        )}
+        onClick={onToggleFlatMode}
+      >
+        <Text
           className={classNames(
-            styles.flatButtonWrapper,
+            styles.flatButtonText,
             isFlat && styles.flatModeActive
           )}
-          onClick={onToggleFlatMode}
         >
-          <Text
-            className={classNames(
-              styles.flatButtonText,
-              isFlat && styles.flatModeActive
-            )}
-          >
-            Flat mode
-          </Text>
-        </div>
-      )}
+          Flat mode
+        </Text>
+      </div>
     </div>
   );
 };

--- a/plugins-structure/packages/comments/src/ui/Comments/CommentsFilter.js
+++ b/plugins-structure/packages/comments/src/ui/Comments/CommentsFilter.js
@@ -19,7 +19,12 @@ const options = [
   },
 ];
 
-export const CommentsFilter = ({ onSort, onToggleFlatMode, isFlat }) => {
+export const CommentsFilter = ({
+  onSort,
+  onToggleFlatMode,
+  isFlat,
+  hideFlatModeButton,
+}) => {
   const [selected, setSelected] = useState(options[0]);
 
   function handleFilterChanges(option) {
@@ -47,22 +52,24 @@ export const CommentsFilter = ({ onSort, onToggleFlatMode, isFlat }) => {
         onChange={handleFilterChanges}
         customStyles={{ container: () => ({ padding: "0" }) }}
       />
-      <div
-        className={classNames(
-          styles.flatButtonWrapper,
-          isFlat && styles.flatModeActive
-        )}
-        onClick={onToggleFlatMode}
-      >
-        <Text
+      {!hideFlatModeButton && (
+        <div
           className={classNames(
-            styles.flatButtonText,
+            styles.flatButtonWrapper,
             isFlat && styles.flatModeActive
           )}
+          onClick={onToggleFlatMode}
         >
-          Flat mode
-        </Text>
-      </div>
+          <Text
+            className={classNames(
+              styles.flatButtonText,
+              isFlat && styles.flatModeActive
+            )}
+          >
+            Flat mode
+          </Text>
+        </div>
+      )}
     </div>
   );
 };

--- a/plugins-structure/packages/comments/src/ui/Comments/CommentsList.js
+++ b/plugins-structure/packages/comments/src/ui/Comments/CommentsList.js
@@ -15,42 +15,47 @@ export const CommentsList = ({
   depth = 0,
   recordOwner,
   commentPath,
+  previewId,
 }) => {
   if (!commentsByParent || !commentsByParent[parentId]) {
     return null;
   }
-  return commentsByParent[parentId].map((childId) => (
+  const comment = comments[parentId];
+
+  return (
     <CommentCard
-      key={childId}
       depth={depth}
-      comment={comments[childId]}
+      comment={comment}
       onCensor={onCensor}
-      threadLength={commentsByParent[childId]?.length}
+      threadLength={commentsByParent[parentId]?.length}
       showCensor={showCensor}
-      userVote={userVotes[childId]}
+      userVote={userVotes[parentId]}
       onComment={onReply}
       disableReply={disableReply}
-      showParentCommentPreview={isFlat}
-      parentComment={comments[comments[childId].parentid]}
+      showParentCommentPreview={isFlat || previewId === parentId}
+      parentComment={comments[comment?.parentid]}
       recordOwner={recordOwner}
       commentPath={commentPath}
     >
-      <CommentsList
-        comments={comments}
-        showCensor={showCensor}
-        onCensor={onCensor}
-        parentId={childId}
-        commentsByParent={commentsByParent}
-        userVotes={userVotes}
-        onReply={onReply}
-        disableReply={disableReply}
-        isFlat={isFlat}
-        depth={depth + 1}
-        recordOwner={recordOwner}
-        commentPath={commentPath}
-      />
+      {commentsByParent[parentId].map((childId) => (
+        <CommentsList
+          key={childId}
+          comments={comments}
+          showCensor={showCensor}
+          onCensor={onCensor}
+          parentId={childId}
+          commentsByParent={commentsByParent}
+          userVotes={userVotes}
+          onReply={onReply}
+          disableReply={disableReply}
+          isFlat={isFlat}
+          depth={depth + 1}
+          recordOwner={recordOwner}
+          commentPath={commentPath}
+        />
+      ))}
     </CommentCard>
-  ));
+  );
 };
 
 CommentsList.propTypes = {

--- a/plugins-structure/packages/comments/src/ui/Comments/CommentsList.js
+++ b/plugins-structure/packages/comments/src/ui/Comments/CommentsList.js
@@ -36,6 +36,7 @@ export const CommentsList = ({
       parentComment={comments[comment?.parentid]}
       recordOwner={recordOwner}
       commentPath={commentPath}
+      isFlat={isFlat}
     >
       {commentsByParent[parentId].map((childId) => (
         <CommentsList

--- a/plugins-structure/packages/comments/src/ui/Comments/CommentsList.js
+++ b/plugins-structure/packages/comments/src/ui/Comments/CommentsList.js
@@ -14,6 +14,7 @@ export const CommentsList = ({
   isFlat,
   depth = 0,
   recordOwner,
+  commentPath,
 }) => {
   if (!commentsByParent || !commentsByParent[parentId]) {
     return null;
@@ -32,6 +33,7 @@ export const CommentsList = ({
       showParentCommentPreview={isFlat}
       parentComment={comments[comments[childId].parentid]}
       recordOwner={recordOwner}
+      commentPath={commentPath}
     >
       <CommentsList
         comments={comments}
@@ -45,6 +47,7 @@ export const CommentsList = ({
         isFlat={isFlat}
         depth={depth + 1}
         recordOwner={recordOwner}
+        commentPath={commentPath}
       />
     </CommentCard>
   ));

--- a/plugins-structure/packages/comments/src/ui/Comments/CommentsList.js
+++ b/plugins-structure/packages/comments/src/ui/Comments/CommentsList.js
@@ -12,6 +12,7 @@ export const CommentsList = ({
   onReply,
   disableReply,
   isFlat,
+  depth = 0,
 }) => {
   if (!commentsByParent || !commentsByParent[parentId]) {
     return null;
@@ -19,6 +20,7 @@ export const CommentsList = ({
   return commentsByParent[parentId].map((childId) => (
     <CommentCard
       key={childId}
+      depth={depth}
       comment={comments[childId]}
       onCensor={onCensor}
       threadLength={commentsByParent[childId]?.length}
@@ -39,6 +41,7 @@ export const CommentsList = ({
         onReply={onReply}
         disableReply={disableReply}
         isFlat={isFlat}
+        depth={depth + 1}
       />
     </CommentCard>
   ));

--- a/plugins-structure/packages/comments/src/ui/Comments/CommentsList.js
+++ b/plugins-structure/packages/comments/src/ui/Comments/CommentsList.js
@@ -11,6 +11,7 @@ export const CommentsList = ({
   userVotes,
   onReply,
   disableReply,
+  isFlat,
 }) => {
   if (!commentsByParent || !commentsByParent[parentId]) {
     return null;
@@ -25,6 +26,8 @@ export const CommentsList = ({
       userVote={userVotes[childId]}
       onComment={onReply}
       disableReply={disableReply}
+      showParentCommentPreview={isFlat}
+      parentComment={comments[comments[childId].parentid]}
     >
       <CommentsList
         comments={comments}
@@ -35,6 +38,7 @@ export const CommentsList = ({
         userVotes={userVotes}
         onReply={onReply}
         disableReply={disableReply}
+        isFlat={isFlat}
       />
     </CommentCard>
   ));
@@ -47,6 +51,9 @@ CommentsList.propTypes = {
   onCensor: PropTypes.func,
   commentsByParent: PropTypes.object,
   userVotes: PropTypes.object,
+  onReply: PropTypes.func,
+  disableReply: PropTypes.bool,
+  isFlat: PropTypes.bool,
 };
 
 CommentsList.defaultProps = {

--- a/plugins-structure/packages/comments/src/ui/Comments/styles.module.css
+++ b/plugins-structure/packages/comments/src/ui/Comments/styles.module.css
@@ -63,3 +63,9 @@ span.flatModeActive {
   margin-bottom: 1rem;
   font-weight: var(--font-weight-regular);
 }
+
+.fullThreadLink {
+  margin-top: 1rem;
+  color: var(--link-color);
+  cursor: pointer;
+}

--- a/plugins-structure/packages/common-ui/src/components/Join/Join.js
+++ b/plugins-structure/packages/common-ui/src/components/Join/Join.js
@@ -5,10 +5,12 @@ import styles from "./styles.module.css";
 
 const DefaultSeparator = () => <span className={styles.separator}>•</span>;
 
-export const Join = ({ children, SeparatorComponent, className }) => {
+export const Join = ({ children, SeparatorComponent, className, inline }) => {
   const childrenArray = React.Children.toArray(children).filter((c) => !!c);
   return (
-    <div className={classNames(styles.join, className)}>
+    <div
+      className={classNames(styles.join, inline && styles.inline, className)}
+    >
       {childrenArray.map((child, idx) => (
         <React.Fragment key={`join-${idx}`}>
           {React.cloneElement(child)}

--- a/plugins-structure/packages/common-ui/src/components/Join/styles.module.css
+++ b/plugins-structure/packages/common-ui/src/components/Join/styles.module.css
@@ -9,14 +9,14 @@
 }
 
 @media (--xs-viewport) {
-  .join {
+  .join:not(.inline) {
     flex-flow: column;
     max-width: 100%;
   }
-  .join > *:not(:first-child) {
+  .join:not(.inline) > *:not(:first-child) {
     padding-top: 1rem;
   }
-  .separator {
+  .join:not(.inline) > .separator {
     display: none;
   }
 }

--- a/plugins-structure/packages/ticketvote/src/dev/mocks/index.js
+++ b/plugins-structure/packages/ticketvote/src/dev/mocks/index.js
@@ -1,7 +1,77 @@
 import { getTokensArray } from "@politeiagui/core/dev/mocks";
 import { getHumanReadableTicketvoteStatus } from "../../lib/utils";
+import {
+  TICKETVOTE_STATUS_APPROVED,
+  TICKETVOTE_STATUS_AUTHORIZED,
+  TICKETVOTE_STATUS_INELIGIBLE,
+  TICKETVOTE_STATUS_REJECTED,
+  TICKETVOTE_STATUS_STARTED,
+  TICKETVOTE_STATUS_UNAUTHORIZED,
+} from "../../lib/constants";
 
 const bestblock = 420;
+
+const approvedTicketvoteSummary = {
+  type: 1,
+  status: TICKETVOTE_STATUS_APPROVED,
+  duration: 10,
+  startblockheight: bestblock - 20,
+  startblockhash:
+    "0000000094f39c5495faad40a6554f6996c9912d378afa19b971055ebe505382",
+  endblockheight: bestblock - 10,
+  eligibletickets: 5589,
+  quorumpercentage: 0,
+  passpercentage: 60,
+  results: [
+    { id: "yes", votes: 500 },
+    { id: "no", votes: 50 },
+  ],
+  bestblock,
+};
+
+const rejectedTicketvoteSummary = {
+  ...approvedTicketvoteSummary,
+  status: TICKETVOTE_STATUS_REJECTED,
+  results: [
+    { id: "yes", votes: 50 },
+    { id: "no", votes: 500 },
+  ],
+};
+
+const emptyTicketvoteSummary = {
+  status: 0, // Missing status by default
+  type: 0,
+  duration: 0,
+  startblockheight: 0,
+  startblockhash: "",
+  endblockheight: 0,
+  eligibletickets: 0,
+  quorumpercentage: 0,
+  passpercentage: 0,
+  results: [],
+};
+
+export const ticketvoteSummariesByStatus = {
+  approved: approvedTicketvoteSummary,
+  rejected: rejectedTicketvoteSummary,
+  authorized: {
+    ...emptyTicketvoteSummary,
+    status: TICKETVOTE_STATUS_AUTHORIZED,
+  },
+  ineligible: {
+    ...emptyTicketvoteSummary,
+    status: TICKETVOTE_STATUS_INELIGIBLE,
+  },
+  started: {
+    ...approvedTicketvoteSummary,
+    endblockheight: bestblock + 10,
+    status: TICKETVOTE_STATUS_STARTED,
+  },
+  unauthorized: {
+    ...emptyTicketvoteSummary,
+    status: TICKETVOTE_STATUS_UNAUTHORIZED,
+  },
+};
 
 export function mockTicketvoteInventory(amount, customTokens = []) {
   const amountToGenerate = amount - customTokens.length;
@@ -43,17 +113,17 @@ export function mockTicketvoteSubmissions(amount = 1) {
 }
 
 export function mockTicketvoteSummaries({
-  status = 0, // Missing status by default
-  type = 0,
-  duration = 0,
-  startblockheight = 0,
-  startblockhash = "",
-  endblockheight = 0,
-  eligibletickets = 0,
-  quorumpercentage = 0,
-  passpercentage = 0,
-  results = [],
-} = {}) {
+  status, // Missing status by default
+  type,
+  duration,
+  startblockheight,
+  startblockhash,
+  endblockheight,
+  eligibletickets,
+  quorumpercentage,
+  passpercentage,
+  results,
+} = emptyTicketvoteSummary) {
   return ({ tokens }) => {
     const summaries = tokens.reduce(
       (response, token) => ({


### PR DESCRIPTION
Closes #2858 
Closes #2855 
Closes #2862 

This PR adds Proposal author updates on our politeia app-shell. This was
achievable due to the new comments threads organization approach implemented
by the new `keyCommentsThreadsBy` util on **comments plugin**.

Also, this PR adds some improvements on flat mode comments threads, and now
displays a preview of the parent reply, if replying to some comment, as well as
a **single comment thread support**.

### Preview

<img width="1100" alt="Screen Shot 2022-09-26 at 5 05 53 PM" src="https://user-images.githubusercontent.com/22639213/192369721-e3d67ed9-713c-4472-82f9-b5b6c3aed21a.png">

<img width="1100" alt="Screen Shot 2022-09-26 at 6 12 58 PM" src="https://user-images.githubusercontent.com/22639213/192381604-936cd71c-ed04-451d-a12b-c71bd035a2f8.png">

<img width="1416" alt="Screen Shot 2022-10-05 at 12 35 51 PM" src="https://user-images.githubusercontent.com/22639213/194101741-13dcd0db-3238-4a5f-b0fd-cd8570575e71.png">


