### PR TITLE
build: improve code-splitting and chunks cache

### DIFF
--- a/plugins-structure/apps/politeia/package.json
+++ b/plugins-structure/apps/politeia/package.json
@@ -14,6 +14,7 @@
     "test:no:watch": "politeiagui-scripts test --no-watch",
     "build": "politeiagui-scripts build-app",
     "analyze": "source-map-explorer 'dist/*.js'",
+    "analyze:gzip": "source-map-explorer 'dist/*.js' --gzip",
     "start": "politeiagui-scripts start-app",
     "serve": "politeiagui-scripts start-app --serve",
     "test:e2e:run": "START_SERVER_AND_TEST_INSECURE=1 start-server-and-test 'yarn serve' https-get://localhost:8080 'politeiagui-scripts test-e2e'",
@@ -24,10 +25,10 @@
     "@politeiagui/common-ui": "1.0.0",
     "@politeiagui/core": "1.0.0",
     "@politeiagui/ticketvote": "1.0.0",
-    "js-file-download": "^0.4.12",
-    "politeiagui-scripts": "1.0.0"
+    "js-file-download": "^0.4.12"
   },
   "devDependencies": {
+    "politeiagui-scripts": "1.0.0",
     "source-map-explorer": "^2.5.2"
   }
 }

--- a/plugins-structure/apps/politeia/src/pages/Details/index.js
+++ b/plugins-structure/apps/politeia/src/pages/Details/index.js
@@ -1,3 +1,4 @@
+import { lazy } from "react";
 import App from "../../app";
 import { routeCleanup } from "../../utils/routeCleanup";
 import { createRouteView } from "../../utils/createRouteView";
@@ -10,80 +11,80 @@ import {
   fetchRfpLinkedProposalListenerCreator,
   fetchRfpSubmissionsListenerCreator,
   fetchVoteSummaryListenerCreator,
-  recordFetchDetailsListenerCreator,
+  recordFetchDetailsListenerCreator
 } from "./listeners";
-
-import Details from "./Details";
 
 export default App.createRoute({
   path: "/record/:token",
   setupServices: [
     {
-      id: "ticketvote/timestamps",
+      id: "ticketvote/timestamps"
     },
     {
-      id: "comments/timestamps",
+      id: "comments/timestamps"
     },
     {
       id: "records/details",
-      listenerCreator: recordFetchDetailsListenerCreator,
+      listenerCreator: recordFetchDetailsListenerCreator
     },
     {
       id: "ticketvote/summaries/single",
-      listenerCreator: fetchDetailsListenerCreator,
+      listenerCreator: fetchDetailsListenerCreator
     },
     {
       id: "comments",
-      listenerCreator: fetchDetailsListenerCreator,
+      listenerCreator: fetchDetailsListenerCreator
     },
     {
       id: "pi/summaries/single",
-      listenerCreator: fetchDetailsListenerCreator,
+      listenerCreator: fetchDetailsListenerCreator
     },
     {
       id: "pi/billingStatusChanges/single",
-      listenerCreator: fetchProposalSummaryListenerCreator,
+      listenerCreator: fetchProposalSummaryListenerCreator
     },
     // Proposal status changes services
     {
       id: "pi/proposals/voteStatusChanges",
-      listenerCreator: fetchVoteSummaryListenerCreator,
+      listenerCreator: fetchVoteSummaryListenerCreator
     },
     {
       id: "pi/proposals/recordStatusChanges",
-      listenerCreator: fetchRecordDetailsListenerCreator,
+      listenerCreator: fetchRecordDetailsListenerCreator
     },
     {
       id: "pi/proposals/billingStatusChanges",
-      listenerCreator: fetchBillingStatusChangesListenerCreator,
+      listenerCreator: fetchBillingStatusChangesListenerCreator
     },
     // RFP Proposals Services
     {
       id: "ticketvote/submissions",
-      listenerCreator: fetchRfpDetailsListenerCreator,
+      listenerCreator: fetchRfpDetailsListenerCreator
     },
     {
       id: "records/batch/all",
-      listenerCreator: fetchRfpSubmissionsListenerCreator,
+      listenerCreator: fetchRfpSubmissionsListenerCreator
     },
     {
       id: "ticketvote/summaries/all",
-      listenerCreator: fetchRfpSubmissionsListenerCreator,
+      listenerCreator: fetchRfpSubmissionsListenerCreator
     },
     {
       id: "pi/summaries/all",
-      listenerCreator: fetchRfpSubmissionsListenerCreator,
+      listenerCreator: fetchRfpSubmissionsListenerCreator
     },
     {
       id: "comments/count/all",
-      listenerCreator: fetchRfpSubmissionsListenerCreator,
+      listenerCreator: fetchRfpSubmissionsListenerCreator
     },
     // RFP Submissions Services
     {
       id: "records/batch",
-      listenerCreator: fetchRfpLinkedProposalListenerCreator,
-    },
+      listenerCreator: fetchRfpLinkedProposalListenerCreator
+    }
   ],
   cleanup: routeCleanup,
-  view: createRouteView(Details),
+  view: createRouteView(
+    lazy(() => import(/* webpackChunkName: "details_page" */ "./Details"))
+  )
 });

