### PR TITLE
feat: add User Details page layouts

### DIFF
--- a/plugins-structure/apps/politeia/src/pages/User/Details/Account.js
+++ b/plugins-structure/apps/politeia/src/pages/User/Details/Account.js
@@ -1,0 +1,102 @@
+import React from "react";
+import { Button, Card, Text } from "pi-ui";
+import { LabelValueList } from "@politeiagui/common-ui";
+import {
+  convertAtomsToDcr,
+  formatUnixTimestamp,
+} from "@politeiagui/common-ui/utils";
+import UserDetails from "./Details";
+import styles from "./styles.module.css";
+
+import isEmpty from "lodash/isEmpty";
+import isBoolean from "lodash/isBoolean";
+
+import { user } from "./_mock";
+
+function formatItemValue(value) {
+  return isBoolean(value) ? (
+    value ? (
+      "Yes"
+    ) : (
+      "No"
+    )
+  ) : isEmpty(value) ? (
+    <Text color="gray">No information provided</Text>
+  ) : (
+    value
+  );
+}
+
+function formatItemsList(items) {
+  return items.map(({ label, value }) => ({
+    label,
+    value: formatItemValue(value),
+  }));
+}
+
+const PersonalData = ({ onClear }) => (
+  <div className={styles.section}>
+    <Text color="gray">
+      You can clear all of your user data stored in the browser, including your
+      identity and draft records. Make a backup copy of your identity key if you
+      are choosing to do so. You will be logged out after doing this.
+    </Text>
+    <div>
+      <Button size="sm" onClick={onClear}>
+        Clear Data
+      </Button>
+    </div>
+  </div>
+);
+
+function UserAccount() {
+  const accountItems = [
+    { label: "Admin", value: user.isadmin },
+    { label: "Verified Email", value: !user.newuserverificationtoken },
+    { label: "Password", value: <Button size="sm">Change Password</Button> },
+    { label: "Personal Data", value: <PersonalData onClear={() => {}} /> },
+  ];
+  const paywallItems = [
+    { label: "Address", value: user.newuserpaywalladdress },
+    {
+      label: "Amount",
+      value: `${convertAtomsToDcr(user.newuserpaywallamount)} DCR`,
+    },
+    {
+      label: "Pay after",
+      value: formatUnixTimestamp(user.newuserpaywalltxnotbefore),
+    },
+  ];
+  const securityItems = [
+    { label: "Failed login attempts", value: user.failedloginattempts },
+    { label: "Locked", value: user.islocked },
+  ];
+
+  return (
+    <UserDetails tab="Account">
+      <Card paddingSize="small" className={styles.userCard}>
+        <div>
+          <Text weight="semibold" color="grayDark">
+            Account Details
+          </Text>
+          <LabelValueList alignValues items={formatItemsList(accountItems)} />
+        </div>
+        <div>
+          <Text weight="semibold" color="grayDark">
+            Paywall
+          </Text>
+          <LabelValueList alignValues items={formatItemsList(paywallItems)} />
+        </div>
+        <div>
+          <Text weight="semibold" color="grayDark">
+            Security
+          </Text>
+          <LabelValueList alignValues items={formatItemsList(securityItems)} />
+          <Button size="sm">Deactivate Account</Button>
+        </div>
+      </Card>
+    </UserDetails>
+  );
+}
+
+export default UserAccount;

