### PR TITLE
fix(multi): core API error fixes + E2E tests fixes

### DIFF
--- a/plugins-structure/apps/politeia/cypress/e2e/app.cy.js
+++ b/plugins-structure/apps/politeia/cypress/e2e/app.cy.js
@@ -1,0 +1,23 @@
+function errorMock() {
+  return {
+    errorcode: 1658261424,
+  };
+}
+describe("Given failed app startup", () => {
+  it("should display correct message when server returns an error", () => {
+    cy.mockResponse("/api", errorMock, { statusCode: 500 });
+    cy.visit("/");
+    cy.findByTestId("politeia-error-message").should(
+      "include.text",
+      1658261424
+    );
+  });
+  it("should display correct message when response error has no body", () => {
+    cy.mockResponse("/api", () => {}, { statusCode: 400 });
+    cy.visit("/");
+    cy.findByTestId("politeia-error-message").should(
+      "include.text",
+      "Is politeiawww running?"
+    );
+  });
+});

--- a/plugins-structure/apps/politeia/cypress/e2e/pageHome.cy.js
+++ b/plugins-structure/apps/politeia/cypress/e2e/pageHome.cy.js
@@ -1,6 +1,7 @@
 import {
   mockTicketvoteInventory,
   mockTicketvoteSummaries,
+  ticketvoteSummariesByStatus,
 } from "@politeiagui/ticketvote/dev/mocks";
 import { mockCommentsCount } from "@politeiagui/comments/dev/mocks";
 import { mockRecordsBatch } from "@politeiagui/core/dev/mocks";
@@ -21,11 +22,13 @@ Cypress.Commands.add("mockInventory", (amount, matcherParams = {}) =>
   )
 );
 