--- a/plugins-structure/apps/politeia/src/pages/Details/index.js
+++ b/plugins-structure/apps/politeia/src/pages/Details/index.js
@@ -11,80 +11,80 @@ import {
   fetchRfpLinkedProposalListenerCreator,
   fetchRfpSubmissionsListenerCreator,
   fetchVoteSummaryListenerCreator,
-  recordFetchDetailsListenerCreator
+  recordFetchDetailsListenerCreator,
 } from "./listeners";
 
 export default App.createRoute({
   path: "/record/:token",
   setupServices: [
     {
-      id: "ticketvote/timestamps"
+      id: "ticketvote/timestamps",
     },
     {
-      id: "comments/timestamps"
+      id: "comments/timestamps",
     },
     {
       id: "records/details",
-      listenerCreator: recordFetchDetailsListenerCreator
+      listenerCreator: recordFetchDetailsListenerCreator,
     },
     {
       id: "ticketvote/summaries/single",
-      listenerCreator: fetchDetailsListenerCreator
+      listenerCreator: fetchDetailsListenerCreator,
     },
     {
       id: "comments",
-      listenerCreator: fetchDetailsListenerCreator
+      listenerCreator: fetchDetailsListenerCreator,
     },
     {
       id: "pi/summaries/single",
-      listenerCreator: fetchDetailsListenerCreator
+      listenerCreator: fetchDetailsListenerCreator,
     },
     {
       id: "pi/billingStatusChanges/single",
-      listenerCreator: fetchProposalSummaryListenerCreator
+      listenerCreator: fetchProposalSummaryListenerCreator,
     },
     // Proposal status changes services
     {
       id: "pi/proposals/voteStatusChanges",
-      listenerCreator: fetchVoteSummaryListenerCreator
+      listenerCreator: fetchVoteSummaryListenerCreator,
     },
     {
       id: "pi/proposals/recordStatusChanges",
-      listenerCreator: fetchRecordDetailsListenerCreator
+      listenerCreator: fetchRecordDetailsListenerCreator,
     },
     {
       id: "pi/proposals/billingStatusChanges",
-      listenerCreator: fetchBillingStatusChangesListenerCreator
+      listenerCreator: fetchBillingStatusChangesListenerCreator,
     },
     // RFP Proposals Services
     {
       id: "ticketvote/submissions",
-      listenerCreator: fetchRfpDetailsListenerCreator
+      listenerCreator: fetchRfpDetailsListenerCreator,
     },
     {
       id: "records/batch/all",
-      listenerCreator: fetchRfpSubmissionsListenerCreator
+      listenerCreator: fetchRfpSubmissionsListenerCreator,
     },
     {
       id: "ticketvote/summaries/all",
-      listenerCreator: fetchRfpSubmissionsListenerCreator
+      listenerCreator: fetchRfpSubmissionsListenerCreator,
     },
     {
       id: "pi/summaries/all",
-      listenerCreator: fetchRfpSubmissionsListenerCreator
+      listenerCreator: fetchRfpSubmissionsListenerCreator,
     },
     {
       id: "comments/count/all",
-      listenerCreator: fetchRfpSubmissionsListenerCreator
+      listenerCreator: fetchRfpSubmissionsListenerCreator,
     },
     // RFP Submissions Services
     {
       id: "records/batch",
-      listenerCreator: fetchRfpLinkedProposalListenerCreator
-    }
+      listenerCreator: fetchRfpLinkedProposalListenerCreator,
+    },
   ],
   cleanup: routeCleanup,
   view: createRouteView(
     lazy(() => import(/* webpackChunkName: "details_page" */ "./Details"))
-  )
+  ),
 });

--- a/plugins-structure/apps/politeia/src/pages/Home/index.js
+++ b/plugins-structure/apps/politeia/src/pages/Home/index.js
@@ -1,7 +1,8 @@
+import { lazy } from "react";
 import App from "../../app";
 import { routeCleanup } from "../../utils/routeCleanup";
 import { createRouteView } from "../../utils/createRouteView";
