### PR TITLE
feat(app/pi): Add Admin page layouts

### DIFF
--- a/plugins-structure/apps/politeia/cypress/e2e/admin.cy.js
+++ b/plugins-structure/apps/politeia/cypress/e2e/admin.cy.js
@@ -1,0 +1,46 @@
+import { mockRecordsInventory } from "@politeiagui/core/dev/mocks";
+
+Cypress.Commands.add("mockInventory", (amount, matcherParams = {}) =>
+  cy.mockResponse(
+    { url: "/api/records/v1/inventory", ...matcherParams },
+    mockRecordsInventory(amount)
+  )
+);
+
+describe("Admin", () => {
+  beforeEach(() => {
+    cy.mockProposalsBatch("unreviewed");
+    cy.mockInventory(0);
+  });
+  it("should show empty list message when inventory is empty", () => {
+    cy.mockInventory(0);
+    cy.visit("/admin/records");
+    cy.assertProposalsListLength(0);
+    cy.findByTestId("proposals-list-empty").should("be.visible");
+    cy.findByTestId("tab-1").click();
+    cy.findByTestId("proposals-list-empty").should("be.visible");
+  });
+  it("should list unvetted unreviewed proposals", () => {
+    cy.mockInventory(10);
+    cy.visit("/admin/records");
+    cy.waitProposalsBatch();
+    cy.findAllByTestId("proposal-card").last().scrollIntoView({
+      easing: "linear",
+      duration: 500,
+    });
+    cy.waitProposalsBatch({ hasCounts: false });
+    cy.assertProposalsListLength(10);
+  });
+  it("should list unvetted censored proposals", () => {
+    cy.mockProposalsBatch("unvettedCensored");
+    cy.mockInventory(10);
+    cy.visit("/admin/records");
+    cy.waitProposalsBatch();
+    cy.findAllByTestId("proposal-card").last().scrollIntoView({
+      easing: "linear",
+      duration: 500,
+    });
+    cy.waitProposalsBatch({ hasCounts: false });
+    cy.assertProposalsListLength(10);
+  });
+});

--- a/plugins-structure/apps/politeia/cypress/e2e/admin.cy.js
+++ b/plugins-structure/apps/politeia/cypress/e2e/admin.cy.js
@@ -7,7 +7,7 @@ Cypress.Commands.add("mockInventory", (amount, matcherParams = {}) =>
   )
 );
 