--- a/plugins-structure/apps/politeia/src/pages/User/Details/Identity.js
+++ b/plugins-structure/apps/politeia/src/pages/User/Details/Identity.js
@@ -1,0 +1,77 @@
+import React from "react";
+import { Button, Card, Link, Text } from "pi-ui";
+import UserDetails from "./Details";
+import styles from "./styles.module.css";
+
+const Label = ({ text }) => (
+  <Text weight="semibold" color="grayDark">
+    {text}
+  </Text>
+);
+
+const TextHighlighted = ({ text }) => (
+  <Text
+    backgroundColor="blueLighter"
+    monospace
+    className={styles.textHighlight}
+  >
+    {text}
+  </Text>
+);
+
+const TextUuidMessage = () => (
+  <span>
+    <Text>
+      Unique 16-byte UUID, as defined in{" "}
+      <Link
+        target="_blank"
+        href="https://tools.ietf.org/html/rfc4122"
+        rel="noreferrer"
+      >
+        RFC 4122
+      </Link>
+      , used to identify your user.
+    </Text>
+  </span>
+);
+
+function UserIdentity({ userid }) {
+  const pubkey = "MOCK-810c5396d21e1b43ccc1cb796ee68bcc";
+  return (
+    <UserDetails tab={"identity"}>
+      <Card paddingSize="small" className={styles.userCard}>
+        <div>
+          <Label text="Public Key" />
+          <Text>
+            Your public and private keys constitute your identity. The private
+            key is used to sign your proposals, comments and any up/down votes
+            on Politeia. You can have only one identity active at a time. Your
+            keys are stored in your browser by default, so if you use Politeia
+            on multiple machines you will need to import your keys before you
+            can participate.
+          </Text>
+          <TextHighlighted text={pubkey} />
+          <div>
+            <Button size="sm">Create new Identity</Button>
+            <Button size="sm">Import Identity</Button>
+            <Button size="sm">Download Identity</Button>
+          </div>
+        </div>
+        <div>
+          <Label text="Past Public Keys" />
+          <Text>
+            List of inactive public keys your account has had in the past.
+          </Text>
+          <Button size="sm">Show All</Button>
+        </div>
+        <div>
+          <Label text="User ID" />
+          <TextUuidMessage />
+          <TextHighlighted text={userid} />
+        </div>
+      </Card>
+    </UserDetails>
+  );
+}
+
+export default UserIdentity;

--- a/plugins-structure/apps/politeia/src/pages/User/Details/_mock.js
+++ b/plugins-structure/apps/politeia/src/pages/User/Details/_mock.js
@@ -1,0 +1,30 @@
+export const user = {
+  id: "0612f387-3777-4003-8f40-87b183f89032",
+  email: "admin@example.com",
+  username: "admin",
+  isadmin: true,
+  newuserpaywalladdress: "TsRBnD2mnZX1upPMFNoQ1ckYr9Y4TZyuGTV",
+  newuserpaywallamount: 0,
+  newuserpaywalltx: "cleared_by_admin",
+  newuserpaywalltxnotbefore: 1646242149,
+  newuserpaywallpollexpiry: 0,
+  newuserverificationtoken: null,
+  newuserverificationexpiry: 0,
+  updatekeyverificationtoken: null,
+  updatekeyverificationexpiry: 0,
+  resetpasswordverificationtoken: null,
+  resetpasswordverificationexpiry: 0,
+  lastlogintime: 1670531891,
+  failedloginattempts: 0,
+  isdeactivated: false,
+  islocked: false,
+  identities: [
+    {
+      pubkey:
+        "4e0d248935f52b3f50a05fbbd5f127f49e9b684c9cc9c6ca8aa3947c35f09641",
+      isactive: false,
+    },
+  ],
+  proposalcredits: 9994,
+  emailnotifications: 0,
+};