-import Home from "./Home";
+
 import {
   fetchBillingStatusChangesListenerCreator,
   fetchInventoryListenerCreator,
@@ -12,7 +13,7 @@ import {
   fetchRecordsListenerCreator,
   fetchRecordsRfpSubmissionsListenerCreator,
   fetchVoteSummariesListenerCreator,
-  listeners,
+  listeners
 } from "./listeners";
 
 export default App.createRoute({
@@ -20,48 +21,50 @@ export default App.createRoute({
   setupServices: [
     {
       id: "ticketvote/inventory",
-      listenerCreator: fetchInventoryListenerCreator,
+      listenerCreator: fetchInventoryListenerCreator
     },
     {
       id: "records/batch",
-      listenerCreator: fetchNextBatchRecordsListenerCreator,
+      listenerCreator: fetchNextBatchRecordsListenerCreator
     },
     {
       id: "ticketvote/summaries/batch",
-      listenerCreator: fetchNextBatchSummariesListenerCreator,
+      listenerCreator: fetchNextBatchSummariesListenerCreator
     },
     {
       id: "pi/summaries/batch",
-      listenerCreator: fetchNextBatchSummariesListenerCreator,
+      listenerCreator: fetchNextBatchSummariesListenerCreator
     },
     {
       id: "pi/billingStatusChanges",
-      listenerCreator: fetchNextBatchBillingStatusesListenerCreator,
+      listenerCreator: fetchNextBatchBillingStatusesListenerCreator
     },
     {
       id: "comments/count",
-      listenerCreator: fetchNextBatchCountListenerCreator,
+      listenerCreator: fetchNextBatchCountListenerCreator
     },
     // Proposals Status changes
     {
       id: "pi/proposals/voteStatusChanges",
-      listenerCreator: fetchVoteSummariesListenerCreator,
+      listenerCreator: fetchVoteSummariesListenerCreator
     },
     {
       id: "pi/proposals/recordStatusChanges",
-      listenerCreator: fetchRecordsListenerCreator,
+      listenerCreator: fetchRecordsListenerCreator
     },
     {
       id: "pi/proposals/billingStatusChanges",
-      listenerCreator: fetchBillingStatusChangesListenerCreator,
+      listenerCreator: fetchBillingStatusChangesListenerCreator
     },
     // Rfp Sumbissions
     {
       id: "records/batch/all",
-      listenerCreator: fetchRecordsRfpSubmissionsListenerCreator,
-    },
+      listenerCreator: fetchRecordsRfpSubmissionsListenerCreator
+    }
   ],
   listeners,
   cleanup: routeCleanup,
-  view: createRouteView(Home),
+  view: createRouteView(
+    lazy(() => import(/* webpackChunkName: "home_page" */ "./Home"))
+  )
 });

--- a/plugins-structure/apps/politeia/src/pages/Home/index.js
+++ b/plugins-structure/apps/politeia/src/pages/Home/index.js
@@ -13,7 +13,7 @@ import {
   fetchRecordsListenerCreator,
   fetchRecordsRfpSubmissionsListenerCreator,
   fetchVoteSummariesListenerCreator,
-  listeners
+  listeners,
 } from "./listeners";
 
 export default App.createRoute({
@@ -21,50 +21,50 @@ export default App.createRoute({
   setupServices: [
     {
       id: "ticketvote/inventory",
-      listenerCreator: fetchInventoryListenerCreator
+      listenerCreator: fetchInventoryListenerCreator,
     },
     {
       id: "records/batch",
-      listenerCreator: fetchNextBatchRecordsListenerCreator
+      listenerCreator: fetchNextBatchRecordsListenerCreator,
     },
     {
       id: "ticketvote/summaries/batch",
-      listenerCreator: fetchNextBatchSummariesListenerCreator
+      listenerCreator: fetchNextBatchSummariesListenerCreator,
     },
     {
       id: "pi/summaries/batch",
-      listenerCreator: fetchNextBatchSummariesListenerCreator
+      listenerCreator: fetchNextBatchSummariesListenerCreator,
     },
     {
       id: "pi/billingStatusChanges",
-      listenerCreator: fetchNextBatchBillingStatusesListenerCreator
+      listenerCreator: fetchNextBatchBillingStatusesListenerCreator,
     },
     {
       id: "comments/count",
-      listenerCreator: fetchNextBatchCountListenerCreator
+      listenerCreator: fetchNextBatchCountListenerCreator,
     },
     // Proposals Status changes
     {
       id: "pi/proposals/voteStatusChanges",
-      listenerCreator: fetchVoteSummariesListenerCreator
+      listenerCreator: fetchVoteSummariesListenerCreator,
     },
     {
       id: "pi/proposals/recordStatusChanges",
-      listenerCreator: fetchRecordsListenerCreator
+      listenerCreator: fetchRecordsListenerCreator,
     },
     {
       id: "pi/proposals/billingStatusChanges",
-      listenerCreator: fetchBillingStatusChangesListenerCreator
+      listenerCreator: fetchBillingStatusChangesListenerCreator,
     },
     // Rfp Sumbissions
     {
       id: "records/batch/all",
-      listenerCreator: fetchRecordsRfpSubmissionsListenerCreator
-    }
+      listenerCreator: fetchRecordsRfpSubmissionsListenerCreator,
+    },
   ],
   listeners,
   cleanup: routeCleanup,
   view: createRouteView(
     lazy(() => import(/* webpackChunkName: "home_page" */ "./Home"))
-  )
+  ),
 });

--- a/plugins-structure/apps/politeia/src/pages/New/index.js
+++ b/plugins-structure/apps/politeia/src/pages/New/index.js
@@ -1,11 +1,13 @@
+import { lazy } from "react";
 import App from "../../app";
 import { routeCleanup } from "../../utils/routeCleanup";
 import { createRouteView } from "../../utils/createRouteView";
-import New from "./New";
 
 export default App.createRoute({
   path: "/record/new",
   setupServices: [{ id: "pi/new" }],
   cleanup: routeCleanup,
-  view: createRouteView(New),
+  view: createRouteView(
+    lazy(() => import(/* webpackChunkName: "new_proposal_page" */ "./New"))
+  )
 });

--- a/plugins-structure/apps/politeia/src/pages/New/index.js
+++ b/plugins-structure/apps/politeia/src/pages/New/index.js
@@ -9,5 +9,5 @@ export default App.createRoute({
   cleanup: routeCleanup,
   view: createRouteView(
     lazy(() => import(/* webpackChunkName: "new_proposal_page" */ "./New"))
-  )
+  ),
 });

--- a/plugins-structure/apps/politeia/src/utils/createRouteView.js
+++ b/plugins-structure/apps/politeia/src/utils/createRouteView.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Suspense } from "react";
 import ReactDOM from "react-dom";
 import { store } from "@politeiagui/core";
 import { Provider } from "react-redux";
