### PR TITLE
test(core): fix failing createSliceServices tests

### DIFF
--- a/plugins-structure/packages/core/src/toolkit/createSliceServices.test.js
+++ b/plugins-structure/packages/core/src/toolkit/createSliceServices.test.js
@@ -9,7 +9,7 @@ const validServices = {
 
 describe("Given createSliceService tool", () => {
   it("should create slices services correctly", () => {
-    const { pluginServices, setups } = createSliceServices({
+    const { pluginServices, serviceSetups } = createSliceServices({
       name: "test",
       services: validServices,
     });
@@ -17,29 +17,35 @@ describe("Given createSliceService tool", () => {
     expect(pluginServices).toHaveLength(1);
     expect(pluginServices[0]).toHaveProperty("id", "test/foo");
     // Services Setups
-    expect(setups).toHaveProperty("foo");
-    expect(setups.foo).toHaveProperty("id", "test/foo");
-    expect(setups.foo).toHaveProperty("listenTo");
+    expect(serviceSetups).toHaveProperty("foo");
+    expect(serviceSetups.foo).toHaveProperty("id", "test/foo");
+    expect(serviceSetups.foo).toHaveProperty("listenTo");
   });
   it("should be able to setup listeners and effects", () => {
-    const { setups } = createSliceServices({
+    const { serviceSetups } = createSliceServices({
       name: "test",
       services: validServices,
     });
     // Listeners
-    expect(setups.foo.listenTo({ type: "action/foo" })).toHaveProperty(
+    expect(serviceSetups.foo.listenTo({ type: "action/foo" })).toHaveProperty(
       "listenerCreator"
     );
-    expect(setups.foo.listenTo({ type: "action/foo" })).toHaveProperty("id");
-    expect(setups.foo.listenTo({ type: "action/foo" })).toHaveProperty(
+    expect(serviceSetups.foo.listenTo({ type: "action/foo" })).toHaveProperty(
+      "id"
+    );
+    expect(serviceSetups.foo.listenTo({ type: "action/foo" })).toHaveProperty(
       "customizeEffect"
     );
     // Customize effect
     expect(
-      setups.foo.listenTo({ type: "action/foo" }).customizeEffect(() => {})
+      serviceSetups.foo
+        .listenTo({ type: "action/foo" })
+        .customizeEffect(() => {})
     ).toHaveProperty("listenerCreator");
     expect(
-      setups.foo.listenTo({ type: "action/foo" }).customizeEffect(() => {})
+      serviceSetups.foo
+        .listenTo({ type: "action/foo" })
+        .customizeEffect(() => {})
     ).toHaveProperty("id");
   });
   it("should throw when name is falsy", () => {


### PR DESCRIPTION
This PR fixes the failing tests on Master due to a prop
name change that wasn't applied to tests.

Introduced by #2869 