-Cypress.Commands.add("mockVoteSummaries", (status, matcherParams = {}) =>
-  cy.mockResponse(
-    { url: "/api/ticketvote/v1/summaries", ...matcherParams },
-    mockTicketvoteSummaries({ status })
-  )
+Cypress.Commands.add(
+  "mockVoteSummaries",
+  (status = "unauthorized", matcherParams = {}) =>
+    cy.mockResponse(
+      { url: "/api/ticketvote/v1/summaries", ...matcherParams },
+      mockTicketvoteSummaries(ticketvoteSummariesByStatus[status])
+    )
 );
 
 Cypress.Commands.add("mockPiSummaries", (status, matcherParams = {}) =>
@@ -139,17 +142,17 @@ describe("Given Home Under Review tab", () => {
     it("should load all proposals from list", () => {
       // Orders are reverse due to intercept stack behavior (FILO).
       // 25 Unauthorized.
-      cy.mockVoteSummaries(1).as("summaries");
+      cy.mockVoteSummaries("unauthorized").as("summaries");
       cy.mockPiSummaries("under-review").as("piSummaries");
       cy.mockInventory(5).as("unauthorized");
       cy.mockInventory(20, { times: 1 }).as("unauthorized");
       // 25 Authorized.
-      cy.mockVoteSummaries(2, { times: 5 }).as("summaries");
+      cy.mockVoteSummaries("authorized", { times: 5 }).as("summaries");
       cy.mockPiSummaries("vote-authorized", { times: 5 }).as("piSummaries");
       cy.mockInventory(5, { times: 1 }).as("authorized");
       cy.mockInventory(20, { times: 1 }).as("authorized");
       // 25 Started.
-      cy.mockVoteSummaries(3, { times: 5 }).as("summaries");
+      cy.mockVoteSummaries("started", { times: 5 }).as("summaries");
       cy.mockPiSummaries("vote-started", { times: 5 }).as("piSummaries");
       cy.mockInventory(5, { times: 1 }).as("started");
       cy.mockInventory(20, { times: 1 }).as("started");
@@ -181,15 +184,15 @@ describe("Given Home Under Review tab", () => {
     it("should load all proposals from list", () => {
       // Orders are reverse due to intercept stack behavior (FILO).
       // 10 Unauthorized.
-      cy.mockVoteSummaries(1).as("summaries");
+      cy.mockVoteSummaries("unauthorized").as("summaries");
       cy.mockPiSummaries("under-review").as("piSummaries");
       cy.mockInventory(10).as("unauthorized");
       // 10 Authorized.
-      cy.mockVoteSummaries(2, { times: 2 }).as("summaries");
+      cy.mockVoteSummaries("authorized", { times: 2 }).as("summaries");
       cy.mockPiSummaries("vote-authorized", { times: 1 }).as("piSummaries");
       cy.mockInventory(10, { times: 1 }).as("authorized");
       // 10 Started.
-      cy.mockVoteSummaries(3, { times: 2 }).as("summaries");
+      cy.mockVoteSummaries("started", { times: 2 }).as("summaries");
       cy.mockPiSummaries("vote-started", { times: 2 }).as("piSummaries");
       cy.mockInventory(10, { times: 1 }).as("started");
       // Begin tests.
@@ -219,12 +222,12 @@ describe("Given Home Under Review tab", () => {
     it("should load all proposals from list", () => {
       // Orders are reverse due to intercept stack behavior (FILO).
       // 25 Unauthorized.
-      cy.mockVoteSummaries(1).as("summaries");
+      cy.mockVoteSummaries("unauthorized").as("summaries");
       cy.mockPiSummaries("under-review").as("piSummaries");
       cy.mockInventory(5).as("unauthorized");
       cy.mockInventory(20, { times: 1 }).as("unauthorized");
       // 25 Authorized.
-      cy.mockVoteSummaries(2, { times: 5 }).as("summaries");
+      cy.mockVoteSummaries("authorized", { times: 5 }).as("summaries");
       cy.mockPiSummaries("vote-authorized", { times: 5 }).as("piSummaries");
       cy.mockInventory(5, { times: 1 }).as("authorized");
       cy.mockInventory(20, { times: 1 }).as("authorized");
@@ -256,11 +259,11 @@ describe("Given Home Under Review tab", () => {
   describe("when 0 started, 10 authorized, 25 unauthorized", () => {
     it("should load all proposals from list", () => {
       // 25 Unauthorized.
-      cy.mockVoteSummaries(1).as("summaries");
+      cy.mockVoteSummaries("unauthorized").as("summaries");
       cy.mockInventory(5).as("unauthorized");
       cy.mockInventory(20, { times: 1 }).as("unauthorized");
       // 10 Authorized.
-      cy.mockVoteSummaries(2, { times: 2 }).as("summaries");
+      cy.mockVoteSummaries("authorized", { times: 2 }).as("summaries");
       cy.mockPiSummaries("vote-authorized", { times: 2 }).as("piSummaries");
       cy.mockInventory(10, { times: 1 }).as("authorized");
       // 0 Started.
@@ -292,7 +295,7 @@ describe("Given Home Under Review tab", () => {
     it("should load all proposals from list", () => {
       // Orders are reverse due to intercept stack behavior (FILO).
       // 5 Unauthorized.
-      cy.mockVoteSummaries(1).as("summaries");
+      cy.mockVoteSummaries("unauthorized").as("summaries");
       cy.mockInventory(5).as("unauthorized");
       cy.mockInventory(20, { times: 1 }).as("unauthorized");
       // 0 Authorized.
@@ -325,7 +328,7 @@ describe("Given Home Under Review tab", () => {
     it("should load all proposals from list", () => {
       // Orders are reverse due to intercept stack behavior (FILO).
       // 10 Unauthorized.
-      cy.mockVoteSummaries(1).as("summaries");
+      cy.mockVoteSummaries("unauthorized").as("summaries");
       cy.mockInventory(10).as("unauthorized");
       // 0 Authorized.
       cy.mockInventory(0, { times: 1 }).as("authorized");
@@ -374,7 +377,7 @@ describe("Given Home single status tab (approved, rejected or abandoned)", () =>
   });
   describe("when on Approved tab", () => {
     it("should render all Approved proposals", () => {
-      cy.mockVoteSummaries(5).as("summaries");
+      cy.mockVoteSummaries("approved").as("summaries");
       cy.mockResponse(
         { url: "/api/pi/v1/billingstatuschanges" },
         mockPiBillingStatusChanges({ status: 3 })
@@ -393,14 +396,14 @@ describe("Given Home single status tab (approved, rejected or abandoned)", () =>
   });
   describe("when on Rejected tab", () => {
     it("should render all Rejected proposals", () => {
-      cy.mockVoteSummaries(6).as("summaries");
+      cy.mockVoteSummaries("rejected").as("summaries");
       cy.visit("/?tab=Rejected");
       cy.wait("@records");
     });
   });
   describe("when on Abandoned tab", () => {
     it("should render all Abandoned proposals", () => {
-      cy.mockVoteSummaries(7).as("summaries");
+      cy.mockVoteSummaries("ineligible").as("summaries");
       cy.visit("/?tab=Abandoned");
       cy.wait("@records");
     });
@@ -417,6 +420,7 @@ describe("Given RFP Proposals and Submissions", () => {
       )
     ).as("records");
     cy.visit("/");
+    cy.wait("@records");
     cy.findAllByTestId("proposal-rfp-tag").should("have.length", 4);
     cy.findAllByTestId("proposal-date-expire").should("have.length", 4);
     cy.assertProposalsListLength(4);
@@ -428,6 +432,7 @@ describe("Given RFP Proposals and Submissions", () => {
       mockRecordsBatch(mockProposal({ state: 2, status: 2, linkto: "abcdefg" }))
     ).as("records");
     cy.visit("/");
+    cy.wait(["@records", "@records"]);
     cy.findAllByTestId("proposal-rfp-link").should("have.length", 4);
     cy.assertProposalsListLength(4);
   });

--- a/plugins-structure/apps/politeia/src/components/Error/Error.js
+++ b/plugins-structure/apps/politeia/src/components/Error/Error.js
@@ -5,7 +5,9 @@ function Error({ error }) {
   return (
     error && (
       <StaticContainer style={{ marginTop: "3rem" }}>
-        <Message kind="error">{error.toString()}</Message>
+        <Message kind="error" data-testid="politeia-error-message">
+          {error.toString()}
+        </Message>
       </StaticContainer>
     )
   );

--- a/plugins-structure/packages/core/src/api/apiSlice.js
+++ b/plugins-structure/packages/core/src/api/apiSlice.js
@@ -2,6 +2,7 @@
 // createAsyncThunk gnerate thunks that automatically dispatch
 // start/success/failure actions
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import { getApiErrorMessage } from "./errors";
 
 // Possible status: 'idle' | 'loading' | 'succeeded' | 'failed'
 // Possible error types: string | null
@@ -15,7 +16,14 @@ export const initialState = {
 // Thunks
 export const fetchApi = createAsyncThunk(
   "api/fetch",
-  async (_, { extra }) => await extra.fetchApi()
+  async (_, { extra, rejectWithValue }) => {
+    try {
+      return await extra.fetchApi();
+    } catch (error) {
+      const message = getApiErrorMessage(error.body, error.message);
+      throw rejectWithValue(message);
+    }
+  }
 );
 
 // Reducer
@@ -35,9 +43,9 @@ const apiSlice = createSlice({
         // Assign csrf return to the state
         state.csrf = action.payload.csrf;
       })
-      .addCase(fetchApi.rejected, (state) => {
+      .addCase(fetchApi.rejected, (state, action) => {
         state.status = "failed";
-        state.error = "Cannot fetch `/api`. Is politeiawww running?";
+        state.error = action.payload;
       });
   },
 });

--- a/plugins-structure/packages/core/src/api/errors.js
+++ b/plugins-structure/packages/core/src/api/errors.js
@@ -1,0 +1,17 @@
+import { getDefaultErrorMessage } from "../client";
+
+function getApiUserError(code) {
+  const errorMap = {
+    // TODO: fill API user error codes correctly when user layer gets
+    // implemented on backend
+  };
+
+  return errorMap[code] || getDefaultErrorMessage(code, "");
+}
+
+export function getApiErrorMessage({ errorcode } = {}, defaultMessage) {
+  if (!errorcode) {
+    return defaultMessage;
+  }
+  return getApiUserError(errorcode);
+}


### PR DESCRIPTION
This PR fixes some errors on politeia app e2e tests. While fixing those
errors, I noticed that some API errors were being handled incorrectly,
due to an incorrect variable usage, which were causing tests to fail.

Before:
<img width="1000" alt="Screen Shot 2022-11-01 at 8 42 32 PM" src="https://user-images.githubusercontent.com/22639213/199362419-8885ae73-389c-46be-acb9-a44bc5a5c763.png">

After:
<img width="1002" alt="Screen Shot 2022-11-01 at 8 46 33 PM" src="https://user-images.githubusercontent.com/22639213/199362792-c51c9db1-390e-4aad-b0dc-c6adbc46f392.png">

I also added some e2e tests for app startup errors, which asserts that
`/api` errors are displayed correctly. Once server returns an error, we
should also display the error codes. However, if no response body is
returned, we should display the generic `Cannot fetch "${url}". Is politeiawww running?`
message.

<img width="1000" alt="Screen Shot 2022-11-01 at 8 51 48 PM" src="https://user-images.githubusercontent.com/22639213/199363281-e50f6a7a-4dfc-4f5d-95a4-180d161e7d40.png">
<img width="1002" alt="Screen Shot 2022-11-01 at 8 52 09 PM" src="https://user-images.githubusercontent.com/22639213/199363304-c5c7dc0e-190b-4862-a38b-8c2ff432acd5.png">