@@ -11,7 +11,9 @@ export function createRouteView(Component) {
       <Provider store={store}>
         <ModalProvider>
           <UiTheme>
-            <Component {...params} />
+            <Suspense fallback={React.Component}>
+              <Component {...params} />
+            </Suspense>
           </UiTheme>
         </ModalProvider>
       </Provider>,

--- a/plugins-structure/package.json
+++ b/plugins-structure/package.json
@@ -23,7 +23,7 @@
     "@babel/runtime": "^7.15.3",
     "@reduxjs/toolkit": "^1.8.3",
     "lodash": "^4.17.21",
-    "pi-ui": "decred/pi-ui#v1.1.0",
+    "pi-ui": "https://github.com/decred/pi-ui",
     "prop-types": "15.8.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/plugins-structure/package.json
+++ b/plugins-structure/package.json
@@ -23,7 +23,7 @@
     "@babel/runtime": "^7.15.3",
     "@reduxjs/toolkit": "^1.8.3",
     "lodash": "^4.17.21",
-    "pi-ui": "https://github.com/decred/pi-ui",
+    "pi-ui": "decred/pi-ui#v1.1.0",
     "prop-types": "15.8.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/plugins-structure/packages/politeiagui-scripts/config/webpack/webpack.config.js
+++ b/plugins-structure/packages/politeiagui-scripts/config/webpack/webpack.config.js
@@ -1,3 +1,4 @@
+const CompressionPlugin = require("compression-webpack-plugin");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 
 const { resolveApp, resolveOwn } = require("../../utils");
@@ -5,14 +6,18 @@ const plugins = (isEnvDevelopment, isApp) =>
   isApp
     ? [
         new HtmlWebpackPlugin({
-          template: resolveApp("./src/public/index.html"),
+          template: resolveApp("./src/public/index.html")
         }),
+        new CompressionPlugin({
+          algorithm: "gzip",
+          test: /\.js(\?.*)?$/i
+        })
       ]
     : isEnvDevelopment
     ? [
         new HtmlWebpackPlugin({
-          template: resolveApp("./src/dev/index.html"),
-        }),
+          template: resolveApp("./src/dev/index.html")
+        })
       ]
     : [];
 