--- a/plugins-structure/apps/politeia/src/pages/User/Details/index.js
+++ b/plugins-structure/apps/politeia/src/pages/User/Details/index.js
@@ -35,7 +35,7 @@ const userIdentityRoute = App.createRoute({
   title: "User Identity",
   cleanup: routeCleanup,
   view: createRouteView(
-    lazy(() => import(/* webpackChunkName: "user_details_page" */ "./Details"))
+    lazy(() => import(/* webpackChunkName: "user_details_page" */ "./Identity"))
   ),
 });
 const userAccountRoute = App.createRoute({

--- a/plugins-structure/apps/politeia/src/pages/User/Details/index.js
+++ b/plugins-structure/apps/politeia/src/pages/User/Details/index.js
@@ -43,7 +43,7 @@ const userAccountRoute = App.createRoute({
   title: "User Account",
   cleanup: routeCleanup,
   view: createRouteView(
-    lazy(() => import(/* webpackChunkName: "user_details_page" */ "./Details"))
+    lazy(() => import(/* webpackChunkName: "user_details_page" */ "./Account"))
   ),
 });
 const userPreferencesRoute = App.createRoute({

--- a/plugins-structure/apps/politeia/src/pages/User/Details/styles.module.css
+++ b/plugins-structure/apps/politeia/src/pages/User/Details/styles.module.css
@@ -1,0 +1,13 @@
+.userCard > div > *:not(:last-child) {
+  display: flex;
+  flex-flow: column;
+  margin-bottom: var(--spacing-1);
+}
+
+.userCard > *:not(:last-child) {
+  margin-bottom: var(--spacing-large);
+}
+
+.textHighlight {
+  width: fit-content;
+}

--- a/plugins-structure/apps/politeia/src/pages/User/Details/styles.module.css
+++ b/plugins-structure/apps/politeia/src/pages/User/Details/styles.module.css
@@ -1,3 +1,8 @@
+.userCard {
+  padding: 2rem var(--container-padding-right) 2rem
+    var(--container-padding-left);
+}
+
 .userCard > div > *:not(:last-child) {
   display: flex;
   flex-flow: column;
@@ -10,4 +15,13 @@
 
 .textHighlight {
   width: fit-content;
+}
+
+.section {
+  display: flex;
+  flex-flow: column;
+}
+
+.section > *:not(:last-child) {
+  padding-bottom: 1rem;
 }

--- a/plugins-structure/packages/common-ui/src/components/LabelValueList/LabelValueList.js
+++ b/plugins-structure/packages/common-ui/src/components/LabelValueList/LabelValueList.js
@@ -1,12 +1,16 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { classNames } from "pi-ui";
 import styles from "./styles.module.css";
 
-export function LabelValueList({ items, ...props }) {
+export function LabelValueList({ items, alignValues, ...props }) {
   return (
     <div className={styles.wrapper} {...props}>
       {items.map(({ label, value }, i) => (
-        <div className={styles.item} key={i}>
+        <div
+          className={classNames(styles.item, alignValues && styles.align)}
+          key={i}
+        >
           <div className={styles.label}>{label}:</div>
           <div className={styles.value}>{value}</div>
         </div>
@@ -19,7 +23,8 @@ LabelValueList.propTypes = {
   items: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string.isRequired,
-      value: PropTypes.string.isRequired,
+      value: PropTypes.node.isRequired,
     })
   ).isRequired,
+  alignValues: PropTypes.bool,
 };

--- a/plugins-structure/packages/common-ui/src/components/LabelValueList/styles.module.css
+++ b/plugins-structure/packages/common-ui/src/components/LabelValueList/styles.module.css
@@ -1,7 +1,9 @@
 .item {
   margin-top: var(--spacing-medium);
   display: flex;
+  align-items: center;
 }
+
 .wrapper > div:first-child {
   margin-top: 0;
 }
@@ -17,4 +19,18 @@
 .wrapper {
   display: flex;
   flex-direction: column;
+}
+
+.align {
+  display: grid;
+  grid-template-columns: 1fr 5fr;
+}
+
+@media (--sm-viewport) {
+  .align {
+    display: block;
+  }
+  .align .value {
+    padding: 0;
+  }
 }

--- a/plugins-structure/packages/common-ui/src/utils.js
+++ b/plugins-structure/packages/common-ui/src/utils.js
@@ -1,6 +1,14 @@
 import { INVALID_DATE_LABEL, MONTHS_LABELS } from "./constants";
 
 /**
+ * Converts atoms to DCR
+ *
+ * @param {number} atoms - amount in atoms
+ * @return {number} dcr - amount in dcr
+ */
+export const convertAtomsToDcr = (atoms) => atoms / 100000000;
+
+/**
  * Formats unix seconds timestamp to a UTC string date
  *
  * @param {number} unixtimestamp - unix timestamp


### PR DESCRIPTION
Work in Progress ⏳ 

This PR adds layouts/design for the following User Details tabs:
- [x] Identity
- [x] Account
- [ ] Preferences
- [ ] Credits
- [ ] Draft Proposals
- [ ] Two-factor Authentication