-describe("Admin", () => {
+describe("Admin Proposals Page", () => {
   beforeEach(() => {
     cy.mockProposalsBatch("unreviewed");
     cy.mockInventory(0);
@@ -42,5 +42,17 @@ describe("Admin", () => {
     });
     cy.waitProposalsBatch({ hasCounts: false });
     cy.assertProposalsListLength(10);
+  });
+});
+
+describe("User Search Page", () => {
+  it("should list users", () => {
+    cy.visit("/admin/search");
+    cy.findByText("Search for Users").should("be.visible");
+    cy.findByTestId("admin-search-email").type("test");
+    cy.findByTestId("admin-search-button").click();
+
+    // Should display list of users on table
+    cy.findByTestId("admin-search-results").should("be.visible");
   });
 });

--- a/plugins-structure/apps/politeia/cypress/support/commands.js
+++ b/plugins-structure/apps/politeia/cypress/support/commands.js
@@ -14,6 +14,20 @@ import {
 } from "@politeiagui/ticketvote/dev/mocks";
 
 const proposalStatusMap = {
+  // Record Status
+  unreviewed: {
+    voteStatus: "ineligible",
+    recordsStatus: "unreviewed",
+    recordsState: "unvetted",
+    piStatus: "unvetted",
+  },
+  unvettedCensored: {
+    voteStatus: "ineligible",
+    recordsStatus: "censored",
+    recordsState: "unvetted",
+    piStatus: "censored",
+  },
+  // Vote Status
   unauthorized: {
     voteStatus: "unauthorized",
     recordsStatus: "public",

--- a/plugins-structure/apps/politeia/src/components/Header/Header.js
+++ b/plugins-structure/apps/politeia/src/components/Header/Header.js
@@ -49,6 +49,10 @@ function HeaderItems() {
           name="My Proposals"
         />
         <Item href={`/user/${currentUser.userid}/drafts`} name="My Drafts" />
+        {/* TODO: only show this for admin */}
+        <Item href="/admin/records" name="Admin" />
+        <Item href="/admin/search" name="Search for Users" />
+        {/* END TODO */}
         <Item name="Logout" onClick={handleLogout} />
       </Dropdown>
     </div>

--- a/plugins-structure/apps/politeia/src/pages/Home/Home.js
+++ b/plugins-structure/apps/politeia/src/pages/Home/Home.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { MultiContentPage, TabsBanner } from "@politeiagui/common-ui/layout";
-import { getURLSearchParams } from "../../utils/getURLSearchParams";
+import { getURLSearchParams } from "@politeiagui/core/router";
 import { About } from "../../components";
 import HomeProposals from "./HomeProposals";
 

--- a/plugins-structure/apps/politeia/src/pages/User/Admin/Proposals.js
+++ b/plugins-structure/apps/politeia/src/pages/User/Admin/Proposals.js
@@ -1,0 +1,73 @@
+import React from "react";
+import { useSelector } from "react-redux";
+import { getURLSearchParams } from "@politeiagui/core/router";
+import { SingleContentPage, TabsBanner } from "@politeiagui/common-ui/layout";
+import useProposalsList from "../../../pi/hooks/useProposalsList";
+import useRecordsInventory from "../../../pi/hooks/useRecordsInventory";
+import { selectIsRecordsInventoryListEmpty } from "../../../pi/proposalsList/selectors";
+import { ProposalsList, ProposalsListEmpty } from "../../../components";
+
+const recordsState = "unvetted";
+const TABS = {
+  unreviewed: "Unreviewed",
+  censored: "Censored",
+};
+const TABS_VALUES = Object.values(TABS);
+const tabsLinks = TABS_VALUES.map((tab) => (
+  <a href={`/admin/records?tab=${tab}`} data-link>
+    {tab}
+  </a>
+));
+
+function AdminProposalsList({ status, listName }) {
+  const { onFetchNextBatch, onFetchNextInventoryPage, listFetchStatus } =
+    useProposalsList({ status, recordsState });
+  const { inventory, inventoryStatus } = useRecordsInventory({
+    status,
+    recordsState,
+  });
+  const isListEmpty = useSelector((state) =>
+    selectIsRecordsInventoryListEmpty(state, { recordsState, status })
+  );
+  return isListEmpty ? (
+    <ProposalsListEmpty listName={listName} />
+  ) : (
+    <ProposalsList
+      inventory={inventory}
+      inventoryFetchStatus={inventoryStatus}
+      onFetchNextBatch={onFetchNextBatch}
+      onFetchNextInventoryPage={onFetchNextInventoryPage}
+      listFetchStatus={listFetchStatus}
+    />
+  );
+}
+
+function getListPropsByTab(tab) {
+  const mapTabStatus = {
+    [TABS.unreviewed]: "unreviewed",
+    [TABS.censored]: "censored",
+  };
+  const status = mapTabStatus[tab] || mapTabStatus[TABS.unreviewed];
+  const listName = mapTabStatus[tab] ? tab.toLowerCase() : "unreviewed";
+  return { status, listName };
+}
+
+function AdminProposalsPage() {
+  const { tab } = getURLSearchParams();
+  const { status, listName } = getListPropsByTab(tab);
+  return (
+    <SingleContentPage
+      banner={
+        <TabsBanner
+          title="Unvetted Proposals"
+          activeTab={TABS_VALUES.indexOf(tab || TABS_VALUES[0])}
+          tabs={tabsLinks}
+        />
+      }
+    >
+      <AdminProposalsList listName={listName} status={status} />
+    </SingleContentPage>
+  );
+}
+
+export default AdminProposalsPage;

--- a/plugins-structure/apps/politeia/src/pages/User/Admin/UserSearch.js
+++ b/plugins-structure/apps/politeia/src/pages/User/Admin/UserSearch.js
@@ -1,0 +1,79 @@
+import React, { useState } from "react";
+import { H1, Link, RadioButtonGroup, Table } from "pi-ui";
+import { RecordForm, SubmitButton, TextInput } from "@politeiagui/common-ui";
+import { SingleContentPage } from "@politeiagui/common-ui/layout";
+import styles from "./styles.module.css";
+import { getMockUserMatches } from "./_mock";
+import { InfoCard } from "../../../components";
+
+const MODE_EMAIL = 1;
+const MODE_USERNAME = 2;
+const TABLE_HEADERS = {
+  username: "Username",
+  email: "E-mail",
+  id: "ID",
+};
+const options = [
+  { label: "E-mail", value: MODE_EMAIL },
+  { label: "Username", value: MODE_USERNAME },
+];
+
+function SearchBanner({ onSubmit = () => {} }) {
+  const [mode, setMode] = useState(MODE_EMAIL);
+  function handleSubmit({ email, username }) {
+    console.log("Searching for users", { email, username });
+    onSubmit({ email, username });
+  }
+  return (
+    <div>
+      <H1>Search for Users</H1>
+      <RecordForm className={styles.form} onSubmit={handleSubmit}>
+        {({ formProps }) => (
+          <>
+            <RadioButtonGroup
+              onChange={(args) => {
+                setMode(args.value);
+                formProps.reset();
+              }}
+              value={mode}
+              options={options}
+            />
+            <div className={styles.fields}>
+              {mode === MODE_EMAIL ? (
+                <TextInput name="email" placeholder="Search by E-mail" />
+              ) : (
+                <TextInput name="username" placeholder="Search by Username" />
+              )}
+              <SubmitButton>Search</SubmitButton>
+            </div>
+          </>
+        )}
+      </RecordForm>
+    </div>
+  );
+}
+
+function AdminUserSearch() {
+  // TODO: use user layer api calls instead
+  const { users } = getMockUserMatches(50);
+  const formattedUsers = users.map((u) => ({
+    [TABLE_HEADERS.username]: u.username,
+    [TABLE_HEADERS.email]: u.email,
+    [TABLE_HEADERS.id]: (
+      <Link href={`/user/${u.id}`} data-link>
+        {u.id}
+      </Link>
+    ),
+  }));
+  return (
+    <SingleContentPage banner={<SearchBanner />}>
+      {users ? (
+        <InfoCard title="Search Results">
+          <Table headers={Object.values(TABLE_HEADERS)} data={formattedUsers} />
+        </InfoCard>
+      ) : null}
+    </SingleContentPage>
+  );
+}
+
+export default AdminUserSearch;

--- a/plugins-structure/apps/politeia/src/pages/User/Admin/UserSearch.js
+++ b/plugins-structure/apps/politeia/src/pages/User/Admin/UserSearch.js
@@ -40,11 +40,21 @@ function SearchBanner({ onSubmit = () => {} }) {
             />
             <div className={styles.fields}>
               {mode === MODE_EMAIL ? (
-                <TextInput name="email" placeholder="Search by E-mail" />
+                <TextInput
+                  name="email"
+                  placeholder="Search by E-mail"
+                  data-testid="admin-search-email"
+                />
               ) : (
-                <TextInput name="username" placeholder="Search by Username" />
+                <TextInput
+                  name="username"
+                  placeholder="Search by Username"
+                  data-testid="admin-search-username"
+                />
               )}
-              <SubmitButton>Search</SubmitButton>
+              <SubmitButton data-testid="admin-search-button">
+                Search
+              </SubmitButton>
             </div>
           </>
         )}
@@ -68,7 +78,7 @@ function AdminUserSearch() {
   return (
     <SingleContentPage banner={<SearchBanner />}>
       {users ? (
-        <InfoCard title="Search Results">
+        <InfoCard title="Search Results" data-testid="admin-search-results">
           <Table headers={Object.values(TABLE_HEADERS)} data={formattedUsers} />
         </InfoCard>
       ) : null}

--- a/plugins-structure/apps/politeia/src/pages/User/Admin/_mock.js
+++ b/plugins-structure/apps/politeia/src/pages/User/Admin/_mock.js
@@ -1,0 +1,16 @@
+import { faker } from "@faker-js/faker";
+
+export function getMockUserMatches(matches) {
+  const totalusers = 35;
+  const totalmatches = matches;
+
+  const users = Array.from({ length: totalmatches }, () => {
+    return {
+      id: faker.datatype.uuid(),
+      email: faker.internet.email(),
+      username: faker.internet.userName(),
+    };
+  });
+
+  return { totalusers, totalmatches, users };
+}

--- a/plugins-structure/apps/politeia/src/pages/User/Admin/index.js
+++ b/plugins-structure/apps/politeia/src/pages/User/Admin/index.js
@@ -1,0 +1,22 @@
+import { lazy } from "react";
+import App from "../../../app";
+import { routeCleanup } from "../../../utils/routeCleanup";
+import { createRouteView } from "../../../utils/createRouteView";
+import { servicesSetupsByRecordsInventory } from "../../../pi/proposalsList/servicesSetups";
+import { listenToRecordsInventoryFetch } from "../../../pi/proposalsList/listeners";
+
+const adminProposalsRoute = App.createRoute({
+  path: "/admin/records",
+  cleanup: routeCleanup,
+  setupServices: servicesSetupsByRecordsInventory,
+  listeners: [listenToRecordsInventoryFetch],
+  view: createRouteView(
+    lazy(() =>
+      import(/* webpackChunkName: "admin_proposals_page" */ "./Proposals")
+    )
+  ),
+});
+
+const routes = [adminProposalsRoute];
+
+export default routes;

--- a/plugins-structure/apps/politeia/src/pages/User/Admin/index.js
+++ b/plugins-structure/apps/politeia/src/pages/User/Admin/index.js
@@ -17,6 +17,16 @@ const adminProposalsRoute = App.createRoute({
   ),
 });
 
-const routes = [adminProposalsRoute];
+const adminUserSearchRoute = App.createRoute({
+  path: "/admin/search",
+  cleanup: routeCleanup,
+  view: createRouteView(
+    lazy(() =>
+      import(/* webpackChunkName: "admin_user_search_page" */ "./UserSearch")
+    )
+  ),
+});
+
+const routes = [adminProposalsRoute, adminUserSearchRoute];
 
 export default routes;

--- a/plugins-structure/apps/politeia/src/pages/User/Admin/index.js
+++ b/plugins-structure/apps/politeia/src/pages/User/Admin/index.js
@@ -8,6 +8,7 @@ import { listenToRecordsInventoryFetch } from "../../../pi/proposalsList/listene
 const adminProposalsRoute = App.createRoute({
   path: "/admin/records",
   cleanup: routeCleanup,
+  title: "Admin Unvetted Proposals",
   setupServices: servicesSetupsByRecordsInventory,
   listeners: [listenToRecordsInventoryFetch],
   view: createRouteView(
@@ -19,6 +20,7 @@ const adminProposalsRoute = App.createRoute({
 
 const adminUserSearchRoute = App.createRoute({
   path: "/admin/search",
+  title: "Search for Users",
   cleanup: routeCleanup,
   view: createRouteView(
     lazy(() =>

--- a/plugins-structure/apps/politeia/src/pages/User/Admin/styles.module.css
+++ b/plugins-structure/apps/politeia/src/pages/User/Admin/styles.module.css
@@ -1,0 +1,15 @@
+.form {
+  width: fit-content;
+  margin-top: var(--spacing-medium);
+  padding: 0;
+}
+
+.form .fields {
+  display: flex;
+  align-items: center;
+}
+
+.fields button {
+  margin-bottom: 2.2rem;
+  margin-left: var(--spacing-medium);
+}

--- a/plugins-structure/apps/politeia/src/pages/User/Details/Proposals.js
+++ b/plugins-structure/apps/politeia/src/pages/User/Details/Proposals.js
@@ -22,13 +22,13 @@ function UserProposals() {
     status,
     recordsState,
   });
-  const isEmpty = useSelector((state) =>
+  const isListEmpty = useSelector((state) =>
     selectIsRecordsInventoryListEmpty(state, { recordsState, status })
   );
 
   return (
     <UserDetails>
-      {isEmpty ? (
+      {isListEmpty ? (
         <ProposalsListEmpty listName="from user" />
       ) : (
         <ProposalsList

--- a/plugins-structure/apps/politeia/src/pages/User/Details/index.js
+++ b/plugins-structure/apps/politeia/src/pages/User/Details/index.js
@@ -2,17 +2,17 @@ import { lazy } from "react";
 import App from "../../../app";
 import { routeCleanup } from "../../../utils/routeCleanup";
 import { createRouteView } from "../../../utils/createRouteView";
-import { router } from "@politeiagui/core/router";
 import { serviceListeners as draftsListeners } from "@politeiagui/core/records/drafts/services";
 import { servicesSetupsByRecordsInventory } from "../../../pi/proposalsList/servicesSetups";
 import { listenToRecordsInventoryFetch } from "../../../pi/proposalsList/listeners";
 
 const baseRoute = App.createRoute({
   path: "/user/:userid",
+  title: "User Details",
   cleanup: routeCleanup,
-  view: ({ userid }) => {
-    router.navigateTo(`/user/${userid}/identity`);
-  },
+  view: createRouteView(
+    lazy(() => import(/* webpackChunkName: "user_details_page" */ "./Identity"))
+  ),
 });
 
 const userProposalsRoute = App.createRoute({

--- a/plugins-structure/apps/politeia/src/pages/User/index.js
+++ b/plugins-structure/apps/politeia/src/pages/User/index.js
@@ -1,6 +1,7 @@
 import userDetailsRoutes from "./Details";
 import userSessionRoutes from "./Session";
+import adminRoutes from "./Admin";
 
-const userRoutes = [...userSessionRoutes, ...userDetailsRoutes];
+const userRoutes = [...userSessionRoutes, ...userDetailsRoutes, ...adminRoutes];
 
 export default userRoutes;

--- a/plugins-structure/apps/politeia/src/pi/proposalsList/listeners.js
+++ b/plugins-structure/apps/politeia/src/pi/proposalsList/listeners.js
@@ -17,7 +17,7 @@ export const listenToRecordsInventoryFetch = {
   actionCreator: recordsInventory.fetch.fulfilled,
   effect: ({ meta, payload }, { dispatch }) => {
     const { recordsState, status } = meta.arg;
-    if (payload.recordsInventory[recordsState][status].length > 0) {
+    if (payload.recordsInventory[recordsState][status]?.length > 0) {
       dispatch(fetchNextBatch({ status, recordsState }));
     }
   },

--- a/plugins-structure/packages/core/src/records/inventory/recordsInventorySlice.js
+++ b/plugins-structure/packages/core/src/records/inventory/recordsInventorySlice.js
@@ -90,7 +90,7 @@ const recordsInventorySlice = createSlice({
         const stringState = getHumanReadableRecordState(recordsState);
         const readableStatus = getHumanReadableRecordStatus(status);
         if (
-          recordsInventory[stringState][readableStatus].length ===
+          recordsInventory[stringState][readableStatus]?.length ===
           inventoryPageSize
         ) {
           state[stringState][readableStatus].status = "succeeded/hasMore";
@@ -99,7 +99,7 @@ const recordsInventorySlice = createSlice({
         }
         state[stringState][readableStatus].lastPage = page;
         state[stringState][readableStatus].tokens.push(
-          ...recordsInventory[stringState][readableStatus]
+          ...(recordsInventory[stringState][readableStatus] || [])
         );
       })
       .addCase(fetchRecordsInventory.rejected, (state, action) => {


### PR DESCRIPTION
This PR adds the following pages on our politeia app-shell.

- `/admin/records`: Admin unvetted proposals page
    <img width="1181" alt="Screen Shot 2023-01-20 at 11 21 22 AM" src="https://user-images.githubusercontent.com/22639213/213721528-95ffdbcf-decd-4cb0-82f9-e77f331a1829.png">

- `/admin/search`: Search for Users page
    <img width="1181" alt="Screen Shot 2023-01-20 at 11 18 02 AM" src="https://user-images.githubusercontent.com/22639213/213720513-1666106a-f988-494b-92c4-71a9117d6626.png">