@@ -25,9 +30,9 @@ const jsRules = [
     exclude: /node_modules/,
     options: {
       presets: ["@babel/preset-env", "@babel/preset-react"],
-      plugins: ["@babel/plugin-transform-runtime"],
-    },
-  },
+      plugins: ["@babel/plugin-transform-runtime"]
+    }
+  }
 ];
 
 const cssRules = [
@@ -38,33 +43,33 @@ const cssRules = [
       {
         loader: "css-loader",
         options: {
-          importLoaders: 1,
-        },
+          importLoaders: 1
+        }
       },
       {
         loader: "postcss-loader",
         options: {
           postcssOptions: {
-            config: resolveOwn("./config/postcss/postcss.config.js"),
-          },
-        },
-      },
-    ],
-  },
+            config: resolveOwn("./config/postcss/postcss.config.js")
+          }
+        }
+      }
+    ]
+  }
 ];
 
 const markdownRules = [
   {
     test: /\.md$/,
-    use: "raw-loader",
-  },
+    use: "raw-loader"
+  }
 ];
 
 const svgRules = [
   {
     test: /\.svg$/,
-    use: ["@svgr/webpack"],
-  },
+    use: ["@svgr/webpack"]
+  }
 ];
 
 module.exports = function (webpackEnv = "production", type = "app") {
@@ -81,23 +86,43 @@ module.exports = function (webpackEnv = "production", type = "app") {
     bail: !isEnvDevelopment,
     devtool: isEnvDevelopment ? "cheap-module-source-map" : "source-map",
     mode: isEnvDevelopment ? "development" : "production",
+    optimization: {
+      moduleIds: "deterministic",
+      runtimeChunk: "single",
+      splitChunks: {
+        cacheGroups: {
+          vendors: {
+            test: /node_modules\/(?!pi-ui\/).*/,
+            name: "vendors",
+            chunks: "all"
+          },
+          // This can be your own design library.
+          "pi-ui": {
+            test: /node_modules\/(pi-ui\/).*/,
+            name: "pi-ui",
+            chunks: "all"
+          }
+        }
+      }
+    },
     output: {
       publicPath: "/",
       path: resolveApp("./dist"),
+      filename: "[name].[chunkhash].bundle.js",
       library: {
         name: pkgName + ".js",
-        type: "umd",
+        type: "umd"
       },
-      clean: true,
+      clean: true
     },
     module: {
-      rules: [...jsRules, ...cssRules, ...markdownRules, ...svgRules],
+      rules: [...jsRules, ...cssRules, ...markdownRules, ...svgRules]
     },
     resolve: {
       fallback: {
         crypto: require.resolve("crypto-browserify"),
-        stream: require.resolve("stream-browserify"),
-      },
+        stream: require.resolve("stream-browserify")
+      }
     },
     // Uncomment to see postcss-loader warnings
     // TODO: Remove when the new solution is implemented and warning is removed
@@ -107,9 +132,9 @@ module.exports = function (webpackEnv = "production", type = "app") {
     // Visit the discussion on github for more details. https://github.com/csstools/postcss-plugins/discussions/192
     ignoreWarnings: [
       {
-        module: /postcss-loader\/dist\/cjs\.js/,
-      },
+        module: /postcss-loader\/dist\/cjs\.js/
+      }
     ],
-    plugins: plugins(isEnvDevelopment, isApp),
+    plugins: plugins(isEnvDevelopment, isApp)
   };
 };

--- a/plugins-structure/packages/politeiagui-scripts/config/webpack/webpack.config.js
+++ b/plugins-structure/packages/politeiagui-scripts/config/webpack/webpack.config.js
@@ -6,18 +6,18 @@ const plugins = (isEnvDevelopment, isApp) =>
   isApp
     ? [
         new HtmlWebpackPlugin({
-          template: resolveApp("./src/public/index.html")
+          template: resolveApp("./src/public/index.html"),
         }),
         new CompressionPlugin({
           algorithm: "gzip",
-          test: /\.js(\?.*)?$/i
-        })
+          test: /\.js(\?.*)?$/i,
+        }),
       ]
     : isEnvDevelopment
     ? [
         new HtmlWebpackPlugin({
-          template: resolveApp("./src/dev/index.html")
-        })
+          template: resolveApp("./src/dev/index.html"),
+        }),
       ]
     : [];
 
