### PR TITLE
fix(app/pi): app startup error + lint fixes

### DIFF
--- a/plugins-structure/apps/politeia/src/index.js
+++ b/plugins-structure/apps/politeia/src/index.js
@@ -6,14 +6,13 @@ import { store } from "@politeiagui/core";
 import { UiTheme } from "@politeiagui/common-ui/layout";
 import { ProgressBar, Toast } from "@politeiagui/common-ui";
 // Components
-import { Header, Error } from "./components";
+import { Error, Header } from "./components";
 // App
 import App from "./app";
 import { routes } from "./routes";
 import ErrorView from "./pages/Error";
 
 try {
-  await App.init({ routes, errorView: ErrorView });
   ReactDOM.render(
     <Provider store={store}>
       <UiTheme>
@@ -25,6 +24,7 @@ try {
     </Provider>,
     document.querySelector("#app-root")
   );
+  await App.init({ routes, errorView: ErrorView });
 } catch (e) {
   ReactDOM.render(<Error error={e} />, document.querySelector("#app-root"));
 }


### PR DESCRIPTION
This PR fixes the following error caused by the absence of the 
`#root` element when app routes are initialized:

![image](https://user-images.githubusercontent.com/22639213/198362698-d14326ec-ef11-4a1f-8aea-4c6be69fc6cb.png)