@@ -30,9 +30,9 @@ const jsRules = [
     exclude: /node_modules/,
     options: {
       presets: ["@babel/preset-env", "@babel/preset-react"],
-      plugins: ["@babel/plugin-transform-runtime"]
-    }
-  }
+      plugins: ["@babel/plugin-transform-runtime"],
+    },
+  },
 ];
 
 const cssRules = [
@@ -43,33 +43,33 @@ const cssRules = [
       {
         loader: "css-loader",
         options: {
-          importLoaders: 1
-        }
+          importLoaders: 1,
+        },
       },
       {
         loader: "postcss-loader",
         options: {
           postcssOptions: {
-            config: resolveOwn("./config/postcss/postcss.config.js")
-          }
-        }
-      }
-    ]
-  }
+            config: resolveOwn("./config/postcss/postcss.config.js"),
+          },
+        },
+      },
+    ],
+  },
 ];
 
 const markdownRules = [
   {
     test: /\.md$/,
-    use: "raw-loader"
-  }
+    use: "raw-loader",
+  },
 ];
 
 const svgRules = [
   {
     test: /\.svg$/,
-    use: ["@svgr/webpack"]
-  }
+    use: ["@svgr/webpack"],
+  },
 ];
 
 module.exports = function (webpackEnv = "production", type = "app") {
@@ -94,16 +94,16 @@ module.exports = function (webpackEnv = "production", type = "app") {
           vendors: {
             test: /node_modules\/(?!pi-ui\/).*/,
             name: "vendors",
-            chunks: "all"
+            chunks: "all",
           },
           // This can be your own design library.
           "pi-ui": {
             test: /node_modules\/(pi-ui\/).*/,
             name: "pi-ui",
-            chunks: "all"
-          }
-        }
-      }
+            chunks: "all",
+          },
+        },
+      },
     },
     output: {
       publicPath: "/",
@@ -111,18 +111,18 @@ module.exports = function (webpackEnv = "production", type = "app") {
       filename: "[name].[chunkhash].bundle.js",
       library: {
         name: pkgName + ".js",
-        type: "umd"
+        type: "umd",
       },
-      clean: true
+      clean: true,
     },
     module: {
-      rules: [...jsRules, ...cssRules, ...markdownRules, ...svgRules]
+      rules: [...jsRules, ...cssRules, ...markdownRules, ...svgRules],
     },
     resolve: {
       fallback: {
         crypto: require.resolve("crypto-browserify"),
-        stream: require.resolve("stream-browserify")
-      }
+        stream: require.resolve("stream-browserify"),
+      },
     },
     // Uncomment to see postcss-loader warnings
     // TODO: Remove when the new solution is implemented and warning is removed
@@ -132,9 +132,9 @@ module.exports = function (webpackEnv = "production", type = "app") {
     // Visit the discussion on github for more details. https://github.com/csstools/postcss-plugins/discussions/192
     ignoreWarnings: [
       {
-        module: /postcss-loader\/dist\/cjs\.js/
-      }
+        module: /postcss-loader\/dist\/cjs\.js/,
+      },
     ],
-    plugins: plugins(isEnvDevelopment, isApp)
+    plugins: plugins(isEnvDevelopment, isApp),
   };
 };

--- a/plugins-structure/packages/politeiagui-scripts/package.json
+++ b/plugins-structure/packages/politeiagui-scripts/package.json
@@ -35,6 +35,7 @@
     "babel-jest": "^27.0.6",
     "babel-loader": "^8.2.2",
     "babel-plugin-module-resolver": "^4.1.0",
+    "compression-webpack-plugin": "^10.0.0",
     "css-loader": "^6.5.1",
     "cypress": "^10.4.0",
     "eslint": "^7.5.0",

--- a/plugins-structure/yarn.lock
+++ b/plugins-structure/yarn.lock
@@ -2250,6 +2250,18 @@
   resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-7.3.0.tgz#a508df35ded585c4e071cb5d9d7c89623c837fae"
   integrity sha512-1W0PZezq2rxlAssoWemi9gFRD8IQxvf0FPL5Km3TOmGHFG7ib0TbFBJ0yC7D/1NsxunjNTK6WjUXV8ao/mKZ5w==
 
+"@floating-ui/core@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.0.1.tgz#00e64d74e911602c8533957af0cce5af6b2e93c8"
+  integrity sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA==
+
+"@floating-ui/dom@^1.0.1":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.0.3.tgz#b439c8a66436c2cae8d97e889f0b76cce757a6ec"
+  integrity sha512-6H1kwjkOZKabApNtXRiYHvMmYJToJ1DV7rQ3xc/WJpOABhQIOJJOdz2AOejj8X+gcybaFmBpisVTZxBZAM3V0w==
+  dependencies:
+    "@floating-ui/core" "^1.0.1"
+
 "@hapi/hoek@^9.0.0":
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.3.0.tgz#8368869dcb735be2e7f5cb7647de78e167a251fb"
@@ -9487,10 +9499,10 @@ memfs@^3.4.3:
   dependencies:
     fs-monkey "^1.0.3"
 
-memoize-one@^5.0.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
-  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
+memoize-one@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-6.0.0.tgz#b2591b871ed82948aee4727dc6abceeeac8c1045"
+  integrity sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==
 
 meow@^7.0.0:
   version "7.1.1"
@@ -10606,14 +10618,14 @@ performance-now@^2.1.0:
 
 "pi-ui@https://github.com/decred/pi-ui":
   version "1.0.0"
-  resolved "https://github.com/decred/pi-ui#8d54b8070a72f974ea8730e279add4290370c4f2"
+  resolved "https://github.com/decred/pi-ui#abd999b620b1a08d2c3591975e32e0848178042d"
   dependencies:
     clamp-js-main "^0.11.5"
     lodash "^4.17.15"
     prop-types "^15.8.1"
-    react-select "^5.2.1"
-    react-select-event "^5.5.0"
-    react-spring "^9.4.5"
+    react-select "^5.4.0"
+    react-select-event "^5.5.1"
+    react-spring "^9.5.5"
     react-tapper "^0.1.23"
 
 picocolors@^1.0.0:
@@ -11354,27 +11366,29 @@ react-redux@^7.2.4:
     prop-types "^15.7.2"
     react-is "^16.13.1"
 
-react-select-event@^5.5.0:
+react-select-event@^5.5.1:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/react-select-event/-/react-select-event-5.5.1.tgz#d67e04a6a51428b1534b15ecb1b82afbe5edddcb"
   integrity sha512-goAx28y0+iYrbqZA2FeRTreHHs/ZtSuKxtA+J5jpKT5RHPCbVZJ4MqACfPnWyFXsEec+3dP5bCrNTxIX8oYe9A==
   dependencies:
     "@testing-library/dom" ">=7"
 
-react-select@^5.2.1:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.4.0.tgz#81f6ac73906126706f104751ee14437bd16798f4"
-  integrity sha512-CjE9RFLUvChd5SdlfG4vqxZd55AZJRrLrHzkQyTYeHlpOztqcgnyftYAolJ0SGsBev6zAs6qFrjm6KU3eo2hzg==
+react-select@^5.4.0:
+  version "5.5.4"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.5.4.tgz#da05b8b66d33f6fc1f92fdccd0fa50d7f4418554"
+  integrity sha512-lyr19joBUm/CNJgjZMBSnFvJ/MeHCmBYvQ050qYAP3EPa7Oenlnx9guhU+SW0goYgxLQyqwRvkFllQpFAp8tmQ==
   dependencies:
     "@babel/runtime" "^7.12.0"
     "@emotion/cache" "^11.4.0"
     "@emotion/react" "^11.8.1"
+    "@floating-ui/dom" "^1.0.1"
     "@types/react-transition-group" "^4.4.0"
-    memoize-one "^5.0.0"
+    memoize-one "^6.0.0"
     prop-types "^15.6.0"
     react-transition-group "^4.3.0"
+    use-isomorphic-layout-effect "^1.1.2"
 
-react-spring@^9.4.5:
+react-spring@^9.5.5:
   version "9.5.5"
   resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-9.5.5.tgz#314009a65efc04d0ef157d3d60590dbb9de65f3c"
   integrity sha512-vMGVd2yjgxWcRCzoLn9AD1d24+WpunHBRg5DoehcRdiBocaOH6qgle0xN9C5LPplXfv4yIpS5QWGN5MKrWxSZg==
@@ -13203,6 +13217,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+use-isomorphic-layout-effect@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz#497cefb13d863d687b08477d9e5a164ad8c1a6fb"
+  integrity sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"

--- a/plugins-structure/yarn.lock
+++ b/plugins-structure/yarn.lock
@@ -5589,6 +5589,14 @@ compressible@~2.0.16:
   dependencies:
     mime-db ">= 1.43.0 < 2"
 
+compression-webpack-plugin@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/compression-webpack-plugin/-/compression-webpack-plugin-10.0.0.tgz#3496af1b0dc792e13efc474498838dbff915c823"
+  integrity sha512-wLXLIBwpul/ALcm7Aj+69X0pYT3BYt6DdPn3qrgBIh9YejV9Bju9ShhlAsjujLyWMo6SAweFIWaUoFmXZNuNrg==
+  dependencies:
+    schema-utils "^4.0.0"
+    serialize-javascript "^6.0.0"
+
 compression@^1.7.4:
   version "1.7.4"
   resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.4.tgz#95523eff170ca57c29a0ca41e6fe131f41e5bb8f"

--- a/plugins-structure/yarn.lock
+++ b/plugins-structure/yarn.lock
@@ -10604,9 +10604,9 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-pi-ui@decred/pi-ui#v1.1.0:
+"pi-ui@https://github.com/decred/pi-ui":
   version "1.1.0"
-  resolved "https://codeload.github.com/decred/pi-ui/tar.gz/6a024e4769ae1508f1c5e7a19f75d4a287a13467"
+  resolved "https://github.com/decred/pi-ui#6a024e4769ae1508f1c5e7a19f75d4a287a13467"
   dependencies:
     clamp-js-main "^0.11.5"
     lodash "^4.17.15"

--- a/plugins-structure/yarn.lock
+++ b/plugins-structure/yarn.lock
@@ -2250,18 +2250,6 @@
   resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-7.3.0.tgz#a508df35ded585c4e071cb5d9d7c89623c837fae"
   integrity sha512-1W0PZezq2rxlAssoWemi9gFRD8IQxvf0FPL5Km3TOmGHFG7ib0TbFBJ0yC7D/1NsxunjNTK6WjUXV8ao/mKZ5w==
 
-"@floating-ui/core@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.0.1.tgz#00e64d74e911602c8533957af0cce5af6b2e93c8"
-  integrity sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA==
-
-"@floating-ui/dom@^1.0.1":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.0.3.tgz#b439c8a66436c2cae8d97e889f0b76cce757a6ec"
-  integrity sha512-6H1kwjkOZKabApNtXRiYHvMmYJToJ1DV7rQ3xc/WJpOABhQIOJJOdz2AOejj8X+gcybaFmBpisVTZxBZAM3V0w==
-  dependencies:
-    "@floating-ui/core" "^1.0.1"
-
 "@hapi/hoek@^9.0.0":
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.3.0.tgz#8368869dcb735be2e7f5cb7647de78e167a251fb"
@@ -9499,10 +9487,10 @@ memfs@^3.4.3:
   dependencies:
     fs-monkey "^1.0.3"
 
-memoize-one@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-6.0.0.tgz#b2591b871ed82948aee4727dc6abceeeac8c1045"
-  integrity sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==
+memoize-one@^5.0.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
+  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
 
 meow@^7.0.0:
   version "7.1.1"
@@ -10616,14 +10604,14 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-"pi-ui@https://github.com/decred/pi-ui":
-  version "1.0.0"
-  resolved "https://github.com/decred/pi-ui#abd999b620b1a08d2c3591975e32e0848178042d"
+pi-ui@decred/pi-ui#v1.1.0:
+  version "1.1.0"
+  resolved "https://codeload.github.com/decred/pi-ui/tar.gz/6a024e4769ae1508f1c5e7a19f75d4a287a13467"
   dependencies:
     clamp-js-main "^0.11.5"
     lodash "^4.17.15"
     prop-types "^15.8.1"
-    react-select "^5.4.0"
+    react-select "5.4.0"
     react-select-event "^5.5.1"
     react-spring "^9.5.5"
     react-tapper "^0.1.23"
@@ -11373,20 +11361,18 @@ react-select-event@^5.5.1:
   dependencies:
     "@testing-library/dom" ">=7"
 
-react-select@^5.4.0:
-  version "5.5.4"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.5.4.tgz#da05b8b66d33f6fc1f92fdccd0fa50d7f4418554"
-  integrity sha512-lyr19joBUm/CNJgjZMBSnFvJ/MeHCmBYvQ050qYAP3EPa7Oenlnx9guhU+SW0goYgxLQyqwRvkFllQpFAp8tmQ==
+react-select@5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.4.0.tgz#81f6ac73906126706f104751ee14437bd16798f4"
+  integrity sha512-CjE9RFLUvChd5SdlfG4vqxZd55AZJRrLrHzkQyTYeHlpOztqcgnyftYAolJ0SGsBev6zAs6qFrjm6KU3eo2hzg==
   dependencies:
     "@babel/runtime" "^7.12.0"
     "@emotion/cache" "^11.4.0"
     "@emotion/react" "^11.8.1"
-    "@floating-ui/dom" "^1.0.1"
     "@types/react-transition-group" "^4.4.0"
-    memoize-one "^6.0.0"
+    memoize-one "^5.0.0"
     prop-types "^15.6.0"
     react-transition-group "^4.3.0"
-    use-isomorphic-layout-effect "^1.1.2"
 
 react-spring@^9.5.5:
   version "9.5.5"
@@ -13217,11 +13203,6 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
-
-use-isomorphic-layout-effect@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz#497cefb13d863d687b08477d9e5a164ad8c1a6fb"
-  integrity sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Depends on https://github.com/decred/pi-ui/pull/466

- Lazy load routes (this separate routes in different chunks)
- Split pi-ui from vendors chunk (since pi-ui is a UI lib and can change frequently so we cache it separately)
- Cache vendors and pi-ui
- Gzip

Bundle size before (1.5Mb):

<img width="1280" alt="Screen Shot 2022-10-22 at 17 49 32" src="https://user-images.githubusercontent.com/13955303/197600365-743ab56d-acbe-42c2-8441-42d3832f7dfe.png">

Bundle size after (482Kb gziped):

<img width="1280" alt="Screen Shot 2022-10-24 at 14 11 36" src="https://user-images.githubusercontent.com/13955303/197600410-5918225d-7941-4082-9fbe-af0034eb66cb.png">
